### PR TITLE
feat: add workflow service MVP

### DIFF
--- a/.github/workflows/workflow-service-ci.yml
+++ b/.github/workflows/workflow-service-ci.yml
@@ -1,0 +1,33 @@
+name: Workflow Service CI
+
+on:
+  pull_request:
+    paths:
+      - 'workflow-service/**'
+      - 'common/**'
+      - 'pom.xml'
+      - '.github/workflows/workflow-service-ci.yml'
+  push:
+    branches:
+      - agent/workflow-mvp
+    paths:
+      - 'workflow-service/**'
+      - 'common/**'
+      - 'pom.xml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+
+      - name: Test workflow service
+        run: mvn -B -pl workflow-service -am test

--- a/docs/business/workflow/workflow-mvp.md
+++ b/docs/business/workflow/workflow-mvp.md
@@ -1,0 +1,222 @@
+# Matrix Workflow Service MVP
+
+## 1. Scope
+
+The first phase provides a lightweight workflow engine for business documents. It supports:
+
+- versioned workflow definitions
+- idempotent workflow startup
+- user tasks
+- service tasks through registered handlers
+- safe exclusive conditions
+- approve and reject actions
+- business object lookup
+- task inbox queries
+- terminal event Outbox callbacks with retry
+
+The first phase deliberately excludes parallel gateways, countersign, add-sign, subprocesses, definition migration and arbitrary scripts.
+
+## 2. Service boundary
+
+Business systems own document data. Workflow Service owns definitions, instances, node instances, tasks, action logs and delivery events.
+
+A business document is linked through:
+
+```text
+sourceSystem + businessType + businessId
+```
+
+The workflow database must not duplicate complete reimbursement, payment or contract records.
+
+## 3. Database initialization
+
+Create the database and execute:
+
+```text
+workflow-service/src/main/resources/sql/workflow_v1.sql
+```
+
+Runtime datasource settings:
+
+```text
+WORKFLOW_DB_URL
+WORKFLOW_DB_USERNAME
+WORKFLOW_DB_PASSWORD
+```
+
+Nacos settings:
+
+```text
+NACOS_ADDR
+NACOS_GROUP
+NACOS_NAMESPACE
+```
+
+## 4. Example definition
+
+```json
+{
+  "tenantId": "default",
+  "definitionKey": "expense_reimbursement",
+  "definitionName": "费用报销审批",
+  "createdBy": "admin",
+  "definition": {
+    "nodes": [
+      {
+        "key": "start",
+        "name": "开始",
+        "type": "START"
+      },
+      {
+        "key": "attachmentCheck",
+        "name": "影像检查",
+        "type": "SERVICE_TASK",
+        "handlerKey": "attachment-check",
+        "config": {
+          "requiredCategories": ["INVOICE", "PAYMENT_PROOF"]
+        }
+      },
+      {
+        "key": "firstReview",
+        "name": "初审",
+        "type": "USER_TASK",
+        "assigneeRule": {
+          "type": "ROLE",
+          "value": "FINANCE_FIRST_REVIEWER"
+        }
+      },
+      {
+        "key": "amountGateway",
+        "name": "金额判断",
+        "type": "EXCLUSIVE_GATEWAY"
+      },
+      {
+        "key": "secondReview",
+        "name": "复审",
+        "type": "USER_TASK",
+        "assigneeRule": {
+          "type": "VARIABLE",
+          "value": "secondReviewerId"
+        }
+      },
+      {
+        "key": "end",
+        "name": "结束",
+        "type": "END"
+      }
+    ],
+    "transitions": [
+      {"from": "start", "to": "attachmentCheck", "priority": 0},
+      {"from": "attachmentCheck", "to": "firstReview", "priority": 0},
+      {"from": "firstReview", "to": "amountGateway", "priority": 0},
+      {
+        "from": "amountGateway",
+        "to": "secondReview",
+        "priority": 10,
+        "condition": {
+          "field": "amount",
+          "operator": "GT",
+          "value": 10000
+        }
+      },
+      {"from": "amountGateway", "to": "end", "priority": 0},
+      {"from": "secondReview", "to": "end", "priority": 0}
+    ]
+  }
+}
+```
+
+Create and publish:
+
+```text
+POST /api/workflow/definitions
+POST /api/workflow/definitions/expense_reimbursement/versions/1/publish?tenantId=default
+```
+
+## 5. Start a workflow
+
+```http
+POST /api/workflow/instances
+Idempotency-Key: fi-expense-202607220028
+Content-Type: application/json
+```
+
+```json
+{
+  "tenantId": "default",
+  "definitionKey": "expense_reimbursement",
+  "sourceSystem": "fi-service",
+  "businessType": "expense_claim",
+  "businessId": "EXP202607220028",
+  "initiatorId": "10001",
+  "callbackUrl": "http://fi-service/api/workflow/callback",
+  "variables": {
+    "amount": 12000,
+    "secondReviewerId": "10008",
+    "attachmentCategories": ["INVOICE", "PAYMENT_PROOF"]
+  }
+}
+```
+
+Repeated requests with the same tenant, source system and `Idempotency-Key` return the original instance.
+
+## 6. Task operations
+
+Query an inbox:
+
+```text
+GET /api/workflow/tasks?tenantId=default&assigneeType=ROLE&assigneeValue=FINANCE_FIRST_REVIEWER&status=PENDING
+```
+
+Approve:
+
+```http
+POST /api/workflow/tasks/{taskId}/actions
+X-Request-Id: approve-request-001
+Content-Type: application/json
+```
+
+```json
+{
+  "action": "APPROVE",
+  "operatorId": "10008",
+  "comment": "影像和金额核对无误",
+  "variables": {
+    "approved": true
+  }
+}
+```
+
+Reject by changing `action` to `REJECT`.
+
+For `USER` tasks the service checks the operator directly. For `ROLE` tasks, Gateway or Auth Service must verify role membership before forwarding the request.
+
+## 7. Outbox callbacks
+
+Terminal workflow changes insert an Outbox event in the same database transaction. A scheduler claims events using a conditional status update, posts the payload to `callbackUrl`, and retries failures with exponential backoff.
+
+Business systems must use the `X-Workflow-Event-Id` header as an idempotency key and store processed event IDs with a unique index.
+
+Current delivery is HTTP callback. RabbitMQ publishing and HMAC callback signatures are planned extensions.
+
+## 8. Extension rules
+
+Custom automatic nodes implement:
+
+```java
+WorkflowNodeHandler
+```
+
+Each handler has a unique `handlerKey`. Workflow definitions may configure handler parameters but cannot execute arbitrary Java, Groovy, SpEL or JavaScript code.
+
+## 9. Next phase
+
+Recommended next work:
+
+1. integrate Auth Service role membership checks
+2. add attachment metadata and presigned upload APIs
+3. add return-to-initiator and resubmission
+4. add transfer, claim and add-sign actions
+5. add signed callback requests
+6. add workflow monitoring and manual Outbox retry screens
+7. implement a Vue Flow definition designer in matrix-web

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <module>fi-service</module>
         <module>share-service</module>
         <module>scheduler-service</module>
+        <module>workflow-service</module>
         <module>common</module>
         <module>infra</module>
         <module>config</module>

--- a/workflow-service/pom.xml
+++ b/workflow-service/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>single.cjj</groupId>
+        <artifactId>matrix</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>workflow-service</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>single.cjj</groupId>
+            <artifactId>common</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba.cloud</groupId>
+            <artifactId>spring-cloud-starter-alibaba-nacos-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba.cloud</groupId>
+            <artifactId>spring-cloud-starter-alibaba-nacos-discovery</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/workflow-service/src/main/java/single/cjj/workflow/WorkflowApplication.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/WorkflowApplication.java
@@ -2,7 +2,9 @@ package single.cjj.workflow;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class WorkflowApplication {
 

--- a/workflow-service/src/main/java/single/cjj/workflow/WorkflowApplication.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/WorkflowApplication.java
@@ -1,0 +1,12 @@
+package single.cjj.workflow;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class WorkflowApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(WorkflowApplication.class, args);
+    }
+}

--- a/workflow-service/src/main/java/single/cjj/workflow/api/WorkflowContracts.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/api/WorkflowContracts.java
@@ -1,0 +1,100 @@
+package single.cjj.workflow.api;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import single.cjj.workflow.model.WorkflowDefinition;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public final class WorkflowContracts {
+
+    private WorkflowContracts() {
+    }
+
+    public record DefinitionCreateRequest(
+            @NotBlank String tenantId,
+            @NotBlank String definitionKey,
+            @NotBlank String definitionName,
+            @NotNull @Valid WorkflowDefinition definition,
+            @NotBlank String createdBy
+    ) {
+    }
+
+    public record DefinitionResponse(
+            String tenantId,
+            String definitionKey,
+            String definitionName,
+            int version,
+            String status,
+            WorkflowDefinition definition,
+            LocalDateTime createdAt,
+            LocalDateTime publishedAt
+    ) {
+    }
+
+    public record StartWorkflowRequest(
+            @NotBlank String tenantId,
+            @NotBlank String definitionKey,
+            @NotBlank String sourceSystem,
+            @NotBlank String businessType,
+            @NotBlank String businessId,
+            @NotBlank String initiatorId,
+            Map<String, Object> variables,
+            String callbackUrl
+    ) {
+        public Map<String, Object> safeVariables() {
+            return variables == null ? new LinkedHashMap<>() : new LinkedHashMap<>(variables);
+        }
+    }
+
+    public record TaskActionRequest(
+            @NotNull TaskAction action,
+            @NotBlank String operatorId,
+            String comment,
+            Map<String, Object> variables
+    ) {
+        public Map<String, Object> safeVariables() {
+            return variables == null ? Map.of() : variables;
+        }
+    }
+
+    public enum TaskAction {
+        APPROVE,
+        REJECT
+    }
+
+    public record InstanceResponse(
+            String instanceId,
+            String tenantId,
+            String definitionKey,
+            int definitionVersion,
+            String sourceSystem,
+            String businessType,
+            String businessId,
+            String initiatorId,
+            String currentNodeKey,
+            String status,
+            Map<String, Object> variables,
+            LocalDateTime startedAt,
+            LocalDateTime endedAt
+    ) {
+    }
+
+    public record TaskResponse(
+            String taskId,
+            String instanceId,
+            String nodeInstanceId,
+            String nodeKey,
+            String taskName,
+            String assigneeType,
+            String assigneeValue,
+            String status,
+            int version,
+            LocalDateTime createdAt,
+            LocalDateTime completedAt
+    ) {
+    }
+}

--- a/workflow-service/src/main/java/single/cjj/workflow/controller/WorkflowDefinitionController.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/controller/WorkflowDefinitionController.java
@@ -1,0 +1,49 @@
+package single.cjj.workflow.controller;
+
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import single.cjj.bizfi.entity.ApiResponse;
+import single.cjj.workflow.api.WorkflowContracts;
+import single.cjj.workflow.service.WorkflowService;
+
+@RestController
+@RequestMapping("/workflow/definitions")
+public class WorkflowDefinitionController {
+
+    private final WorkflowService workflowService;
+
+    public WorkflowDefinitionController(WorkflowService workflowService) {
+        this.workflowService = workflowService;
+    }
+
+    @PostMapping
+    public ApiResponse<WorkflowContracts.DefinitionResponse> create(
+            @Valid @RequestBody WorkflowContracts.DefinitionCreateRequest request) {
+        return ApiResponse.success(workflowService.createDefinition(request));
+    }
+
+    @PostMapping("/{definitionKey}/versions/{version}/publish")
+    public ApiResponse<WorkflowContracts.DefinitionResponse> publish(
+            @PathVariable("definitionKey") String definitionKey,
+            @PathVariable("version") int version,
+            @RequestParam("tenantId") String tenantId) {
+        return ApiResponse.success(
+                workflowService.publishDefinition(tenantId, definitionKey, version)
+        );
+    }
+
+    @GetMapping("/{definitionKey}/published")
+    public ApiResponse<WorkflowContracts.DefinitionResponse> published(
+            @PathVariable("definitionKey") String definitionKey,
+            @RequestParam("tenantId") String tenantId) {
+        return ApiResponse.success(
+                workflowService.getPublishedDefinition(tenantId, definitionKey)
+        );
+    }
+}

--- a/workflow-service/src/main/java/single/cjj/workflow/controller/WorkflowInstanceController.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/controller/WorkflowInstanceController.java
@@ -1,0 +1,49 @@
+package single.cjj.workflow.controller;
+
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import single.cjj.bizfi.entity.ApiResponse;
+import single.cjj.workflow.api.WorkflowContracts;
+import single.cjj.workflow.service.WorkflowService;
+
+@RestController
+@RequestMapping("/workflow")
+public class WorkflowInstanceController {
+
+    private final WorkflowService workflowService;
+
+    public WorkflowInstanceController(WorkflowService workflowService) {
+        this.workflowService = workflowService;
+    }
+
+    @PostMapping("/instances")
+    public ApiResponse<WorkflowContracts.InstanceResponse> start(
+            @RequestHeader("Idempotency-Key") String idempotencyKey,
+            @Valid @RequestBody WorkflowContracts.StartWorkflowRequest request) {
+        return ApiResponse.success(workflowService.startWorkflow(request, idempotencyKey));
+    }
+
+    @GetMapping("/instances/{instanceId}")
+    public ApiResponse<WorkflowContracts.InstanceResponse> get(
+            @PathVariable("instanceId") String instanceId) {
+        return ApiResponse.success(workflowService.getInstance(instanceId));
+    }
+
+    @GetMapping("/business/{sourceSystem}/{businessType}/{businessId}")
+    public ApiResponse<WorkflowContracts.InstanceResponse> getByBusiness(
+            @PathVariable("sourceSystem") String sourceSystem,
+            @PathVariable("businessType") String businessType,
+            @PathVariable("businessId") String businessId,
+            @RequestParam("tenantId") String tenantId) {
+        return ApiResponse.success(workflowService.getBusinessInstance(
+                tenantId, sourceSystem, businessType, businessId
+        ));
+    }
+}

--- a/workflow-service/src/main/java/single/cjj/workflow/controller/WorkflowTaskController.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/controller/WorkflowTaskController.java
@@ -1,0 +1,38 @@
+package single.cjj.workflow.controller;
+
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import single.cjj.bizfi.entity.ApiResponse;
+import single.cjj.workflow.api.WorkflowContracts;
+import single.cjj.workflow.service.WorkflowService;
+
+@RestController
+@RequestMapping("/workflow/tasks")
+public class WorkflowTaskController {
+
+    private final WorkflowService workflowService;
+
+    public WorkflowTaskController(WorkflowService workflowService) {
+        this.workflowService = workflowService;
+    }
+
+    @GetMapping("/{taskId}")
+    public ApiResponse<WorkflowContracts.TaskResponse> get(
+            @PathVariable("taskId") String taskId) {
+        return ApiResponse.success(workflowService.getTask(taskId));
+    }
+
+    @PostMapping("/{taskId}/actions")
+    public ApiResponse<WorkflowContracts.InstanceResponse> action(
+            @PathVariable("taskId") String taskId,
+            @RequestHeader(value = "X-Request-Id", required = false) String requestId,
+            @Valid @RequestBody WorkflowContracts.TaskActionRequest request) {
+        return ApiResponse.success(workflowService.actOnTask(taskId, request, requestId));
+    }
+}

--- a/workflow-service/src/main/java/single/cjj/workflow/controller/WorkflowTaskInboxController.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/controller/WorkflowTaskInboxController.java
@@ -1,0 +1,38 @@
+package single.cjj.workflow.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import single.cjj.bizfi.entity.ApiResponse;
+import single.cjj.workflow.api.WorkflowContracts;
+import single.cjj.workflow.service.WorkflowTaskQueryService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/workflow/tasks")
+public class WorkflowTaskInboxController {
+
+    private final WorkflowTaskQueryService taskQueryService;
+
+    public WorkflowTaskInboxController(WorkflowTaskQueryService taskQueryService) {
+        this.taskQueryService = taskQueryService;
+    }
+
+    @GetMapping
+    public ApiResponse<List<WorkflowContracts.TaskResponse>> list(
+            @RequestParam("tenantId") String tenantId,
+            @RequestParam("assigneeType") String assigneeType,
+            @RequestParam("assigneeValue") String assigneeValue,
+            @RequestParam(value = "status", defaultValue = "PENDING") String status,
+            @RequestParam(value = "limit", defaultValue = "50") int limit) {
+        return ApiResponse.success(taskQueryService.listTasks(
+                tenantId,
+                assigneeType.toUpperCase(),
+                assigneeValue,
+                status.toUpperCase(),
+                limit
+        ));
+    }
+}

--- a/workflow-service/src/main/java/single/cjj/workflow/engine/AttachmentCheckNodeHandler.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/engine/AttachmentCheckNodeHandler.java
@@ -1,0 +1,50 @@
+package single.cjj.workflow.engine;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+@Component
+public class AttachmentCheckNodeHandler implements WorkflowNodeHandler {
+
+    public static final String HANDLER_KEY = "attachment-check";
+
+    @Override
+    public String handlerKey() {
+        return HANDLER_KEY;
+    }
+
+    @Override
+    public ExecutionResult execute(ExecutionContext context) {
+        Object requiredValue = context.node().getConfig().get("requiredCategories");
+        if (!(requiredValue instanceof Collection<?> requiredCategories) || requiredCategories.isEmpty()) {
+            return ExecutionResult.success(Map.of("checked", true));
+        }
+
+        Set<String> required = toStringSet(requiredCategories);
+        Object uploadedValue = context.variables().get("attachmentCategories");
+        Set<String> uploaded = uploadedValue instanceof Collection<?> collection
+                ? toStringSet(collection)
+                : Set.of();
+
+        Set<String> missing = new LinkedHashSet<>(required);
+        missing.removeAll(uploaded);
+        if (!missing.isEmpty()) {
+            return ExecutionResult.failure("缺少必要影像分类: " + String.join(",", missing));
+        }
+        return ExecutionResult.success(Map.of("checked", true, "categories", uploaded));
+    }
+
+    private Set<String> toStringSet(Collection<?> values) {
+        Set<String> result = new LinkedHashSet<>();
+        for (Object value : values) {
+            if (value != null) {
+                result.add(String.valueOf(value));
+            }
+        }
+        return result;
+    }
+}

--- a/workflow-service/src/main/java/single/cjj/workflow/engine/WorkflowConditionEvaluator.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/engine/WorkflowConditionEvaluator.java
@@ -1,0 +1,90 @@
+package single.cjj.workflow.engine;
+
+import org.springframework.stereotype.Component;
+import single.cjj.workflow.model.WorkflowDefinition;
+
+import java.math.BigDecimal;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+@Component
+public class WorkflowConditionEvaluator {
+
+    public String resolveNextNode(WorkflowDefinition definition,
+                                  String currentNodeKey,
+                                  Map<String, Object> variables) {
+        List<WorkflowDefinition.Transition> outgoing = definition.getTransitions().stream()
+                .filter(transition -> currentNodeKey.equals(transition.getFrom()))
+                .sorted(Comparator.comparing(
+                        WorkflowDefinition.Transition::getPriority,
+                        Comparator.nullsLast(Comparator.reverseOrder())
+                ))
+                .toList();
+
+        WorkflowDefinition.Transition defaultTransition = null;
+        for (WorkflowDefinition.Transition transition : outgoing) {
+            if (transition.getCondition() == null) {
+                if (defaultTransition == null) {
+                    defaultTransition = transition;
+                }
+                continue;
+            }
+            if (matches(transition.getCondition(), variables)) {
+                return transition.getTo();
+            }
+        }
+        if (defaultTransition != null) {
+            return defaultTransition.getTo();
+        }
+        throw new IllegalStateException("节点没有可执行的后续连线: " + currentNodeKey);
+    }
+
+    public boolean matches(WorkflowDefinition.Condition condition,
+                           Map<String, Object> variables) {
+        Object actual = variables.get(condition.getField());
+        Object expected = condition.getValue();
+        WorkflowDefinition.ConditionOperator operator = condition.getOperator();
+        if (operator == null) {
+            throw new IllegalArgumentException("条件操作符不能为空");
+        }
+
+        return switch (operator) {
+            case IS_NULL -> actual == null;
+            case NOT_NULL -> actual != null;
+            case EQ -> equalsValue(actual, expected);
+            case NE -> !equalsValue(actual, expected);
+            case GT -> compare(actual, expected) > 0;
+            case GE -> compare(actual, expected) >= 0;
+            case LT -> compare(actual, expected) < 0;
+            case LE -> compare(actual, expected) <= 0;
+            case IN -> expected instanceof Collection<?> collection
+                    && collection.stream().anyMatch(item -> equalsValue(actual, item));
+            case NOT_IN -> expected instanceof Collection<?> collection
+                    && collection.stream().noneMatch(item -> equalsValue(actual, item));
+        };
+    }
+
+    private boolean equalsValue(Object actual, Object expected) {
+        if (actual instanceof Number && expected instanceof Number) {
+            return decimal(actual).compareTo(decimal(expected)) == 0;
+        }
+        return Objects.equals(actual, expected);
+    }
+
+    private int compare(Object actual, Object expected) {
+        if (actual == null || expected == null) {
+            throw new IllegalArgumentException("比较条件的值不能为空");
+        }
+        if (actual instanceof Number && expected instanceof Number) {
+            return decimal(actual).compareTo(decimal(expected));
+        }
+        return String.valueOf(actual).compareTo(String.valueOf(expected));
+    }
+
+    private BigDecimal decimal(Object value) {
+        return new BigDecimal(String.valueOf(value));
+    }
+}

--- a/workflow-service/src/main/java/single/cjj/workflow/engine/WorkflowNodeHandler.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/engine/WorkflowNodeHandler.java
@@ -1,0 +1,33 @@
+package single.cjj.workflow.engine;
+
+import single.cjj.workflow.model.WorkflowDefinition;
+
+import java.util.Map;
+
+public interface WorkflowNodeHandler {
+
+    String handlerKey();
+
+    ExecutionResult execute(ExecutionContext context);
+
+    record ExecutionContext(
+            String instanceId,
+            WorkflowDefinition.Node node,
+            Map<String, Object> variables
+    ) {
+    }
+
+    record ExecutionResult(
+            boolean success,
+            String message,
+            Map<String, Object> output
+    ) {
+        public static ExecutionResult success(Map<String, Object> output) {
+            return new ExecutionResult(true, "OK", output == null ? Map.of() : output);
+        }
+
+        public static ExecutionResult failure(String message) {
+            return new ExecutionResult(false, message, Map.of());
+        }
+    }
+}

--- a/workflow-service/src/main/java/single/cjj/workflow/engine/WorkflowNodeHandlerRegistry.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/engine/WorkflowNodeHandlerRegistry.java
@@ -1,0 +1,30 @@
+package single.cjj.workflow.engine;
+
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class WorkflowNodeHandlerRegistry {
+
+    private final Map<String, WorkflowNodeHandler> handlers = new HashMap<>();
+
+    public WorkflowNodeHandlerRegistry(List<WorkflowNodeHandler> handlerList) {
+        for (WorkflowNodeHandler handler : handlerList) {
+            WorkflowNodeHandler previous = handlers.put(handler.handlerKey(), handler);
+            if (previous != null) {
+                throw new IllegalStateException("重复的工作流 Handler: " + handler.handlerKey());
+            }
+        }
+    }
+
+    public WorkflowNodeHandler require(String handlerKey) {
+        WorkflowNodeHandler handler = handlers.get(handlerKey);
+        if (handler == null) {
+            throw new IllegalStateException("工作流 Handler 未注册: " + handlerKey);
+        }
+        return handler;
+    }
+}

--- a/workflow-service/src/main/java/single/cjj/workflow/exception/WorkflowExceptionHandler.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/exception/WorkflowExceptionHandler.java
@@ -1,0 +1,41 @@
+package single.cjj.workflow.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import single.cjj.bizfi.entity.ApiResponse;
+import single.cjj.bizfi.exception.BizException;
+
+@Slf4j
+@RestControllerAdvice
+public class WorkflowExceptionHandler {
+
+    @ExceptionHandler(BizException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBizException(BizException ex) {
+        return ResponseEntity.badRequest().body(ApiResponse.error(ex.getMessage()));
+    }
+
+    @ExceptionHandler({MethodArgumentNotValidException.class, MissingRequestHeaderException.class})
+    public ResponseEntity<ApiResponse<Void>> handleValidation(Exception ex) {
+        return ResponseEntity.badRequest().body(ApiResponse.error("请求参数不完整或格式错误"));
+    }
+
+    @ExceptionHandler(DuplicateKeyException.class)
+    public ResponseEntity<ApiResponse<Void>> handleDuplicate(DuplicateKeyException ex) {
+        log.warn("workflow duplicate key", ex);
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ApiResponse.error(409, "请求已处理或数据版本冲突"));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleUnexpected(Exception ex) {
+        log.error("workflow unexpected exception", ex);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error(500, "工作流服务异常"));
+    }
+}

--- a/workflow-service/src/main/java/single/cjj/workflow/integration/WorkflowOutboxDispatcher.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/integration/WorkflowOutboxDispatcher.java
@@ -1,0 +1,77 @@
+package single.cjj.workflow.integration;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import single.cjj.workflow.repository.WorkflowOutboxRepository;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+public class WorkflowOutboxDispatcher {
+
+    private final WorkflowOutboxRepository outboxRepository;
+    private final ObjectMapper objectMapper;
+    private final RestClient restClient = RestClient.create();
+
+    @Value("${workflow.outbox.batch-size:20}")
+    private int batchSize;
+
+    public WorkflowOutboxDispatcher(WorkflowOutboxRepository outboxRepository,
+                                    ObjectMapper objectMapper) {
+        this.outboxRepository = outboxRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    @Scheduled(fixedDelayString = "${workflow.outbox.dispatch-delay-ms:5000}")
+    public void dispatch() {
+        List<WorkflowOutboxRepository.OutboxRow> rows = outboxRepository
+                .findDispatchable(Math.max(1, batchSize));
+        for (WorkflowOutboxRepository.OutboxRow row : rows) {
+            if (!outboxRepository.claim(row.id())) {
+                continue;
+            }
+            dispatchOne(row);
+        }
+    }
+
+    private void dispatchOne(WorkflowOutboxRepository.OutboxRow row) {
+        try {
+            Map<String, Object> payload = objectMapper.readValue(
+                    row.payloadJson(),
+                    new TypeReference<LinkedHashMap<String, Object>>() {
+                    }
+            );
+            String callbackUrl = payload.get("callbackUrl") == null
+                    ? null : String.valueOf(payload.get("callbackUrl"));
+            if (!StringUtils.hasText(callbackUrl)) {
+                outboxRepository.markSent(row.id());
+                return;
+            }
+
+            restClient.post()
+                    .uri(callbackUrl)
+                    .header("X-Workflow-Event-Id", row.eventId())
+                    .header("X-Workflow-Event-Type", row.eventType())
+                    .body(payload)
+                    .retrieve()
+                    .toBodilessEntity();
+            outboxRepository.markSent(row.id());
+        } catch (Exception ex) {
+            long delaySeconds = Math.min(3600L, 5L * (1L << Math.min(row.retryCount(), 9)));
+            LocalDateTime nextRetryTime = LocalDateTime.now().plusSeconds(delaySeconds);
+            outboxRepository.markFailed(row.id(), nextRetryTime);
+            log.warn("workflow callback failed, eventId={}, nextRetryTime={}",
+                    row.eventId(), nextRetryTime, ex);
+        }
+    }
+}

--- a/workflow-service/src/main/java/single/cjj/workflow/model/WorkflowDefinition.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/model/WorkflowDefinition.java
@@ -1,0 +1,93 @@
+package single.cjj.workflow.model;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+public class WorkflowDefinition {
+
+    private List<Node> nodes = new ArrayList<>();
+    private List<Transition> transitions = new ArrayList<>();
+
+    public Node requireNode(String nodeKey) {
+        return nodes.stream()
+                .filter(node -> nodeKey.equals(node.getKey()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("流程节点不存在: " + nodeKey));
+    }
+
+    public Node requireStartNode() {
+        return nodes.stream()
+                .filter(node -> node.getType() == NodeType.START)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("流程定义缺少 START 节点"));
+    }
+
+    @Data
+    @NoArgsConstructor
+    public static class Node {
+        private String key;
+        private String name;
+        private NodeType type;
+        private String handlerKey;
+        private AssigneeRule assigneeRule;
+        private Map<String, Object> config = new LinkedHashMap<>();
+    }
+
+    @Data
+    @NoArgsConstructor
+    public static class Transition {
+        private String from;
+        private String to;
+        private Condition condition;
+        private Integer priority = 0;
+    }
+
+    @Data
+    @NoArgsConstructor
+    public static class Condition {
+        private String field;
+        private ConditionOperator operator;
+        private Object value;
+    }
+
+    @Data
+    @NoArgsConstructor
+    public static class AssigneeRule {
+        private AssigneeType type;
+        private String value;
+    }
+
+    public enum NodeType {
+        START,
+        USER_TASK,
+        SERVICE_TASK,
+        EXCLUSIVE_GATEWAY,
+        END
+    }
+
+    public enum ConditionOperator {
+        EQ,
+        NE,
+        GT,
+        GE,
+        LT,
+        LE,
+        IN,
+        NOT_IN,
+        IS_NULL,
+        NOT_NULL
+    }
+
+    public enum AssigneeType {
+        USER,
+        ROLE,
+        VARIABLE
+    }
+}

--- a/workflow-service/src/main/java/single/cjj/workflow/repository/WorkflowOutboxRepository.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/repository/WorkflowOutboxRepository.java
@@ -1,0 +1,85 @@
+package single.cjj.workflow.repository;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public class WorkflowOutboxRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public WorkflowOutboxRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public List<OutboxRow> findDispatchable(int limit) {
+        return jdbcTemplate.query("""
+                SELECT id, event_id, instance_id, event_type, payload_json,
+                       status, retry_count, next_retry_time, created_at
+                FROM wf_event_outbox
+                WHERE status IN ('PENDING', 'FAILED')
+                  AND (next_retry_time IS NULL OR next_retry_time <= NOW())
+                ORDER BY created_at
+                LIMIT ?
+                """, this::mapRow, limit);
+    }
+
+    public boolean claim(String id) {
+        return jdbcTemplate.update("""
+                UPDATE wf_event_outbox
+                SET status = 'SENDING'
+                WHERE id = ?
+                  AND status IN ('PENDING', 'FAILED')
+                  AND (next_retry_time IS NULL OR next_retry_time <= NOW())
+                """, id) == 1;
+    }
+
+    public void markSent(String id) {
+        jdbcTemplate.update("""
+                UPDATE wf_event_outbox
+                SET status = 'SUCCESS', sent_at = NOW(), next_retry_time = NULL
+                WHERE id = ? AND status = 'SENDING'
+                """, id);
+    }
+
+    public void markFailed(String id, LocalDateTime nextRetryTime) {
+        jdbcTemplate.update("""
+                UPDATE wf_event_outbox
+                SET status = 'FAILED', retry_count = retry_count + 1,
+                    next_retry_time = ?
+                WHERE id = ? AND status = 'SENDING'
+                """, nextRetryTime, id);
+    }
+
+    private OutboxRow mapRow(ResultSet rs, int rowNum) throws SQLException {
+        return new OutboxRow(
+                rs.getString("id"),
+                rs.getString("event_id"),
+                rs.getString("instance_id"),
+                rs.getString("event_type"),
+                rs.getString("payload_json"),
+                rs.getString("status"),
+                rs.getInt("retry_count"),
+                rs.getObject("next_retry_time", LocalDateTime.class),
+                rs.getObject("created_at", LocalDateTime.class)
+        );
+    }
+
+    public record OutboxRow(
+            String id,
+            String eventId,
+            String instanceId,
+            String eventType,
+            String payloadJson,
+            String status,
+            int retryCount,
+            LocalDateTime nextRetryTime,
+            LocalDateTime createdAt
+    ) {
+    }
+}

--- a/workflow-service/src/main/java/single/cjj/workflow/repository/WorkflowRepository.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/repository/WorkflowRepository.java
@@ -1,0 +1,349 @@
+package single.cjj.workflow.repository;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class WorkflowRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public WorkflowRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public void ensureDefinition(String tenantId,
+                                 String definitionKey,
+                                 String definitionName,
+                                 String createdBy) {
+        jdbcTemplate.update("""
+                INSERT INTO wf_definition
+                    (tenant_id, definition_key, definition_name, latest_version, status, created_by)
+                VALUES (?, ?, ?, 0, 'ACTIVE', ?)
+                ON DUPLICATE KEY UPDATE definition_name = VALUES(definition_name)
+                """, tenantId, definitionKey, definitionName, createdBy);
+    }
+
+    public int nextDefinitionVersion(String tenantId, String definitionKey) {
+        Integer value = jdbcTemplate.queryForObject("""
+                SELECT COALESCE(MAX(version), 0) + 1
+                FROM wf_definition_version
+                WHERE tenant_id = ? AND definition_key = ?
+                """, Integer.class, tenantId, definitionKey);
+        return value == null ? 1 : value;
+    }
+
+    public void insertDefinitionVersion(String tenantId,
+                                        String definitionKey,
+                                        String definitionName,
+                                        int version,
+                                        String definitionJson,
+                                        String createdBy) {
+        jdbcTemplate.update("""
+                INSERT INTO wf_definition_version
+                    (tenant_id, definition_key, definition_name, version,
+                     definition_json, status, created_by)
+                VALUES (?, ?, ?, ?, CAST(? AS JSON), 'DRAFT', ?)
+                """, tenantId, definitionKey, definitionName, version, definitionJson, createdBy);
+        jdbcTemplate.update("""
+                UPDATE wf_definition
+                SET latest_version = GREATEST(latest_version, ?)
+                WHERE tenant_id = ? AND definition_key = ?
+                """, version, tenantId, definitionKey);
+    }
+
+    public int publishDefinition(String tenantId, String definitionKey, int version) {
+        jdbcTemplate.update("""
+                UPDATE wf_definition_version
+                SET status = 'RETIRED'
+                WHERE tenant_id = ? AND definition_key = ? AND status = 'PUBLISHED'
+                """, tenantId, definitionKey);
+        return jdbcTemplate.update("""
+                UPDATE wf_definition_version
+                SET status = 'PUBLISHED', published_at = NOW()
+                WHERE tenant_id = ? AND definition_key = ? AND version = ? AND status = 'DRAFT'
+                """, tenantId, definitionKey, version);
+    }
+
+    public Optional<DefinitionVersionRow> findDefinition(String tenantId,
+                                                         String definitionKey,
+                                                         int version) {
+        return first(jdbcTemplate.query("""
+                SELECT tenant_id, definition_key, definition_name, version,
+                       definition_json, status, created_at, published_at
+                FROM wf_definition_version
+                WHERE tenant_id = ? AND definition_key = ? AND version = ?
+                """, this::mapDefinition, tenantId, definitionKey, version));
+    }
+
+    public Optional<DefinitionVersionRow> findPublishedDefinition(String tenantId,
+                                                                  String definitionKey) {
+        return first(jdbcTemplate.query("""
+                SELECT tenant_id, definition_key, definition_name, version,
+                       definition_json, status, created_at, published_at
+                FROM wf_definition_version
+                WHERE tenant_id = ? AND definition_key = ? AND status = 'PUBLISHED'
+                ORDER BY version DESC
+                LIMIT 1
+                """, this::mapDefinition, tenantId, definitionKey));
+    }
+
+    public Optional<InstanceRow> findByIdempotency(String tenantId,
+                                                   String sourceSystem,
+                                                   String idempotencyKey) {
+        return first(jdbcTemplate.query("""
+                SELECT * FROM wf_instance
+                WHERE tenant_id = ? AND source_system = ? AND idempotency_key = ?
+                LIMIT 1
+                """, this::mapInstance, tenantId, sourceSystem, idempotencyKey));
+    }
+
+    public void insertInstance(InstanceRow row) {
+        jdbcTemplate.update("""
+                INSERT INTO wf_instance
+                    (id, tenant_id, definition_key, definition_version,
+                     source_system, business_type, business_id, business_key,
+                     idempotency_key, initiator_id, current_node_key, status,
+                     variables_json, callback_url, version, started_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CAST(? AS JSON), ?, 0, ?)
+                """, row.id(), row.tenantId(), row.definitionKey(), row.definitionVersion(),
+                row.sourceSystem(), row.businessType(), row.businessId(), row.businessKey(),
+                row.idempotencyKey(), row.initiatorId(), row.currentNodeKey(), row.status(),
+                row.variablesJson(), row.callbackUrl(), row.startedAt());
+    }
+
+    public Optional<InstanceRow> findInstance(String instanceId) {
+        return first(jdbcTemplate.query("SELECT * FROM wf_instance WHERE id = ?",
+                this::mapInstance, instanceId));
+    }
+
+    public Optional<InstanceRow> findLatestBusinessInstance(String tenantId,
+                                                            String sourceSystem,
+                                                            String businessType,
+                                                            String businessId) {
+        return first(jdbcTemplate.query("""
+                SELECT * FROM wf_instance
+                WHERE tenant_id = ? AND source_system = ?
+                  AND business_type = ? AND business_id = ?
+                ORDER BY started_at DESC
+                LIMIT 1
+                """, this::mapInstance, tenantId, sourceSystem, businessType, businessId));
+    }
+
+    public void insertNodeInstance(NodeInstanceRow row) {
+        jdbcTemplate.update("""
+                INSERT INTO wf_node_instance
+                    (id, instance_id, node_key, node_name, node_type, status,
+                     handler_key, input_json, started_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, CAST(? AS JSON), ?)
+                """, row.id(), row.instanceId(), row.nodeKey(), row.nodeName(), row.nodeType(),
+                row.status(), row.handlerKey(), row.inputJson(), row.startedAt());
+    }
+
+    public void completeNode(String nodeInstanceId, String outputJson) {
+        jdbcTemplate.update("""
+                UPDATE wf_node_instance
+                SET status = 'COMPLETED', output_json = CAST(? AS JSON), ended_at = NOW()
+                WHERE id = ? AND status = 'ACTIVE'
+                """, outputJson, nodeInstanceId);
+    }
+
+    public void insertTask(TaskRow row) {
+        jdbcTemplate.update("""
+                INSERT INTO wf_task
+                    (id, tenant_id, instance_id, node_instance_id, node_key,
+                     task_name, assignee_type, assignee_value, status, version, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?)
+                """, row.id(), row.tenantId(), row.instanceId(), row.nodeInstanceId(),
+                row.nodeKey(), row.taskName(), row.assigneeType(), row.assigneeValue(),
+                row.status(), row.createdAt());
+    }
+
+    public Optional<TaskRow> findTask(String taskId) {
+        return first(jdbcTemplate.query("SELECT * FROM wf_task WHERE id = ?",
+                this::mapTask, taskId));
+    }
+
+    public int completeTask(String taskId, int expectedVersion, String terminalStatus) {
+        return jdbcTemplate.update("""
+                UPDATE wf_task
+                SET status = ?, version = version + 1, completed_at = NOW()
+                WHERE id = ? AND status IN ('PENDING', 'CLAIMED') AND version = ?
+                """, terminalStatus, taskId, expectedVersion);
+    }
+
+    public void updateInstancePosition(String instanceId,
+                                       String currentNodeKey,
+                                       String variablesJson) {
+        jdbcTemplate.update("""
+                UPDATE wf_instance
+                SET current_node_key = ?, variables_json = CAST(? AS JSON), version = version + 1
+                WHERE id = ? AND status = 'RUNNING'
+                """, currentNodeKey, variablesJson, instanceId);
+    }
+
+    public int finishInstance(String instanceId,
+                              String terminalStatus,
+                              String variablesJson) {
+        return jdbcTemplate.update("""
+                UPDATE wf_instance
+                SET status = ?, current_node_key = NULL,
+                    variables_json = CAST(? AS JSON), ended_at = NOW(), version = version + 1
+                WHERE id = ? AND status = 'RUNNING'
+                """, terminalStatus, variablesJson, instanceId);
+    }
+
+    public void insertActionLog(String id,
+                                String instanceId,
+                                String taskId,
+                                String action,
+                                String operatorId,
+                                String comment,
+                                String beforeStatus,
+                                String afterStatus,
+                                String requestId) {
+        jdbcTemplate.update("""
+                INSERT INTO wf_action_log
+                    (id, instance_id, task_id, action, operator_id, comment_text,
+                     before_status, after_status, request_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """, id, instanceId, taskId, action, operatorId, comment,
+                beforeStatus, afterStatus, requestId);
+    }
+
+    public void insertOutbox(String id,
+                             String eventId,
+                             String instanceId,
+                             String eventType,
+                             String payloadJson) {
+        jdbcTemplate.update("""
+                INSERT INTO wf_event_outbox
+                    (id, event_id, instance_id, event_type, payload_json, status)
+                VALUES (?, ?, ?, ?, CAST(? AS JSON), 'PENDING')
+                """, id, eventId, instanceId, eventType, payloadJson);
+    }
+
+    private DefinitionVersionRow mapDefinition(ResultSet rs, int rowNum) throws SQLException {
+        return new DefinitionVersionRow(
+                rs.getString("tenant_id"),
+                rs.getString("definition_key"),
+                rs.getString("definition_name"),
+                rs.getInt("version"),
+                rs.getString("definition_json"),
+                rs.getString("status"),
+                rs.getObject("created_at", LocalDateTime.class),
+                rs.getObject("published_at", LocalDateTime.class)
+        );
+    }
+
+    private InstanceRow mapInstance(ResultSet rs, int rowNum) throws SQLException {
+        return new InstanceRow(
+                rs.getString("id"),
+                rs.getString("tenant_id"),
+                rs.getString("definition_key"),
+                rs.getInt("definition_version"),
+                rs.getString("source_system"),
+                rs.getString("business_type"),
+                rs.getString("business_id"),
+                rs.getString("business_key"),
+                rs.getString("idempotency_key"),
+                rs.getString("initiator_id"),
+                rs.getString("current_node_key"),
+                rs.getString("status"),
+                rs.getString("variables_json"),
+                rs.getString("callback_url"),
+                rs.getInt("version"),
+                rs.getObject("started_at", LocalDateTime.class),
+                rs.getObject("ended_at", LocalDateTime.class)
+        );
+    }
+
+    private TaskRow mapTask(ResultSet rs, int rowNum) throws SQLException {
+        return new TaskRow(
+                rs.getString("id"),
+                rs.getString("tenant_id"),
+                rs.getString("instance_id"),
+                rs.getString("node_instance_id"),
+                rs.getString("node_key"),
+                rs.getString("task_name"),
+                rs.getString("assignee_type"),
+                rs.getString("assignee_value"),
+                rs.getString("status"),
+                rs.getInt("version"),
+                rs.getObject("created_at", LocalDateTime.class),
+                rs.getObject("completed_at", LocalDateTime.class)
+        );
+    }
+
+    private <T> Optional<T> first(List<T> rows) {
+        return rows.isEmpty() ? Optional.empty() : Optional.of(rows.get(0));
+    }
+
+    public record DefinitionVersionRow(
+            String tenantId,
+            String definitionKey,
+            String definitionName,
+            int version,
+            String definitionJson,
+            String status,
+            LocalDateTime createdAt,
+            LocalDateTime publishedAt
+    ) {
+    }
+
+    public record InstanceRow(
+            String id,
+            String tenantId,
+            String definitionKey,
+            int definitionVersion,
+            String sourceSystem,
+            String businessType,
+            String businessId,
+            String businessKey,
+            String idempotencyKey,
+            String initiatorId,
+            String currentNodeKey,
+            String status,
+            String variablesJson,
+            String callbackUrl,
+            int version,
+            LocalDateTime startedAt,
+            LocalDateTime endedAt
+    ) {
+    }
+
+    public record NodeInstanceRow(
+            String id,
+            String instanceId,
+            String nodeKey,
+            String nodeName,
+            String nodeType,
+            String status,
+            String handlerKey,
+            String inputJson,
+            LocalDateTime startedAt
+    ) {
+    }
+
+    public record TaskRow(
+            String id,
+            String tenantId,
+            String instanceId,
+            String nodeInstanceId,
+            String nodeKey,
+            String taskName,
+            String assigneeType,
+            String assigneeValue,
+            String status,
+            int version,
+            LocalDateTime createdAt,
+            LocalDateTime completedAt
+    ) {
+    }
+}

--- a/workflow-service/src/main/java/single/cjj/workflow/service/WorkflowService.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/service/WorkflowService.java
@@ -1,0 +1,480 @@
+package single.cjj.workflow.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import single.cjj.bizfi.exception.BizException;
+import single.cjj.workflow.api.WorkflowContracts;
+import single.cjj.workflow.engine.WorkflowConditionEvaluator;
+import single.cjj.workflow.engine.WorkflowNodeHandler;
+import single.cjj.workflow.engine.WorkflowNodeHandlerRegistry;
+import single.cjj.workflow.model.WorkflowDefinition;
+import single.cjj.workflow.repository.WorkflowRepository;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+public class WorkflowService {
+
+    private static final String INSTANCE_RUNNING = "RUNNING";
+    private static final String INSTANCE_COMPLETED = "COMPLETED";
+    private static final String INSTANCE_REJECTED = "REJECTED";
+
+    private final WorkflowRepository repository;
+    private final WorkflowConditionEvaluator conditionEvaluator;
+    private final WorkflowNodeHandlerRegistry handlerRegistry;
+    private final ObjectMapper objectMapper;
+
+    public WorkflowService(WorkflowRepository repository,
+                           WorkflowConditionEvaluator conditionEvaluator,
+                           WorkflowNodeHandlerRegistry handlerRegistry,
+                           ObjectMapper objectMapper) {
+        this.repository = repository;
+        this.conditionEvaluator = conditionEvaluator;
+        this.handlerRegistry = handlerRegistry;
+        this.objectMapper = objectMapper;
+    }
+
+    @Transactional
+    public WorkflowContracts.DefinitionResponse createDefinition(
+            WorkflowContracts.DefinitionCreateRequest request) {
+        validateDefinition(request.definition());
+        repository.ensureDefinition(
+                request.tenantId(),
+                request.definitionKey(),
+                request.definitionName(),
+                request.createdBy()
+        );
+        int version = repository.nextDefinitionVersion(request.tenantId(), request.definitionKey());
+        repository.insertDefinitionVersion(
+                request.tenantId(),
+                request.definitionKey(),
+                request.definitionName(),
+                version,
+                writeJson(request.definition()),
+                request.createdBy()
+        );
+        return getDefinition(request.tenantId(), request.definitionKey(), version);
+    }
+
+    @Transactional
+    public WorkflowContracts.DefinitionResponse publishDefinition(String tenantId,
+                                                                  String definitionKey,
+                                                                  int version) {
+        WorkflowRepository.DefinitionVersionRow row = repository
+                .findDefinition(tenantId, definitionKey, version)
+                .orElseThrow(() -> new BizException("流程定义版本不存在"));
+        validateDefinition(readDefinition(row.definitionJson()));
+        int affected = repository.publishDefinition(tenantId, definitionKey, version);
+        if (affected != 1) {
+            throw new BizException("只有草稿版本可以发布");
+        }
+        return getDefinition(tenantId, definitionKey, version);
+    }
+
+    public WorkflowContracts.DefinitionResponse getPublishedDefinition(String tenantId,
+                                                                       String definitionKey) {
+        WorkflowRepository.DefinitionVersionRow row = repository
+                .findPublishedDefinition(tenantId, definitionKey)
+                .orElseThrow(() -> new BizException("没有已发布的流程定义"));
+        return toDefinitionResponse(row);
+    }
+
+    public WorkflowContracts.DefinitionResponse getDefinition(String tenantId,
+                                                              String definitionKey,
+                                                              int version) {
+        WorkflowRepository.DefinitionVersionRow row = repository
+                .findDefinition(tenantId, definitionKey, version)
+                .orElseThrow(() -> new BizException("流程定义版本不存在"));
+        return toDefinitionResponse(row);
+    }
+
+    @Transactional
+    public WorkflowContracts.InstanceResponse startWorkflow(
+            WorkflowContracts.StartWorkflowRequest request,
+            String idempotencyKey) {
+        if (!StringUtils.hasText(idempotencyKey)) {
+            throw new BizException("缺少 Idempotency-Key 请求头");
+        }
+
+        WorkflowRepository.InstanceRow existing = repository
+                .findByIdempotency(request.tenantId(), request.sourceSystem(), idempotencyKey)
+                .orElse(null);
+        if (existing != null) {
+            return toInstanceResponse(existing);
+        }
+
+        WorkflowRepository.DefinitionVersionRow definitionRow = repository
+                .findPublishedDefinition(request.tenantId(), request.definitionKey())
+                .orElseThrow(() -> new BizException("没有可启动的已发布流程定义"));
+        WorkflowDefinition definition = readDefinition(definitionRow.definitionJson());
+        validateDefinition(definition);
+
+        String instanceId = newId();
+        Map<String, Object> variables = request.safeVariables();
+        variables.putIfAbsent("initiatorId", request.initiatorId());
+        String businessKey = request.sourceSystem() + ":" + request.businessType() + ":" + request.businessId();
+        LocalDateTime now = LocalDateTime.now();
+
+        WorkflowRepository.InstanceRow instance = new WorkflowRepository.InstanceRow(
+                instanceId,
+                request.tenantId(),
+                request.definitionKey(),
+                definitionRow.version(),
+                request.sourceSystem(),
+                request.businessType(),
+                request.businessId(),
+                businessKey,
+                idempotencyKey,
+                request.initiatorId(),
+                null,
+                INSTANCE_RUNNING,
+                writeJson(variables),
+                request.callbackUrl(),
+                0,
+                now,
+                null
+        );
+        repository.insertInstance(instance);
+        repository.insertActionLog(
+                newId(), instanceId, null, "START", request.initiatorId(),
+                "启动流程", null, INSTANCE_RUNNING, idempotencyKey
+        );
+
+        WorkflowDefinition.Node startNode = definition.requireStartNode();
+        String startNodeInstanceId = createNodeInstance(instanceId, startNode, variables);
+        repository.completeNode(startNodeInstanceId, "{}");
+        advanceFrom(instance, definition, startNode.getKey(), variables);
+        return getInstance(instanceId);
+    }
+
+    @Transactional
+    public WorkflowContracts.InstanceResponse actOnTask(String taskId,
+                                                        WorkflowContracts.TaskActionRequest request,
+                                                        String requestId) {
+        WorkflowRepository.TaskRow task = repository.findTask(taskId)
+                .orElseThrow(() -> new BizException("待办任务不存在"));
+        if (!("PENDING".equals(task.status()) || "CLAIMED".equals(task.status()))) {
+            throw new BizException("待办任务已经处理");
+        }
+        validateOperator(task, request.operatorId());
+
+        WorkflowRepository.InstanceRow instance = repository.findInstance(task.instanceId())
+                .orElseThrow(() -> new BizException("流程实例不存在"));
+        if (!INSTANCE_RUNNING.equals(instance.status())) {
+            throw new BizException("流程实例不在运行中");
+        }
+
+        WorkflowRepository.DefinitionVersionRow definitionRow = repository
+                .findDefinition(instance.tenantId(), instance.definitionKey(), instance.definitionVersion())
+                .orElseThrow(() -> new BizException("流程实例对应的定义版本不存在"));
+        WorkflowDefinition definition = readDefinition(definitionRow.definitionJson());
+
+        Map<String, Object> variables = readMap(instance.variablesJson());
+        variables.putAll(request.safeVariables());
+        String taskTerminalStatus = request.action() == WorkflowContracts.TaskAction.APPROVE
+                ? "APPROVED" : "REJECTED";
+        int affected = repository.completeTask(taskId, task.version(), taskTerminalStatus);
+        if (affected != 1) {
+            throw new BizException("任务已被其他请求处理，请刷新后重试");
+        }
+        repository.completeNode(task.nodeInstanceId(), writeJson(Map.of(
+                "action", request.action().name(),
+                "operatorId", request.operatorId()
+        )));
+        repository.insertActionLog(
+                newId(), instance.id(), task.id(), request.action().name(),
+                request.operatorId(), request.comment(), task.status(), taskTerminalStatus, requestId
+        );
+
+        if (request.action() == WorkflowContracts.TaskAction.REJECT) {
+            int finished = repository.finishInstance(instance.id(), INSTANCE_REJECTED, writeJson(variables));
+            if (finished != 1) {
+                throw new BizException("流程实例状态已变化，请刷新后重试");
+            }
+            emitTerminalEvent(instance, INSTANCE_REJECTED, variables);
+        } else {
+            advanceFrom(instance, definition, task.nodeKey(), variables);
+        }
+        return getInstance(instance.id());
+    }
+
+    public WorkflowContracts.InstanceResponse getInstance(String instanceId) {
+        return repository.findInstance(instanceId)
+                .map(this::toInstanceResponse)
+                .orElseThrow(() -> new BizException("流程实例不存在"));
+    }
+
+    public WorkflowContracts.InstanceResponse getBusinessInstance(String tenantId,
+                                                                  String sourceSystem,
+                                                                  String businessType,
+                                                                  String businessId) {
+        return repository.findLatestBusinessInstance(tenantId, sourceSystem, businessType, businessId)
+                .map(this::toInstanceResponse)
+                .orElseThrow(() -> new BizException("业务对象没有流程实例"));
+    }
+
+    public WorkflowContracts.TaskResponse getTask(String taskId) {
+        return repository.findTask(taskId)
+                .map(this::toTaskResponse)
+                .orElseThrow(() -> new BizException("待办任务不存在"));
+    }
+
+    private void advanceFrom(WorkflowRepository.InstanceRow instance,
+                             WorkflowDefinition definition,
+                             String completedNodeKey,
+                             Map<String, Object> variables) {
+        String nextNodeKey = conditionEvaluator.resolveNextNode(definition, completedNodeKey, variables);
+        int guard = Math.max(definition.getNodes().size() * 2, 10);
+
+        while (guard-- > 0) {
+            WorkflowDefinition.Node node = definition.requireNode(nextNodeKey);
+            switch (node.getType()) {
+                case START -> throw new BizException("流程不能回到 START 节点");
+                case USER_TASK -> {
+                    activateUserTask(instance, node, variables);
+                    return;
+                }
+                case SERVICE_TASK -> {
+                    String nodeInstanceId = createNodeInstance(instance.id(), node, variables);
+                    repository.updateInstancePosition(instance.id(), node.getKey(), writeJson(variables));
+                    WorkflowNodeHandler.ExecutionResult result = handlerRegistry
+                            .require(node.getHandlerKey())
+                            .execute(new WorkflowNodeHandler.ExecutionContext(
+                                    instance.id(), node, Map.copyOf(variables)
+                            ));
+                    if (!result.success()) {
+                        throw new BizException(result.message());
+                    }
+                    if (result.output() != null && !result.output().isEmpty()) {
+                        variables.putAll(result.output());
+                    }
+                    repository.completeNode(nodeInstanceId, writeJson(result.output()));
+                    nextNodeKey = conditionEvaluator.resolveNextNode(definition, node.getKey(), variables);
+                }
+                case EXCLUSIVE_GATEWAY -> {
+                    String nodeInstanceId = createNodeInstance(instance.id(), node, variables);
+                    repository.completeNode(nodeInstanceId, "{}");
+                    nextNodeKey = conditionEvaluator.resolveNextNode(definition, node.getKey(), variables);
+                }
+                case END -> {
+                    String nodeInstanceId = createNodeInstance(instance.id(), node, variables);
+                    repository.completeNode(nodeInstanceId, "{}");
+                    int finished = repository.finishInstance(
+                            instance.id(), INSTANCE_COMPLETED, writeJson(variables)
+                    );
+                    if (finished != 1) {
+                        throw new BizException("流程实例状态已变化，请刷新后重试");
+                    }
+                    emitTerminalEvent(instance, INSTANCE_COMPLETED, variables);
+                    return;
+                }
+            }
+        }
+        throw new BizException("流程节点跳转次数超过安全限制，可能存在死循环");
+    }
+
+    private void activateUserTask(WorkflowRepository.InstanceRow instance,
+                                  WorkflowDefinition.Node node,
+                                  Map<String, Object> variables) {
+        Assignee assignee = resolveAssignee(node, variables);
+        String nodeInstanceId = createNodeInstance(instance.id(), node, variables);
+        String taskId = newId();
+        repository.insertTask(new WorkflowRepository.TaskRow(
+                taskId,
+                instance.tenantId(),
+                instance.id(),
+                nodeInstanceId,
+                node.getKey(),
+                node.getName(),
+                assignee.type(),
+                assignee.value(),
+                "PENDING",
+                0,
+                LocalDateTime.now(),
+                null
+        ));
+        repository.updateInstancePosition(instance.id(), node.getKey(), writeJson(variables));
+    }
+
+    private String createNodeInstance(String instanceId,
+                                      WorkflowDefinition.Node node,
+                                      Map<String, Object> variables) {
+        String nodeInstanceId = newId();
+        repository.insertNodeInstance(new WorkflowRepository.NodeInstanceRow(
+                nodeInstanceId,
+                instanceId,
+                node.getKey(),
+                StringUtils.hasText(node.getName()) ? node.getName() : node.getKey(),
+                node.getType().name(),
+                "ACTIVE",
+                node.getHandlerKey(),
+                writeJson(variables),
+                LocalDateTime.now()
+        ));
+        return nodeInstanceId;
+    }
+
+    private Assignee resolveAssignee(WorkflowDefinition.Node node,
+                                     Map<String, Object> variables) {
+        WorkflowDefinition.AssigneeRule rule = node.getAssigneeRule();
+        if (rule == null || rule.getType() == null || !StringUtils.hasText(rule.getValue())) {
+            throw new BizException("人工节点未配置审批人规则: " + node.getKey());
+        }
+        return switch (rule.getType()) {
+            case USER -> new Assignee("USER", rule.getValue());
+            case ROLE -> new Assignee("ROLE", rule.getValue());
+            case VARIABLE -> {
+                Object value = variables.get(rule.getValue());
+                if (value == null || !StringUtils.hasText(String.valueOf(value))) {
+                    throw new BizException("审批人变量不存在: " + rule.getValue());
+                }
+                yield new Assignee("USER", String.valueOf(value));
+            }
+        };
+    }
+
+    private void validateOperator(WorkflowRepository.TaskRow task, String operatorId) {
+        if ("USER".equals(task.assigneeType()) && !task.assigneeValue().equals(operatorId)) {
+            throw new BizException("当前用户不是该任务的处理人");
+        }
+        // ROLE 类型由网关或权限服务校验角色成员关系；工作流服务保留最终任务并发校验。
+    }
+
+    private void emitTerminalEvent(WorkflowRepository.InstanceRow instance,
+                                   String status,
+                                   Map<String, Object> variables) {
+        String eventId = newId();
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("eventId", eventId);
+        payload.put("eventType", "INSTANCE_" + status);
+        payload.put("instanceId", instance.id());
+        payload.put("tenantId", instance.tenantId());
+        payload.put("sourceSystem", instance.sourceSystem());
+        payload.put("businessType", instance.businessType());
+        payload.put("businessId", instance.businessId());
+        payload.put("callbackUrl", instance.callbackUrl());
+        payload.put("variables", variables);
+        payload.put("occurredAt", LocalDateTime.now().toString());
+        repository.insertOutbox(newId(), eventId, instance.id(), "INSTANCE_" + status, writeJson(payload));
+    }
+
+    private void validateDefinition(WorkflowDefinition definition) {
+        if (definition == null || definition.getNodes() == null || definition.getNodes().isEmpty()) {
+            throw new BizException("流程定义至少需要一个节点");
+        }
+        if (definition.getTransitions() == null) {
+            definition.setTransitions(new ArrayList<>());
+        }
+
+        Set<String> nodeKeys = new HashSet<>();
+        long startCount = 0;
+        long endCount = 0;
+        for (WorkflowDefinition.Node node : definition.getNodes()) {
+            if (node == null || !StringUtils.hasText(node.getKey()) || node.getType() == null) {
+                throw new BizException("流程节点 key 和 type 不能为空");
+            }
+            if (!nodeKeys.add(node.getKey())) {
+                throw new BizException("流程节点 key 重复: " + node.getKey());
+            }
+            if (node.getType() == WorkflowDefinition.NodeType.START) {
+                startCount++;
+            }
+            if (node.getType() == WorkflowDefinition.NodeType.END) {
+                endCount++;
+            }
+            if (node.getType() == WorkflowDefinition.NodeType.USER_TASK
+                    && node.getAssigneeRule() == null) {
+                throw new BizException("人工节点必须配置审批人规则: " + node.getKey());
+            }
+            if (node.getType() == WorkflowDefinition.NodeType.SERVICE_TASK
+                    && !StringUtils.hasText(node.getHandlerKey())) {
+                throw new BizException("服务节点必须配置 handlerKey: " + node.getKey());
+            }
+        }
+        if (startCount != 1) {
+            throw new BizException("流程定义必须且只能有一个 START 节点");
+        }
+        if (endCount < 1) {
+            throw new BizException("流程定义至少需要一个 END 节点");
+        }
+        for (WorkflowDefinition.Transition transition : definition.getTransitions()) {
+            if (transition == null
+                    || !nodeKeys.contains(transition.getFrom())
+                    || !nodeKeys.contains(transition.getTo())) {
+                throw new BizException("流程连线引用了不存在的节点");
+            }
+        }
+    }
+
+    private WorkflowContracts.DefinitionResponse toDefinitionResponse(
+            WorkflowRepository.DefinitionVersionRow row) {
+        return new WorkflowContracts.DefinitionResponse(
+                row.tenantId(), row.definitionKey(), row.definitionName(), row.version(),
+                row.status(), readDefinition(row.definitionJson()), row.createdAt(), row.publishedAt()
+        );
+    }
+
+    private WorkflowContracts.InstanceResponse toInstanceResponse(
+            WorkflowRepository.InstanceRow row) {
+        return new WorkflowContracts.InstanceResponse(
+                row.id(), row.tenantId(), row.definitionKey(), row.definitionVersion(),
+                row.sourceSystem(), row.businessType(), row.businessId(), row.initiatorId(),
+                row.currentNodeKey(), row.status(), readMap(row.variablesJson()),
+                row.startedAt(), row.endedAt()
+        );
+    }
+
+    private WorkflowContracts.TaskResponse toTaskResponse(WorkflowRepository.TaskRow row) {
+        return new WorkflowContracts.TaskResponse(
+                row.id(), row.instanceId(), row.nodeInstanceId(), row.nodeKey(),
+                row.taskName(), row.assigneeType(), row.assigneeValue(), row.status(),
+                row.version(), row.createdAt(), row.completedAt()
+        );
+    }
+
+    private WorkflowDefinition readDefinition(String json) {
+        try {
+            return objectMapper.readValue(json, WorkflowDefinition.class);
+        } catch (JsonProcessingException ex) {
+            throw new BizException("流程定义 JSON 无法解析: " + ex.getOriginalMessage());
+        }
+    }
+
+    private Map<String, Object> readMap(String json) {
+        if (!StringUtils.hasText(json)) {
+            return new LinkedHashMap<>();
+        }
+        try {
+            return objectMapper.readValue(json, new TypeReference<LinkedHashMap<String, Object>>() {
+            });
+        } catch (JsonProcessingException ex) {
+            throw new BizException("流程变量 JSON 无法解析: " + ex.getOriginalMessage());
+        }
+    }
+
+    private String writeJson(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException ex) {
+            throw new BizException("工作流数据无法序列化: " + ex.getOriginalMessage());
+        }
+    }
+
+    private String newId() {
+        return UUID.randomUUID().toString().replace("-", "");
+    }
+
+    private record Assignee(String type, String value) {
+    }
+}

--- a/workflow-service/src/main/java/single/cjj/workflow/service/WorkflowTaskQueryService.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/service/WorkflowTaskQueryService.java
@@ -1,0 +1,54 @@
+package single.cjj.workflow.service;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import single.cjj.workflow.api.WorkflowContracts;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class WorkflowTaskQueryService {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public WorkflowTaskQueryService(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public List<WorkflowContracts.TaskResponse> listTasks(String tenantId,
+                                                          String assigneeType,
+                                                          String assigneeValue,
+                                                          String status,
+                                                          int limit) {
+        int safeLimit = Math.min(Math.max(limit, 1), 200);
+        return jdbcTemplate.query("""
+                SELECT id, instance_id, node_instance_id, node_key, task_name,
+                       assignee_type, assignee_value, status, version,
+                       created_at, completed_at
+                FROM wf_task
+                WHERE tenant_id = ? AND assignee_type = ? AND assignee_value = ?
+                  AND status = ?
+                ORDER BY created_at
+                LIMIT ?
+                """, this::mapTask, tenantId, assigneeType, assigneeValue, status, safeLimit);
+    }
+
+    private WorkflowContracts.TaskResponse mapTask(ResultSet rs, int rowNum) throws SQLException {
+        return new WorkflowContracts.TaskResponse(
+                rs.getString("id"),
+                rs.getString("instance_id"),
+                rs.getString("node_instance_id"),
+                rs.getString("node_key"),
+                rs.getString("task_name"),
+                rs.getString("assignee_type"),
+                rs.getString("assignee_value"),
+                rs.getString("status"),
+                rs.getInt("version"),
+                rs.getObject("created_at", LocalDateTime.class),
+                rs.getObject("completed_at", LocalDateTime.class)
+        );
+    }
+}

--- a/workflow-service/src/main/resources/application.yml
+++ b/workflow-service/src/main/resources/application.yml
@@ -1,0 +1,37 @@
+server:
+  port: ${SERVER_PORT:10006}
+  servlet:
+    context-path: /api
+
+spring:
+  application:
+    name: workflow-service
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:dev}
+  config:
+    import: optional:nacos:${spring.application.name}
+  cloud:
+    nacos:
+      discovery:
+        server-addr: ${NACOS_ADDR:127.0.0.1:8848}
+        group: ${NACOS_GROUP:DEV_GROUP}
+        namespace: ${NACOS_NAMESPACE:public}
+      config:
+        server-addr: ${NACOS_ADDR:127.0.0.1:8848}
+        file-extension: yaml
+        group: ${NACOS_GROUP:DEV_GROUP}
+        namespace: ${NACOS_NAMESPACE:public}
+  datasource:
+    url: ${WORKFLOW_DB_URL:jdbc:mysql://127.0.0.1:3306/matrix_workflow?useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Shanghai}
+    username: ${WORKFLOW_DB_USERNAME:root}
+    password: ${WORKFLOW_DB_PASSWORD:root}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics
+  endpoint:
+    health:
+      show-details: always

--- a/workflow-service/src/main/resources/sql/workflow_v1.sql
+++ b/workflow-service/src/main/resources/sql/workflow_v1.sql
@@ -1,0 +1,111 @@
+CREATE TABLE IF NOT EXISTS wf_definition (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    tenant_id VARCHAR(64) NOT NULL,
+    definition_key VARCHAR(100) NOT NULL,
+    definition_name VARCHAR(200) NOT NULL,
+    latest_version INT NOT NULL DEFAULT 0,
+    status VARCHAR(32) NOT NULL DEFAULT 'ACTIVE',
+    created_by VARCHAR(64) NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uk_wf_definition (tenant_id, definition_key)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS wf_definition_version (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    tenant_id VARCHAR(64) NOT NULL,
+    definition_key VARCHAR(100) NOT NULL,
+    definition_name VARCHAR(200) NOT NULL,
+    version INT NOT NULL,
+    definition_json JSON NOT NULL,
+    status VARCHAR(32) NOT NULL,
+    created_by VARCHAR(64) NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    published_at DATETIME NULL,
+    UNIQUE KEY uk_wf_definition_version (tenant_id, definition_key, version),
+    KEY idx_wf_definition_published (tenant_id, definition_key, status)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS wf_instance (
+    id VARCHAR(40) PRIMARY KEY,
+    tenant_id VARCHAR(64) NOT NULL,
+    definition_key VARCHAR(100) NOT NULL,
+    definition_version INT NOT NULL,
+    source_system VARCHAR(100) NOT NULL,
+    business_type VARCHAR(100) NOT NULL,
+    business_id VARCHAR(128) NOT NULL,
+    business_key VARCHAR(360) NOT NULL,
+    idempotency_key VARCHAR(160) NOT NULL,
+    initiator_id VARCHAR(64) NOT NULL,
+    current_node_key VARCHAR(100) NULL,
+    status VARCHAR(32) NOT NULL,
+    variables_json JSON NOT NULL,
+    callback_url VARCHAR(500) NULL,
+    version INT NOT NULL DEFAULT 0,
+    started_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    ended_at DATETIME NULL,
+    UNIQUE KEY uk_wf_instance_idempotency (tenant_id, source_system, idempotency_key),
+    KEY idx_wf_instance_business (tenant_id, source_system, business_type, business_id),
+    KEY idx_wf_instance_status (tenant_id, status, started_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS wf_node_instance (
+    id VARCHAR(40) PRIMARY KEY,
+    instance_id VARCHAR(40) NOT NULL,
+    node_key VARCHAR(100) NOT NULL,
+    node_name VARCHAR(200) NOT NULL,
+    node_type VARCHAR(32) NOT NULL,
+    status VARCHAR(32) NOT NULL,
+    handler_key VARCHAR(100) NULL,
+    input_json JSON NULL,
+    output_json JSON NULL,
+    started_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    ended_at DATETIME NULL,
+    KEY idx_wf_node_instance (instance_id, node_key, status)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS wf_task (
+    id VARCHAR(40) PRIMARY KEY,
+    tenant_id VARCHAR(64) NOT NULL,
+    instance_id VARCHAR(40) NOT NULL,
+    node_instance_id VARCHAR(40) NOT NULL,
+    node_key VARCHAR(100) NOT NULL,
+    task_name VARCHAR(200) NOT NULL,
+    assignee_type VARCHAR(32) NOT NULL,
+    assignee_value VARCHAR(200) NOT NULL,
+    status VARCHAR(32) NOT NULL,
+    version INT NOT NULL DEFAULT 0,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at DATETIME NULL,
+    KEY idx_wf_task_assignee (tenant_id, assignee_type, assignee_value, status, created_at),
+    KEY idx_wf_task_instance (instance_id, status)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS wf_action_log (
+    id VARCHAR(40) PRIMARY KEY,
+    instance_id VARCHAR(40) NOT NULL,
+    task_id VARCHAR(40) NULL,
+    action VARCHAR(32) NOT NULL,
+    operator_id VARCHAR(64) NOT NULL,
+    comment_text VARCHAR(1000) NULL,
+    before_status VARCHAR(32) NULL,
+    after_status VARCHAR(32) NULL,
+    request_id VARCHAR(160) NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    KEY idx_wf_action_instance (instance_id, created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS wf_event_outbox (
+    id VARCHAR(40) PRIMARY KEY,
+    event_id VARCHAR(40) NOT NULL,
+    instance_id VARCHAR(40) NOT NULL,
+    event_type VARCHAR(64) NOT NULL,
+    payload_json JSON NOT NULL,
+    status VARCHAR(32) NOT NULL DEFAULT 'PENDING',
+    retry_count INT NOT NULL DEFAULT 0,
+    next_retry_time DATETIME NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    sent_at DATETIME NULL,
+    UNIQUE KEY uk_wf_event_id (event_id),
+    KEY idx_wf_outbox_dispatch (status, next_retry_time, created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/workflow-service/src/test/java/single/cjj/workflow/engine/WorkflowConditionEvaluatorTest.java
+++ b/workflow-service/src/test/java/single/cjj/workflow/engine/WorkflowConditionEvaluatorTest.java
@@ -1,0 +1,54 @@
+package single.cjj.workflow.engine;
+
+import org.junit.jupiter.api.Test;
+import single.cjj.workflow.model.WorkflowDefinition;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WorkflowConditionEvaluatorTest {
+
+    private final WorkflowConditionEvaluator evaluator = new WorkflowConditionEvaluator();
+
+    @Test
+    void shouldRouteByAmountAndUseDefaultTransition() {
+        WorkflowDefinition definition = new WorkflowDefinition();
+
+        WorkflowDefinition.Transition highAmount = new WorkflowDefinition.Transition();
+        highAmount.setFrom("amountGateway");
+        highAmount.setTo("secondReview");
+        highAmount.setPriority(10);
+        WorkflowDefinition.Condition condition = new WorkflowDefinition.Condition();
+        condition.setField("amount");
+        condition.setOperator(WorkflowDefinition.ConditionOperator.GT);
+        condition.setValue(10000);
+        highAmount.setCondition(condition);
+
+        WorkflowDefinition.Transition defaultRoute = new WorkflowDefinition.Transition();
+        defaultRoute.setFrom("amountGateway");
+        defaultRoute.setTo("end");
+        defaultRoute.setPriority(0);
+
+        definition.setTransitions(List.of(highAmount, defaultRoute));
+
+        assertEquals("secondReview", evaluator.resolveNextNode(
+                definition, "amountGateway", Map.of("amount", 12000)
+        ));
+        assertEquals("end", evaluator.resolveNextNode(
+                definition, "amountGateway", Map.of("amount", 5000)
+        ));
+    }
+
+    @Test
+    void shouldCompareNumericValuesWithoutTypeMismatch() {
+        WorkflowDefinition.Condition condition = new WorkflowDefinition.Condition();
+        condition.setField("amount");
+        condition.setOperator(WorkflowDefinition.ConditionOperator.EQ);
+        condition.setValue(10000L);
+
+        assertTrue(evaluator.matches(condition, Map.of("amount", 10000)));
+    }
+}


### PR DESCRIPTION
## Summary

- add a standalone `workflow-service` module to Matrix
- add versioned workflow definitions with publish semantics
- add idempotent workflow instance startup
- add user tasks, service-task handlers, safe exclusive conditions, approve/reject actions and task inbox queries
- add attachment category validation through the `attachment-check` handler
- add transactional terminal events and an HTTP Outbox dispatcher with conditional claiming and retry backoff
- add MySQL schema, usage documentation, unit tests and a focused GitHub Actions workflow

## Design boundaries

Business systems remain the source of truth for document data. Workflow Service stores only business references, process state, tasks, audit records and delivery events.

The MVP intentionally excludes parallel gateways, countersign, subprocesses, arbitrary scripts and definition migration.

## Validation

- `WorkflowConditionEvaluatorTest` covers amount routing, default transitions and numeric equality
- GitHub Actions runs `mvn -B -pl workflow-service -am test`

## Follow-up

- integrate Auth Service role membership checks
- add attachment metadata/presigned upload APIs
- add return-to-initiator and resubmission
- add callback signatures and manual Outbox operations
- build the workflow designer in matrix-web
