### PR TITLE
Prefix API paths

### DIFF
--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -1,3 +1,7 @@
+server:
+  servlet:
+    context-path: /api
+
 spring:
   application:
     name: auth-service

--- a/base-service/src/main/resources/application.yml
+++ b/base-service/src/main/resources/application.yml
@@ -1,3 +1,7 @@
+server:
+  servlet:
+    context-path: /api
+
 spring:
   application:
     name: base-service

--- a/common/src/main/resources/application.yml
+++ b/common/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 server:
   port: 8070
   servlet:
-    context-path: /common
+    context-path: /api
 
 spring:
   application:

--- a/fi-service/src/main/resources/application.yml
+++ b/fi-service/src/main/resources/application.yml
@@ -1,3 +1,7 @@
+server:
+  servlet:
+    context-path: /api
+
 spring:
   application:
     name: fi-gl

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -1,3 +1,7 @@
+server:
+  servlet:
+    context-path: /api
+
 spring:
   application:
     name: gateway


### PR DESCRIPTION
## Summary
- add `/api` context path for all services

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686559976338832f872b5f73a6515e20