### PR TITLE
Implement backend login enforcement

### DIFF
--- a/auth-service/src/main/java/single/cjj/bizfi/config/WebMvcConfig.java
+++ b/auth-service/src/main/java/single/cjj/bizfi/config/WebMvcConfig.java
@@ -1,0 +1,21 @@
+package single.cjj.bizfi.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import single.cjj.bizfi.interceptor.AuthInterceptor;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Autowired
+    private AuthInterceptor authInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor)
+                .addPathPatterns("/**")
+                .excludePathPatterns("/auth/**", "/login", "/swagger-ui/**", "/v3/api-docs/**");
+    }
+}

--- a/auth-service/src/main/java/single/cjj/bizfi/controller/LoginPageController.java
+++ b/auth-service/src/main/java/single/cjj/bizfi/controller/LoginPageController.java
@@ -1,0 +1,13 @@
+package single.cjj.bizfi.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class LoginPageController {
+
+    @GetMapping("/login")
+    public String loginPage() {
+        return "redirect:/"; // 前端路由处理登录页
+    }
+}

--- a/auth-service/src/main/java/single/cjj/bizfi/interceptor/AuthInterceptor.java
+++ b/auth-service/src/main/java/single/cjj/bizfi/interceptor/AuthInterceptor.java
@@ -1,0 +1,52 @@
+package single.cjj.bizfi.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+import single.cjj.bizfi.utils.JwtUtils;
+import io.jsonwebtoken.JwtException;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+@Component
+public class AuthInterceptor implements HandlerInterceptor {
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
+        String token = request.getHeader("Authorization");
+        if (StringUtils.hasText(token) && token.startsWith("Bearer ")) {
+            token = token.substring(7);
+        }
+        if (!StringUtils.hasText(token)) {
+            response.sendRedirect("/login");
+            return false;
+        }
+
+        String redisKey = "token:" + token;
+        String userId = redisTemplate.opsForValue().get(redisKey);
+        if (!StringUtils.hasText(userId)) {
+            response.sendRedirect("/login");
+            return false;
+        }
+
+        try {
+            JwtUtils.parseToken(token);
+        } catch (JwtException e) {
+            redisTemplate.delete(redisKey);
+            response.sendRedirect("/login");
+            return false;
+        }
+
+        // 刷新过期时间
+        redisTemplate.expire(redisKey, 1, TimeUnit.HOURS);
+        return true;
+    }
+}

--- a/auth-service/src/main/java/single/cjj/bizfi/service/impl/BizfiAuthLoginServiceImpl.java
+++ b/auth-service/src/main/java/single/cjj/bizfi/service/impl/BizfiAuthLoginServiceImpl.java
@@ -94,11 +94,18 @@ public class BizfiAuthLoginServiceImpl implements BizfiAuthLoginService {
             throw new BizException("密码错误");
         }
 
+        // 生成登录 Token，并写入 Redis，1 小时未操作自动过期
+        String token = JwtUtils.generateToken(user.getFid(), user.getFid());
+        redisTemplate.opsForValue()
+                .set("token:" + token, String.valueOf(user.getFid()), 1, TimeUnit.HOURS);
+
         LoginResponse response = new LoginResponse();
         response.setFid(user.getFid());
         response.setUserName(user.getFnumber());
         response.setPhoneNumber(user.getFphone());
         response.setEmail(user.getFemail());
+        response.setToken(token);
+        response.setExpireIn(JwtUtils.EXPIRE / 1000);
 
         return response;
     }

--- a/auth-service/src/main/java/single/cjj/bizfi/utils/JwtUtils.java
+++ b/auth-service/src/main/java/single/cjj/bizfi/utils/JwtUtils.java
@@ -1,14 +1,19 @@
 package single.cjj.bizfi.utils;
 
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.JwtException;
 
 import java.util.Date;
 
 public class JwtUtils {
     private static final String SECRET = "secret123456";
-    private static final long EXPIRE = 3600 * 1000;
+    /**
+     * Token 过期时间：1 小时
+     */
+    public static final long EXPIRE = 3600 * 1000;
 
     public static String generateToken(Long userId, Long username) {
         return Jwts.builder()
@@ -17,5 +22,19 @@ public class JwtUtils {
                 .setExpiration(new Date(System.currentTimeMillis() + EXPIRE))
                 .signWith(SignatureAlgorithm.HS256, SECRET)
                 .compact();
+    }
+
+    /**
+     * 解析并验证 Token
+     *
+     * @param token JWT 字符串
+     * @return Claims
+     * @throws JwtException token 无效或已过期
+     */
+    public static Claims parseToken(String token) throws JwtException {
+        return Jwts.parser()
+                .setSigningKey(SECRET)
+                .parseClaimsJws(token)
+                .getBody();
     }
 }


### PR DESCRIPTION
## Summary
- enforce login via AuthInterceptor
- issue JWT token on successful login
- track token in Redis and refresh for 1h idle timeout
- expose `/login` endpoint for frontend routing

## Testing
- `mvn -q -pl auth-service -am package -DskipTests` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685be3c46978832f809bf6172cddceb4