### PR TITLE
Add org pattern backend API

### DIFF
--- a/base-service/src/main/java/single/cjj/bizfi/controller/BizfiBaseOrgPatternController.java
+++ b/base-service/src/main/java/single/cjj/bizfi/controller/BizfiBaseOrgPatternController.java
@@ -1,0 +1,63 @@
+package single.cjj.bizfi.controller;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+import single.cjj.bizfi.entity.ApiResponse;
+import single.cjj.bizfi.entity.BizfiBaseOrgPattern;
+import single.cjj.bizfi.service.BizfiBaseOrgPatternService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 组织形态接口
+ */
+@RestController
+@RequestMapping("/api/org-pattern")
+public class BizfiBaseOrgPatternController {
+    @Autowired
+    private BizfiBaseOrgPatternService service;
+
+    /** 根据ID获取详情 */
+    @GetMapping("/{fid}")
+    public ApiResponse<BizfiBaseOrgPattern> get(@PathVariable("fid") Long fid) {
+        return ApiResponse.success(service.get(fid));
+    }
+
+    /** 新增 */
+    @PostMapping
+    public ApiResponse<BizfiBaseOrgPattern> add(@RequestBody BizfiBaseOrgPattern pattern) {
+        return ApiResponse.success(service.add(pattern));
+    }
+
+    /** 修改 */
+    @PutMapping
+    public ApiResponse<BizfiBaseOrgPattern> update(@RequestBody BizfiBaseOrgPattern pattern) {
+        return ApiResponse.success(service.update(pattern));
+    }
+
+    /** 删除 */
+    @DeleteMapping("/{fid}")
+    public ApiResponse<Boolean> delete(@PathVariable("fid") Long fid) {
+        return ApiResponse.success(service.delete(fid));
+    }
+
+    /** 分页/条件查询列表 */
+    @GetMapping("/list")
+    public ApiResponse<IPage<BizfiBaseOrgPattern>> list(
+            @RequestParam(value = "page", defaultValue = "1") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size,
+            @RequestParam(value = "fname", required = false) String fname,
+            @RequestParam(value = "fbillno", required = false) String fbillno,
+            @RequestParam(value = "fpattern", required = false) String fpattern,
+            @RequestParam(value = "fenable", required = false) Integer fenable
+    ) {
+        Map<String, Object> query = new HashMap<>();
+        query.put("fname", fname);
+        query.put("fbillno", fbillno);
+        query.put("fpattern", fpattern);
+        query.put("fenable", fenable);
+        return ApiResponse.success(service.list(page, size, query));
+    }
+}

--- a/base-service/src/main/java/single/cjj/bizfi/entity/BizfiBaseOrgPattern.java
+++ b/base-service/src/main/java/single/cjj/bizfi/entity/BizfiBaseOrgPattern.java
@@ -1,0 +1,49 @@
+package single.cjj.bizfi.entity;
+
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+/**
+ * 组织形态实体
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@TableName("bizfi_base_org_pattern")
+public class BizfiBaseOrgPattern implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    /** 主键ID */
+    @TableId("fid")
+    private Long fid;
+
+    /** 单据编号 */
+    private String fbillno;
+
+    /** 名称 */
+    private String fname;
+
+    /** 组织形态 */
+    private String fpattern;
+
+    /** 是否可用，1可用，0不可用 */
+    private Integer fenable;
+
+    /** 创建时间 */
+    private LocalDateTime fcreatedate;
+
+    /** 创建人 */
+    private String fcreator;
+
+    /** 修改时间 */
+    private LocalDateTime fmodifydate;
+
+    /** 修改人 */
+    private String fmodifier;
+}

--- a/base-service/src/main/java/single/cjj/bizfi/mapper/BizfiBaseOrgPatternMapper.java
+++ b/base-service/src/main/java/single/cjj/bizfi/mapper/BizfiBaseOrgPatternMapper.java
@@ -1,0 +1,10 @@
+package single.cjj.bizfi.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import single.cjj.bizfi.entity.BizfiBaseOrgPattern;
+
+/**
+ * 组织形态Mapper
+ */
+public interface BizfiBaseOrgPatternMapper extends BaseMapper<BizfiBaseOrgPattern> {
+}

--- a/base-service/src/main/java/single/cjj/bizfi/service/BizfiBaseOrgPatternService.java
+++ b/base-service/src/main/java/single/cjj/bizfi/service/BizfiBaseOrgPatternService.java
@@ -1,0 +1,22 @@
+package single.cjj.bizfi.service;
+
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.service.IService;
+import single.cjj.bizfi.entity.BizfiBaseOrgPattern;
+
+import java.util.Map;
+
+/**
+ * 组织形态服务接口
+ */
+public interface BizfiBaseOrgPatternService extends IService<BizfiBaseOrgPattern> {
+    BizfiBaseOrgPattern add(BizfiBaseOrgPattern pattern);
+
+    BizfiBaseOrgPattern update(BizfiBaseOrgPattern pattern);
+
+    boolean delete(Long fid);
+
+    BizfiBaseOrgPattern get(Long fid);
+
+    IPage<BizfiBaseOrgPattern> list(int page, int size, Map<String, Object> query);
+}

--- a/base-service/src/main/java/single/cjj/bizfi/service/impl/BizfiBaseOrgPatternServiceImpl.java
+++ b/base-service/src/main/java/single/cjj/bizfi/service/impl/BizfiBaseOrgPatternServiceImpl.java
@@ -1,0 +1,68 @@
+package single.cjj.bizfi.service.impl;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import single.cjj.bizfi.entity.BizfiBaseOrgPattern;
+import single.cjj.bizfi.mapper.BizfiBaseOrgPatternMapper;
+import single.cjj.bizfi.service.BizfiBaseOrgPatternService;
+
+import java.util.Map;
+
+/**
+ * 组织形态服务实现
+ */
+@Service
+public class BizfiBaseOrgPatternServiceImpl extends ServiceImpl<BizfiBaseOrgPatternMapper, BizfiBaseOrgPattern>
+        implements BizfiBaseOrgPatternService {
+
+    @Autowired
+    private BizfiBaseOrgPatternMapper mapper;
+
+    @Override
+    public BizfiBaseOrgPattern add(BizfiBaseOrgPattern pattern) {
+        mapper.insert(pattern);
+        return pattern;
+    }
+
+    @Override
+    public BizfiBaseOrgPattern update(BizfiBaseOrgPattern pattern) {
+        mapper.updateById(pattern);
+        return mapper.selectById(pattern.getFid());
+    }
+
+    @Override
+    public boolean delete(Long fid) {
+        return mapper.deleteById(fid) > 0;
+    }
+
+    @Override
+    public BizfiBaseOrgPattern get(Long fid) {
+        return mapper.selectById(fid);
+    }
+
+    @Override
+    public IPage<BizfiBaseOrgPattern> list(int page, int size, Map<String, Object> query) {
+        LambdaQueryWrapper<BizfiBaseOrgPattern> wrapper = new LambdaQueryWrapper<>();
+        if (query != null) {
+            if (StringUtils.hasText((String) query.get("fname"))) {
+                wrapper.like(BizfiBaseOrgPattern::getFname, query.get("fname"));
+            }
+            if (StringUtils.hasText((String) query.get("fbillno"))) {
+                wrapper.like(BizfiBaseOrgPattern::getFbillno, query.get("fbillno"));
+            }
+            if (StringUtils.hasText((String) query.get("fpattern"))) {
+                wrapper.eq(BizfiBaseOrgPattern::getFpattern, query.get("fpattern"));
+            }
+            if (query.get("fenable") != null) {
+                wrapper.eq(BizfiBaseOrgPattern::getFenable, query.get("fenable"));
+            }
+        }
+        Page<BizfiBaseOrgPattern> pageObj = new Page<>(page, size);
+        return mapper.selectPage(pageObj, wrapper);
+    }
+}

--- a/base-service/src/main/resources/mapper/BizfiBaseOrgPatternMapper.xml
+++ b/base-service/src/main/resources/mapper/BizfiBaseOrgPatternMapper.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="single.cjj.bizfi.mapper.BizfiBaseOrgPatternMapper">
+    <resultMap id="BaseResultMap" type="single.cjj.bizfi.entity.BizfiBaseOrgPattern">
+        <id column="fid" property="fid" />
+        <result column="fbillno" property="fbillno" />
+        <result column="fname" property="fname" />
+        <result column="fpattern" property="fpattern" />
+        <result column="fenable" property="fenable" />
+        <result column="fcreatedate" property="fcreatedate" />
+        <result column="fcreator" property="fcreator" />
+        <result column="fmodifydate" property="fmodifydate" />
+        <result column="fmodifier" property="fmodifier" />
+    </resultMap>
+</mapper>


### PR DESCRIPTION
## Summary
- implement organization pattern entity, mapper, service, controller
- expose `/api/org-pattern` endpoints for CRUD operations

## Testing
- `mvn -q -pl base-service -am test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68664bd72118832fbe5c109e084542be