### PR TITLE
feat(im): add unified local and email notification platform

### DIFF
--- a/.github/workflows/im-service-ci.yml
+++ b/.github/workflows/im-service-ci.yml
@@ -19,10 +19,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout quietly
-        shell: bash
-        run: |
-          ref="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
-          git clone --quiet --depth=1 --branch "$ref" "https://github.com/$GITHUB_REPOSITORY.git" .
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
       - name: Test IM module
         run: mvn -q -Dstyle.color=never -pl im-service -am test

--- a/.github/workflows/im-service-ci.yml
+++ b/.github/workflows/im-service-ci.yml
@@ -1,0 +1,28 @@
+name: IM Service CI
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - 'pom.xml'
+      - 'common/**'
+      - 'im-service/**'
+      - '.github/workflows/im-service-ci.yml'
+  pull_request:
+    paths:
+      - 'pom.xml'
+      - 'common/**'
+      - 'im-service/**'
+      - '.github/workflows/im-service-ci.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout quietly
+        shell: bash
+        run: |
+          ref="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
+          git clone --quiet --depth=1 --branch "$ref" "https://github.com/$GITHUB_REPOSITORY.git" .
+      - name: Test IM module
+        run: mvn -q -Dstyle.color=never -pl im-service -am test

--- a/docs/im/im-notification-phase1.md
+++ b/docs/im/im-notification-phase1.md
@@ -1,0 +1,171 @@
+# Matrix 统一消息推送平台：一期实现
+
+## 1. 一期目标
+
+一期将 `im-service` 定位为统一通知平台，而不是完整聊天系统。当前实现两种渠道：
+
+- `LOCAL`：站内消息落库、未读计数、消息列表、单条已读和全部已读。
+- `EMAIL`：通过 Spring Mail/SMTP 发送 HTML 邮件。
+
+Matrix 内部服务和外部业务平台均通过统一开放接口接入。每个调用方使用 `appCode + requestId` 做业务幂等。
+
+## 2. 可靠发送链路
+
+```text
+调用方
+  -> HMAC-SHA256开放接口鉴权
+  -> im_message_task / recipient / channel_task / outbox 同事务落库
+  -> Outbox定时发布RabbitMQ
+  -> 渠道消费者CAS抢占任务
+  -> LOCAL或EMAIL执行器
+  -> 渠道状态更新
+  -> 汇总消息状态
+```
+
+开放接口返回 `ACCEPTED` 仅表示平台已经可靠落库，不代表所有渠道已经成功。
+
+## 3. 状态模型
+
+消息主任务：
+
+- `ACCEPTED`
+- `PROCESSING`
+- `SUCCESS`
+- `PARTIAL_SUCCESS`
+- `FAILED`
+- `UNKNOWN`
+- `CANCELLED`
+- `EXPIRED`
+
+渠道任务：
+
+- `PENDING`
+- `PROCESSING`
+- `SUCCESS`
+- `RETRYING`
+- `DEAD`
+- `UNKNOWN`
+- `CANCELLED`
+- `EXPIRED`
+
+邮件任务进入 `PROCESSING` 后若进程异常中断，平台不会自动重复发送，而是将任务标记为 `UNKNOWN`，避免普通 SMTP 无幂等能力时重复发信。本地提醒具有数据库唯一键，可以安全重试。
+
+## 4. 开放接口鉴权
+
+请求头：
+
+```text
+X-App-Code
+X-Timestamp
+X-Nonce
+X-Signature
+```
+
+签名原文：
+
+```text
+HTTP_METHOD + "\n" +
+REQUEST_URI + "\n" +
+TIMESTAMP + "\n" +
+NONCE + "\n" +
+SHA256_HEX(REQUEST_BODY)
+```
+
+签名值：
+
+```text
+HEX(HMAC_SHA256(APP_SECRET, CANONICAL_TEXT))
+```
+
+Nonce 通过 Redis 防重放，默认签名有效窗口为 300 秒。应用密钥通过 Nacos 或环境变量配置，禁止写入仓库。
+
+## 5. API
+
+### 5.1 直接发送
+
+`POST /api/open-api/v1/messages/send`
+
+```json
+{
+  "requestId": "matrix-task-10001-1",
+  "messageType": "TASK_FAILED",
+  "title": "任务执行失败",
+  "content": "日报任务执行失败",
+  "channels": ["LOCAL", "EMAIL"],
+  "recipients": [
+    {
+      "userId": "10001",
+      "receiverName": "Micor",
+      "email": "user@example.com"
+    }
+  ],
+  "business": {
+    "type": "TASK",
+    "id": "10001",
+    "actionUrl": "/task/10001"
+  }
+}
+```
+
+### 5.2 模板发送
+
+`POST /api/open-api/v1/messages/template-send`
+
+```json
+{
+  "requestId": "matrix-task-10001-2",
+  "templateCode": "TASK_EXECUTION_FAILED",
+  "templateParams": {
+    "taskName": "每日报表",
+    "errorMessage": "数据源连接超时"
+  },
+  "recipients": [
+    {
+      "userId": "10001",
+      "email": "user@example.com"
+    }
+  ]
+}
+```
+
+### 5.3 查询发送状态
+
+`GET /api/open-api/v1/messages/{messageNo}`
+
+### 5.4 模板管理
+
+- `POST /api/im/templates`
+- `GET /api/im/templates`
+
+模板管理接口由 Matrix 网关用户鉴权保护。
+
+### 5.5 本地通知
+
+- `GET /api/im/notifications`
+- `GET /api/im/notifications/unread-count`
+- `POST /api/im/notifications/{notificationId}/read`
+- `POST /api/im/notifications/read-all`
+
+网关需要向下游传递可信的 `X-User-Id`，客户端不得自行伪造。
+
+## 6. 配置项
+
+```text
+IM_MATRIX_APP_SECRET
+RABBITMQ_HOST / RABBITMQ_PORT / RABBITMQ_USERNAME / RABBITMQ_PASSWORD
+REDIS_HOST / REDIS_PORT / REDIS_PASSWORD
+MAIL_HOST / MAIL_PORT / MAIL_USERNAME / MAIL_PASSWORD
+IM_EMAIL_FROM
+```
+
+生产环境必须替换默认应用密钥，并将 SMTP、Redis、RabbitMQ 和数据库配置放入 Nacos 或密钥管理服务。
+
+## 7. 后续迭代
+
+下一阶段按以下顺序推进：
+
+1. WebSocket 在线弹窗及客户端 ACK。
+2. 应用接入管理表、密钥轮换、IP 白名单和调用限流。
+3. 回调任务、回调重试和主动查询补偿。
+4. 用户通知偏好、免打扰时间和紧急消息策略。
+5. 管理端消息任务、失败任务和人工重放页面。

--- a/docs/sql/im-platform-phase1.sql
+++ b/docs/sql/im-platform-phase1.sql
@@ -1,0 +1,152 @@
+-- Matrix unified notification platform - phase 1
+-- MySQL 8.0+
+
+CREATE TABLE IF NOT EXISTS im_message_task (
+    id                  VARCHAR(32)  NOT NULL,
+    message_no          VARCHAR(64)  NOT NULL,
+    tenant_id           VARCHAR(64)  NOT NULL DEFAULT 'default',
+    app_code            VARCHAR(64)  NOT NULL,
+    request_id          VARCHAR(128) NOT NULL,
+    message_type        VARCHAR(64)  NOT NULL,
+    template_code       VARCHAR(64)  NULL,
+    title               VARCHAR(255) NULL,
+    content             TEXT         NULL,
+    priority            VARCHAR(16)  NOT NULL DEFAULT 'NORMAL',
+    scheduled_time      DATETIME(3)  NOT NULL,
+    expire_time         DATETIME(3)  NULL,
+    business_type       VARCHAR(64)  NULL,
+    business_id         VARCHAR(128) NULL,
+    action_url          VARCHAR(1000) NULL,
+    status              VARCHAR(32)  NOT NULL,
+    total_channels      INT          NOT NULL DEFAULT 0,
+    success_channels    INT          NOT NULL DEFAULT 0,
+    failed_channels     INT          NOT NULL DEFAULT 0,
+    callback_url        VARCHAR(1000) NULL,
+    callback_status     VARCHAR(32)   NULL,
+    created_time        DATETIME(3)  NOT NULL,
+    updated_time        DATETIME(3)  NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_im_message_no (message_no),
+    UNIQUE KEY uk_im_app_request (app_code, request_id),
+    KEY idx_im_message_status_time (status, scheduled_time),
+    KEY idx_im_message_business (business_type, business_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='统一消息主任务';
+
+CREATE TABLE IF NOT EXISTS im_message_recipient (
+    id                  VARCHAR(32)  NOT NULL,
+    message_id          VARCHAR(32)  NOT NULL,
+    receiver_type       VARCHAR(32)  NOT NULL,
+    receiver_id         VARCHAR(128) NOT NULL,
+    receiver_name       VARCHAR(128) NULL,
+    email               VARCHAR(255) NULL,
+    read_status         VARCHAR(32)  NOT NULL DEFAULT 'UNREAD',
+    read_time           DATETIME(3)  NULL,
+    created_time        DATETIME(3)  NOT NULL,
+    PRIMARY KEY (id),
+    KEY idx_im_recipient_message (message_id),
+    KEY idx_im_recipient_receiver (receiver_type, receiver_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='消息接收人';
+
+CREATE TABLE IF NOT EXISTS im_channel_task (
+    id                       VARCHAR(32)  NOT NULL,
+    message_id               VARCHAR(32)  NOT NULL,
+    recipient_id             VARCHAR(32)  NOT NULL,
+    channel_type             VARCHAR(32)  NOT NULL,
+    subject                  VARCHAR(255) NOT NULL,
+    content                  LONGTEXT     NOT NULL,
+    status                   VARCHAR(32)  NOT NULL,
+    retry_count              INT          NOT NULL DEFAULT 0,
+    max_retry_count          INT          NOT NULL DEFAULT 5,
+    next_retry_time          DATETIME(3)  NULL,
+    provider_code            VARCHAR(64)  NULL,
+    provider_message_id      VARCHAR(128) NULL,
+    last_error_code          VARCHAR(64)  NULL,
+    last_error_message       VARCHAR(1000) NULL,
+    sent_time                DATETIME(3)  NULL,
+    delivered_time           DATETIME(3)  NULL,
+    processing_started_time  DATETIME(3)  NULL,
+    created_time             DATETIME(3)  NOT NULL,
+    updated_time             DATETIME(3)  NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_im_recipient_channel (message_id, recipient_id, channel_type),
+    KEY idx_im_channel_retry (status, next_retry_time),
+    KEY idx_im_channel_processing (status, processing_started_time)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='渠道发送任务';
+
+CREATE TABLE IF NOT EXISTS im_local_notification (
+    id                  VARCHAR(32)  NOT NULL,
+    message_id          VARCHAR(32)  NOT NULL,
+    recipient_id        VARCHAR(32)  NOT NULL,
+    user_id             VARCHAR(128) NOT NULL,
+    title               VARCHAR(255) NOT NULL,
+    content             LONGTEXT     NOT NULL,
+    message_type        VARCHAR(64)  NOT NULL,
+    business_type       VARCHAR(64)  NULL,
+    business_id         VARCHAR(128) NULL,
+    action_url          VARCHAR(1000) NULL,
+    push_status         VARCHAR(32)  NOT NULL DEFAULT 'CREATED',
+    read_status         VARCHAR(32)  NOT NULL DEFAULT 'UNREAD',
+    read_time           DATETIME(3)  NULL,
+    created_time        DATETIME(3)  NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_im_local_message_user (message_id, user_id),
+    KEY idx_im_local_user_unread (user_id, read_status, created_time)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='本地站内提醒';
+
+CREATE TABLE IF NOT EXISTS im_message_template (
+    id                       VARCHAR(32)  NOT NULL,
+    template_code            VARCHAR(64)  NOT NULL,
+    template_name            VARCHAR(128) NOT NULL,
+    message_type             VARCHAR(64)  NOT NULL,
+    local_title_template     VARCHAR(255) NULL,
+    local_body_template      LONGTEXT     NULL,
+    email_subject_template   VARCHAR(255) NULL,
+    email_body_template      LONGTEXT     NULL,
+    default_channels         VARCHAR(255) NOT NULL,
+    version                  INT          NOT NULL,
+    status                   VARCHAR(32)  NOT NULL DEFAULT 'ENABLED',
+    created_time             DATETIME(3)  NOT NULL,
+    updated_time             DATETIME(3)  NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_im_template_version (template_code, version),
+    KEY idx_im_template_enabled (template_code, status, version)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='消息模板';
+
+CREATE TABLE IF NOT EXISTS im_outbox_event (
+    id                  VARCHAR(32)  NOT NULL,
+    event_id            VARCHAR(160) NOT NULL,
+    aggregate_type      VARCHAR(64)  NOT NULL,
+    aggregate_id        VARCHAR(64)  NOT NULL,
+    event_type          VARCHAR(64)  NOT NULL,
+    payload_json        JSON         NOT NULL,
+    status              VARCHAR(32)  NOT NULL,
+    retry_count         INT          NOT NULL DEFAULT 0,
+    next_retry_time     DATETIME(3)  NULL,
+    last_error          VARCHAR(1000) NULL,
+    created_time        DATETIME(3)  NOT NULL,
+    published_time      DATETIME(3)  NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_im_outbox_event (event_id),
+    KEY idx_im_outbox_due (status, next_retry_time, created_time)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='IM平台Outbox事件';
+
+INSERT INTO im_message_template (
+    id,template_code,template_name,message_type,
+    local_title_template,local_body_template,
+    email_subject_template,email_body_template,
+    default_channels,version,status,created_time,updated_time
+) VALUES (
+    REPLACE(UUID(),'-',''),
+    'TASK_EXECUTION_FAILED',
+    '任务执行失败',
+    'TASK_FAILED',
+    '任务执行失败',
+    '任务「${taskName}」执行失败，失败原因：${errorMessage}',
+    '【Matrix】任务执行失败：${taskName}',
+    '<h3>任务执行失败</h3><p>任务：${taskName}</p><p>失败原因：${errorMessage}</p>',
+    'LOCAL,EMAIL',
+    1,
+    'ENABLED',
+    NOW(3),
+    NOW(3)
+) ON DUPLICATE KEY UPDATE updated_time=VALUES(updated_time);

--- a/im-service/pom.xml
+++ b/im-service/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>single.cjj</groupId>
+        <artifactId>matrix</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>im-service</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>single.cjj</groupId>
+            <artifactId>common</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-amqp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba.cloud</groupId>
+            <artifactId>spring-cloud-starter-alibaba-nacos-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba.cloud</groupId>
+            <artifactId>spring-cloud-starter-alibaba-nacos-discovery</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/im-service/src/main/java/single/cjj/im/ImApplication.java
+++ b/im-service/src/main/java/single/cjj/im/ImApplication.java
@@ -1,0 +1,16 @@
+package single.cjj.im;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableScheduling
+@ConfigurationPropertiesScan
+@SpringBootApplication
+public class ImApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ImApplication.class, args);
+    }
+}

--- a/im-service/src/main/java/single/cjj/im/config/ChannelDeliveryConfiguration.java
+++ b/im-service/src/main/java/single/cjj/im/config/ChannelDeliveryConfiguration.java
@@ -1,0 +1,134 @@
+package single.cjj.im.config;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.MailException;
+import org.springframework.mail.MailParseException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.util.StringUtils;
+import single.cjj.im.domain.ImModels.ChannelSendResult;
+import single.cjj.im.domain.ImModels.ChannelTaskRecord;
+import single.cjj.im.domain.ImModels.ChannelType;
+import single.cjj.im.domain.ImModels.LocalNotificationRecord;
+import single.cjj.im.domain.ImModels.MessageRecord;
+import single.cjj.im.domain.ImModels.ReadStatus;
+import single.cjj.im.domain.ImModels.RecipientRecord;
+import single.cjj.im.repository.ImMessageRepository;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Configuration
+public class ChannelDeliveryConfiguration {
+
+    @Bean
+    ChannelHandler localChannelHandler(ImMessageRepository repository) {
+        return new LocalChannelHandler(repository);
+    }
+
+    @Bean
+    ChannelHandler emailChannelHandler(JavaMailSender mailSender,
+                                       @Value("${im.email.from:}") String from) {
+        return new EmailChannelHandler(mailSender, from);
+    }
+
+    public interface ChannelHandler {
+        boolean supports(String channelType);
+
+        ChannelSendResult send(MessageRecord message,
+                               RecipientRecord recipient,
+                               ChannelTaskRecord channelTask);
+    }
+}
+
+class LocalChannelHandler implements ChannelDeliveryConfiguration.ChannelHandler {
+
+    private final ImMessageRepository repository;
+
+    LocalChannelHandler(ImMessageRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public boolean supports(String channelType) {
+        return ChannelType.LOCAL.equals(channelType);
+    }
+
+    @Override
+    public ChannelSendResult send(MessageRecord message,
+                                  RecipientRecord recipient,
+                                  ChannelTaskRecord channelTask) {
+        if (!StringUtils.hasText(recipient.receiverId()) || !"USER".equals(recipient.receiverType())) {
+            return ChannelSendResult.permanentFailure("LOCAL_USER_MISSING", "本地提醒缺少 Matrix 用户ID");
+        }
+        LocalDateTime now = LocalDateTime.now();
+        repository.insertLocalNotificationIfAbsent(new LocalNotificationRecord(
+                UUID.randomUUID().toString().replace("-", ""),
+                message.id(),
+                recipient.id(),
+                recipient.receiverId(),
+                channelTask.subject(),
+                channelTask.content(),
+                message.messageType(),
+                message.businessType(),
+                message.businessId(),
+                message.actionUrl(),
+                "CREATED",
+                ReadStatus.UNREAD,
+                null,
+                now
+        ));
+        return ChannelSendResult.success("local:" + channelTask.id());
+    }
+}
+
+class EmailChannelHandler implements ChannelDeliveryConfiguration.ChannelHandler {
+
+    private final JavaMailSender mailSender;
+    private final String from;
+
+    EmailChannelHandler(JavaMailSender mailSender, String from) {
+        this.mailSender = mailSender;
+        this.from = from;
+    }
+
+    @Override
+    public boolean supports(String channelType) {
+        return ChannelType.EMAIL.equals(channelType);
+    }
+
+    @Override
+    public ChannelSendResult send(MessageRecord message,
+                                  RecipientRecord recipient,
+                                  ChannelTaskRecord channelTask) {
+        if (!StringUtils.hasText(recipient.email())) {
+            return ChannelSendResult.permanentFailure("EMAIL_MISSING", "邮件渠道缺少收件人邮箱");
+        }
+        if (!StringUtils.hasText(from)) {
+            return ChannelSendResult.permanentFailure("EMAIL_FROM_MISSING", "未配置 im.email.from");
+        }
+        try {
+            MimeMessage mimeMessage = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, false, StandardCharsets.UTF_8.name());
+            helper.setFrom(from);
+            helper.setTo(recipient.email());
+            helper.setSubject(channelTask.subject());
+            helper.setText(channelTask.content(), true);
+            mailSender.send(mimeMessage);
+            return ChannelSendResult.success("smtp:" + channelTask.id());
+        } catch (MailParseException e) {
+            return ChannelSendResult.permanentFailure("EMAIL_CONTENT_INVALID", safeMessage(e));
+        } catch (MailException | MessagingException e) {
+            return ChannelSendResult.retryable("EMAIL_SEND_FAILED", safeMessage(e));
+        }
+    }
+
+    private String safeMessage(Exception e) {
+        return StringUtils.hasText(e.getMessage()) ? e.getMessage() : e.getClass().getSimpleName();
+    }
+}

--- a/im-service/src/main/java/single/cjj/im/config/ImRabbitConfiguration.java
+++ b/im-service/src/main/java/single/cjj/im/config/ImRabbitConfiguration.java
@@ -1,0 +1,32 @@
+package single.cjj.im.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.QueueBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ImRabbitConfiguration {
+
+    public static final String EXCHANGE = "matrix.im.event";
+    public static final String CHANNEL_TASK_QUEUE = "matrix.im.channel-task.queue";
+    public static final String CHANNEL_TASK_ROUTING_KEY = "im.channel-task.dispatch";
+
+    @Bean
+    DirectExchange imEventExchange() {
+        return new DirectExchange(EXCHANGE, true, false);
+    }
+
+    @Bean
+    Queue channelTaskQueue() {
+        return QueueBuilder.durable(CHANNEL_TASK_QUEUE).build();
+    }
+
+    @Bean
+    Binding channelTaskBinding(DirectExchange imEventExchange, Queue channelTaskQueue) {
+        return BindingBuilder.bind(channelTaskQueue).to(imEventExchange).with(CHANNEL_TASK_ROUTING_KEY);
+    }
+}

--- a/im-service/src/main/java/single/cjj/im/controller/ImExceptionHandler.java
+++ b/im-service/src/main/java/single/cjj/im/controller/ImExceptionHandler.java
@@ -1,0 +1,53 @@
+package single.cjj.im.controller;
+
+import jakarta.validation.ConstraintViolationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import single.cjj.bizfi.entity.ApiResponse;
+import single.cjj.im.service.ImBusinessException;
+
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class ImExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(ImExceptionHandler.class);
+
+    @ExceptionHandler(ImBusinessException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ApiResponse<Void> handleBusiness(ImBusinessException e) {
+        return ApiResponse.error(e.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ApiResponse<Void> handleValidation(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(this::fieldErrorMessage)
+                .collect(Collectors.joining("；"));
+        return ApiResponse.error(message);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ApiResponse<Void> handleConstraint(ConstraintViolationException e) {
+        return ApiResponse.error(e.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ApiResponse<Void> handleUnexpected(Exception e) {
+        log.error("im-service unexpected error", e);
+        return ApiResponse.error(500, "消息平台处理失败");
+    }
+
+    private String fieldErrorMessage(FieldError error) {
+        return error.getField() + ": " + (error.getDefaultMessage() == null ? "参数错误" : error.getDefaultMessage());
+    }
+}

--- a/im-service/src/main/java/single/cjj/im/controller/ImMessageController.java
+++ b/im-service/src/main/java/single/cjj/im/controller/ImMessageController.java
@@ -1,0 +1,91 @@
+package single.cjj.im.controller;
+
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import single.cjj.bizfi.entity.ApiResponse;
+import single.cjj.im.domain.ImModels.AcceptedResponse;
+import single.cjj.im.domain.ImModels.LocalNotificationRecord;
+import single.cjj.im.domain.ImModels.MessageStatusResponse;
+import single.cjj.im.domain.ImModels.PagedResult;
+import single.cjj.im.domain.ImModels.SendMessageRequest;
+import single.cjj.im.domain.ImModels.TemplateRecord;
+import single.cjj.im.domain.ImModels.TemplateUpsertRequest;
+import single.cjj.im.security.OpenApiSignatureFilter;
+import single.cjj.im.service.MessageCommandService;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+public class ImMessageController {
+
+    private final MessageCommandService messageService;
+
+    public ImMessageController(MessageCommandService messageService) {
+        this.messageService = messageService;
+    }
+
+    @PostMapping("/open-api/v1/messages/send")
+    public ApiResponse<AcceptedResponse> send(
+            @RequestAttribute(OpenApiSignatureFilter.APP_CODE_ATTRIBUTE) String appCode,
+            @Valid @RequestBody SendMessageRequest request) {
+        return ApiResponse.success("消息已可靠受理", messageService.acceptDirect(appCode, request));
+    }
+
+    @PostMapping("/open-api/v1/messages/template-send")
+    public ApiResponse<AcceptedResponse> templateSend(
+            @RequestAttribute(OpenApiSignatureFilter.APP_CODE_ATTRIBUTE) String appCode,
+            @Valid @RequestBody SendMessageRequest request) {
+        return ApiResponse.success("模板消息已可靠受理", messageService.acceptTemplate(appCode, request));
+    }
+
+    @GetMapping("/open-api/v1/messages/{messageNo}")
+    public ApiResponse<MessageStatusResponse> queryStatus(
+            @RequestAttribute(OpenApiSignatureFilter.APP_CODE_ATTRIBUTE) String appCode,
+            @PathVariable("messageNo") String messageNo) {
+        return ApiResponse.success(messageService.queryStatus(appCode, messageNo));
+    }
+
+    @PostMapping("/im/templates")
+    public ApiResponse<TemplateRecord> upsertTemplate(@Valid @RequestBody TemplateUpsertRequest request) {
+        return ApiResponse.success(messageService.upsertTemplate(request));
+    }
+
+    @GetMapping("/im/templates")
+    public ApiResponse<List<TemplateRecord>> listTemplates() {
+        return ApiResponse.success(messageService.listTemplates());
+    }
+
+    @GetMapping("/im/notifications")
+    public ApiResponse<PagedResult<LocalNotificationRecord>> listNotifications(
+            @RequestHeader("X-User-Id") String userId,
+            @RequestParam(value = "readStatus", required = false) String readStatus,
+            @RequestParam(value = "page", defaultValue = "1") int page,
+            @RequestParam(value = "size", defaultValue = "20") int size) {
+        return ApiResponse.success(messageService.listNotifications(userId, readStatus, page, size));
+    }
+
+    @GetMapping("/im/notifications/unread-count")
+    public ApiResponse<Map<String, Long>> unreadCount(@RequestHeader("X-User-Id") String userId) {
+        return ApiResponse.success(Map.of("count", messageService.unreadCount(userId)));
+    }
+
+    @PostMapping("/im/notifications/{notificationId}/read")
+    public ApiResponse<Boolean> markRead(
+            @RequestHeader("X-User-Id") String userId,
+            @PathVariable("notificationId") String notificationId) {
+        return ApiResponse.success(messageService.markRead(notificationId, userId));
+    }
+
+    @PostMapping("/im/notifications/read-all")
+    public ApiResponse<Map<String, Integer>> markAllRead(@RequestHeader("X-User-Id") String userId) {
+        return ApiResponse.success(Map.of("updated", messageService.markAllRead(userId)));
+    }
+}

--- a/im-service/src/main/java/single/cjj/im/domain/ImModels.java
+++ b/im-service/src/main/java/single/cjj/im/domain/ImModels.java
@@ -1,0 +1,299 @@
+package single.cjj.im.domain;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public final class ImModels {
+
+    private ImModels() {
+    }
+
+    public static final class ChannelType {
+        public static final String LOCAL = "LOCAL";
+        public static final String EMAIL = "EMAIL";
+
+        private ChannelType() {
+        }
+    }
+
+    public static final class MessageStatus {
+        public static final String ACCEPTED = "ACCEPTED";
+        public static final String PROCESSING = "PROCESSING";
+        public static final String SUCCESS = "SUCCESS";
+        public static final String PARTIAL_SUCCESS = "PARTIAL_SUCCESS";
+        public static final String FAILED = "FAILED";
+        public static final String UNKNOWN = "UNKNOWN";
+        public static final String CANCELLED = "CANCELLED";
+        public static final String EXPIRED = "EXPIRED";
+
+        private MessageStatus() {
+        }
+    }
+
+    public static final class ChannelStatus {
+        public static final String PENDING = "PENDING";
+        public static final String PROCESSING = "PROCESSING";
+        public static final String SUCCESS = "SUCCESS";
+        public static final String FAILED = "FAILED";
+        public static final String RETRYING = "RETRYING";
+        public static final String DEAD = "DEAD";
+        public static final String UNKNOWN = "UNKNOWN";
+        public static final String CANCELLED = "CANCELLED";
+        public static final String EXPIRED = "EXPIRED";
+
+        private ChannelStatus() {
+        }
+    }
+
+    public static final class OutboxStatus {
+        public static final String PENDING = "PENDING";
+        public static final String PROCESSING = "PROCESSING";
+        public static final String PUBLISHED = "PUBLISHED";
+        public static final String RETRYING = "RETRYING";
+        public static final String DEAD = "DEAD";
+
+        private OutboxStatus() {
+        }
+    }
+
+    public static final class ReadStatus {
+        public static final String UNREAD = "UNREAD";
+        public static final String READ = "READ";
+
+        private ReadStatus() {
+        }
+    }
+
+    public record SendMessageRequest(
+            @NotBlank @Size(max = 128) String requestId,
+            @Size(max = 64) String messageType,
+            @Size(max = 64) String templateCode,
+            @Size(max = 255) String title,
+            String content,
+            Set<String> channels,
+            Map<String, Object> templateParams,
+            @NotEmpty List<@Valid RecipientRequest> recipients,
+            @Valid BusinessRef business,
+            LocalDateTime scheduledTime,
+            LocalDateTime expireTime,
+            @Size(max = 1000) String callbackUrl,
+            @Size(max = 64) String tenantId,
+            @Size(max = 16) String priority
+    ) {
+    }
+
+    public record RecipientRequest(
+            @Size(max = 128) String userId,
+            @Size(max = 128) String receiverName,
+            @Email @Size(max = 255) String email
+    ) {
+    }
+
+    public record BusinessRef(
+            @Size(max = 64) String type,
+            @Size(max = 128) String id,
+            @Size(max = 1000) String actionUrl
+    ) {
+    }
+
+    public record AcceptedResponse(
+            String messageNo,
+            String requestId,
+            String status,
+            boolean idempotentReplay
+    ) {
+    }
+
+    public record MessageStatusResponse(
+            String messageNo,
+            String requestId,
+            String status,
+            int totalChannels,
+            int successChannels,
+            int failedChannels,
+            List<ChannelStatusResponse> channels,
+            LocalDateTime createdTime,
+            LocalDateTime updatedTime
+    ) {
+    }
+
+    public record ChannelStatusResponse(
+            String channelTaskId,
+            String recipientId,
+            String channel,
+            String status,
+            int retryCount,
+            String providerMessageId,
+            String errorCode,
+            String errorMessage,
+            LocalDateTime sentTime,
+            LocalDateTime deliveredTime
+    ) {
+    }
+
+    public record TemplateUpsertRequest(
+            @NotBlank @Size(max = 64) String templateCode,
+            @NotBlank @Size(max = 128) String templateName,
+            @NotBlank @Size(max = 64) String messageType,
+            String localTitleTemplate,
+            String localBodyTemplate,
+            String emailSubjectTemplate,
+            String emailBodyTemplate,
+            @NotEmpty Set<String> defaultChannels,
+            @NotNull @Positive Integer version,
+            String status
+    ) {
+    }
+
+    public record MessageRecord(
+            String id,
+            String messageNo,
+            String tenantId,
+            String appCode,
+            String requestId,
+            String messageType,
+            String templateCode,
+            String title,
+            String content,
+            String priority,
+            LocalDateTime scheduledTime,
+            LocalDateTime expireTime,
+            String businessType,
+            String businessId,
+            String actionUrl,
+            String status,
+            int totalChannels,
+            int successChannels,
+            int failedChannels,
+            String callbackUrl,
+            String callbackStatus,
+            LocalDateTime createdTime,
+            LocalDateTime updatedTime
+    ) {
+    }
+
+    public record RecipientRecord(
+            String id,
+            String messageId,
+            String receiverType,
+            String receiverId,
+            String receiverName,
+            String email,
+            String readStatus,
+            LocalDateTime readTime,
+            LocalDateTime createdTime
+    ) {
+    }
+
+    public record ChannelTaskRecord(
+            String id,
+            String messageId,
+            String recipientId,
+            String channelType,
+            String subject,
+            String content,
+            String status,
+            int retryCount,
+            int maxRetryCount,
+            LocalDateTime nextRetryTime,
+            String providerCode,
+            String providerMessageId,
+            String lastErrorCode,
+            String lastErrorMessage,
+            LocalDateTime sentTime,
+            LocalDateTime deliveredTime,
+            LocalDateTime processingStartedTime,
+            LocalDateTime createdTime,
+            LocalDateTime updatedTime
+    ) {
+    }
+
+    public record OutboxRecord(
+            String id,
+            String eventId,
+            String aggregateType,
+            String aggregateId,
+            String eventType,
+            String payloadJson,
+            String status,
+            int retryCount,
+            LocalDateTime nextRetryTime,
+            String lastError,
+            LocalDateTime createdTime,
+            LocalDateTime publishedTime
+    ) {
+    }
+
+    public record TemplateRecord(
+            String id,
+            String templateCode,
+            String templateName,
+            String messageType,
+            String localTitleTemplate,
+            String localBodyTemplate,
+            String emailSubjectTemplate,
+            String emailBodyTemplate,
+            String defaultChannels,
+            int version,
+            String status,
+            LocalDateTime createdTime,
+            LocalDateTime updatedTime
+    ) {
+    }
+
+    public record LocalNotificationRecord(
+            String id,
+            String messageId,
+            String recipientId,
+            String userId,
+            String title,
+            String content,
+            String messageType,
+            String businessType,
+            String businessId,
+            String actionUrl,
+            String pushStatus,
+            String readStatus,
+            LocalDateTime readTime,
+            LocalDateTime createdTime
+    ) {
+    }
+
+    public record PagedResult<T>(
+            long total,
+            int page,
+            int size,
+            List<T> records
+    ) {
+    }
+
+    public record ChannelSendResult(
+            boolean success,
+            boolean retryable,
+            String providerMessageId,
+            String errorCode,
+            String errorMessage
+    ) {
+        public static ChannelSendResult success(String providerMessageId) {
+            return new ChannelSendResult(true, false, providerMessageId, null, null);
+        }
+
+        public static ChannelSendResult retryable(String errorCode, String errorMessage) {
+            return new ChannelSendResult(false, true, null, errorCode, errorMessage);
+        }
+
+        public static ChannelSendResult permanentFailure(String errorCode, String errorMessage) {
+            return new ChannelSendResult(false, false, null, errorCode, errorMessage);
+        }
+    }
+}

--- a/im-service/src/main/java/single/cjj/im/repository/ImMessageRepository.java
+++ b/im-service/src/main/java/single/cjj/im/repository/ImMessageRepository.java
@@ -1,0 +1,428 @@
+package single.cjj.im.repository;
+
+import org.springframework.jdbc.core.DataClassRowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+import single.cjj.im.domain.ImModels.ChannelStatusResponse;
+import single.cjj.im.domain.ImModels.ChannelTaskRecord;
+import single.cjj.im.domain.ImModels.LocalNotificationRecord;
+import single.cjj.im.domain.ImModels.MessageRecord;
+import single.cjj.im.domain.ImModels.OutboxRecord;
+import single.cjj.im.domain.ImModels.RecipientRecord;
+import single.cjj.im.domain.ImModels.TemplateRecord;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Repository
+public class ImMessageRepository {
+
+    private final NamedParameterJdbcTemplate jdbc;
+
+    public ImMessageRepository(NamedParameterJdbcTemplate jdbc) {
+        this.jdbc = jdbc;
+    }
+
+    public Optional<MessageRecord> findMessageByAppRequest(String appCode, String requestId) {
+        String sql = "SELECT * FROM im_message_task WHERE app_code=:appCode AND request_id=:requestId LIMIT 1";
+        return queryOne(sql, Map.of("appCode", appCode, "requestId", requestId), MessageRecord.class);
+    }
+
+    public Optional<MessageRecord> findMessageByNo(String messageNo) {
+        String sql = "SELECT * FROM im_message_task WHERE message_no=:messageNo LIMIT 1";
+        return queryOne(sql, Map.of("messageNo", messageNo), MessageRecord.class);
+    }
+
+    public Optional<MessageRecord> findMessageById(String id) {
+        return queryOne("SELECT * FROM im_message_task WHERE id=:id LIMIT 1", Map.of("id", id), MessageRecord.class);
+    }
+
+    public void insertMessage(MessageRecord record) {
+        String sql = """
+                INSERT INTO im_message_task (
+                    id,message_no,tenant_id,app_code,request_id,message_type,template_code,title,content,
+                    priority,scheduled_time,expire_time,business_type,business_id,action_url,status,
+                    total_channels,success_channels,failed_channels,callback_url,callback_status,
+                    created_time,updated_time
+                ) VALUES (
+                    :id,:messageNo,:tenantId,:appCode,:requestId,:messageType,:templateCode,:title,:content,
+                    :priority,:scheduledTime,:expireTime,:businessType,:businessId,:actionUrl,:status,
+                    :totalChannels,:successChannels,:failedChannels,:callbackUrl,:callbackStatus,
+                    :createdTime,:updatedTime
+                )
+                """;
+        jdbc.update(sql, beanParams(record));
+    }
+
+    public void insertRecipient(RecipientRecord record) {
+        String sql = """
+                INSERT INTO im_message_recipient (
+                    id,message_id,receiver_type,receiver_id,receiver_name,email,read_status,read_time,created_time
+                ) VALUES (
+                    :id,:messageId,:receiverType,:receiverId,:receiverName,:email,:readStatus,:readTime,:createdTime
+                )
+                """;
+        jdbc.update(sql, beanParams(record));
+    }
+
+    public void insertChannelTask(ChannelTaskRecord record) {
+        String sql = """
+                INSERT INTO im_channel_task (
+                    id,message_id,recipient_id,channel_type,subject,content,status,retry_count,max_retry_count,
+                    next_retry_time,provider_code,provider_message_id,last_error_code,last_error_message,
+                    sent_time,delivered_time,processing_started_time,created_time,updated_time
+                ) VALUES (
+                    :id,:messageId,:recipientId,:channelType,:subject,:content,:status,:retryCount,:maxRetryCount,
+                    :nextRetryTime,:providerCode,:providerMessageId,:lastErrorCode,:lastErrorMessage,
+                    :sentTime,:deliveredTime,:processingStartedTime,:createdTime,:updatedTime
+                )
+                """;
+        jdbc.update(sql, beanParams(record));
+    }
+
+    public void insertOutbox(OutboxRecord record) {
+        String sql = """
+                INSERT INTO im_outbox_event (
+                    id,event_id,aggregate_type,aggregate_id,event_type,payload_json,status,retry_count,
+                    next_retry_time,last_error,created_time,published_time
+                ) VALUES (
+                    :id,:eventId,:aggregateType,:aggregateId,:eventType,:payloadJson,:status,:retryCount,
+                    :nextRetryTime,:lastError,:createdTime,:publishedTime
+                )
+                """;
+        jdbc.update(sql, beanParams(record));
+    }
+
+    public Optional<RecipientRecord> findRecipient(String id) {
+        return queryOne("SELECT * FROM im_message_recipient WHERE id=:id LIMIT 1", Map.of("id", id), RecipientRecord.class);
+    }
+
+    public Optional<ChannelTaskRecord> findChannelTask(String id) {
+        return queryOne("SELECT * FROM im_channel_task WHERE id=:id LIMIT 1", Map.of("id", id), ChannelTaskRecord.class);
+    }
+
+    public List<ChannelStatusResponse> findChannelStatusResponses(String messageId) {
+        String sql = """
+                SELECT c.id AS channel_task_id,
+                       r.receiver_id AS recipient_id,
+                       c.channel_type AS channel,
+                       c.status,
+                       c.retry_count,
+                       c.provider_message_id,
+                       c.last_error_code AS error_code,
+                       c.last_error_message AS error_message,
+                       c.sent_time,
+                       c.delivered_time
+                FROM im_channel_task c
+                JOIN im_message_recipient r ON r.id=c.recipient_id
+                WHERE c.message_id=:messageId
+                ORDER BY c.created_time,c.id
+                """;
+        return jdbc.query(sql, Map.of("messageId", messageId), DataClassRowMapper.newInstance(ChannelStatusResponse.class));
+    }
+
+    public List<String> findChannelStatuses(String messageId) {
+        return jdbc.queryForList(
+                "SELECT status FROM im_channel_task WHERE message_id=:messageId",
+                Map.of("messageId", messageId),
+                String.class
+        );
+    }
+
+    public int claimChannelTask(String id, LocalDateTime now) {
+        String sql = """
+                UPDATE im_channel_task
+                SET status='PROCESSING',processing_started_time=:now,updated_time=:now
+                WHERE id=:id AND status IN ('PENDING','RETRYING')
+                  AND (next_retry_time IS NULL OR next_retry_time<=:now)
+                """;
+        return jdbc.update(sql, Map.of("id", id, "now", now));
+    }
+
+    public void markChannelSuccess(String id, String providerMessageId, LocalDateTime now) {
+        String sql = """
+                UPDATE im_channel_task
+                SET status='SUCCESS',provider_message_id=:providerMessageId,sent_time=:now,
+                    delivered_time=NULL,last_error_code=NULL,last_error_message=NULL,updated_time=:now
+                WHERE id=:id
+                """;
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("id", id)
+                .addValue("providerMessageId", providerMessageId)
+                .addValue("now", now);
+        jdbc.update(sql, params);
+    }
+
+    public void markChannelRetry(String id,
+                                 int retryCount,
+                                 LocalDateTime nextRetryTime,
+                                 String errorCode,
+                                 String errorMessage,
+                                 LocalDateTime now) {
+        String sql = """
+                UPDATE im_channel_task
+                SET status='RETRYING',retry_count=:retryCount,next_retry_time=:nextRetryTime,
+                    last_error_code=:errorCode,last_error_message=:errorMessage,updated_time=:now
+                WHERE id=:id
+                """;
+        jdbc.update(sql, new MapSqlParameterSource()
+                .addValue("id", id)
+                .addValue("retryCount", retryCount)
+                .addValue("nextRetryTime", nextRetryTime)
+                .addValue("errorCode", errorCode)
+                .addValue("errorMessage", truncate(errorMessage, 1000))
+                .addValue("now", now));
+    }
+
+    public void markChannelDead(String id,
+                                int retryCount,
+                                String errorCode,
+                                String errorMessage,
+                                LocalDateTime now) {
+        String sql = """
+                UPDATE im_channel_task
+                SET status='DEAD',retry_count=:retryCount,last_error_code=:errorCode,
+                    last_error_message=:errorMessage,updated_time=:now
+                WHERE id=:id
+                """;
+        jdbc.update(sql, new MapSqlParameterSource()
+                .addValue("id", id)
+                .addValue("retryCount", retryCount)
+                .addValue("errorCode", errorCode)
+                .addValue("errorMessage", truncate(errorMessage, 1000))
+                .addValue("now", now));
+    }
+
+    public void markChannelExpired(String id, LocalDateTime now) {
+        jdbc.update(
+                "UPDATE im_channel_task SET status='EXPIRED',updated_time=:now WHERE id=:id",
+                Map.of("id", id, "now", now)
+        );
+    }
+
+    public List<ChannelTaskRecord> findStaleChannelTasks(String channelType, LocalDateTime deadline, int limit) {
+        String sql = """
+                SELECT * FROM im_channel_task
+                WHERE channel_type=:channelType AND status='PROCESSING' AND processing_started_time<:deadline
+                ORDER BY processing_started_time,id
+                LIMIT :limit
+                """;
+        return jdbc.query(sql, Map.of("channelType", channelType, "deadline", deadline, "limit", limit),
+                DataClassRowMapper.newInstance(ChannelTaskRecord.class));
+    }
+
+    public int recoverStaleLocalTask(String id, int retryCount, LocalDateTime nextRetryTime, LocalDateTime now) {
+        String sql = """
+                UPDATE im_channel_task
+                SET status='RETRYING',retry_count=:retryCount,next_retry_time=:nextRetryTime,last_error_code='PROCESSING_TIMEOUT',
+                    last_error_message='本地提醒执行超时，已进入安全重试',updated_time=:now
+                WHERE id=:id AND channel_type='LOCAL' AND status='PROCESSING'
+                """;
+        return jdbc.update(sql, Map.of("id", id, "retryCount", retryCount, "nextRetryTime", nextRetryTime, "now", now));
+    }
+
+    public int markStaleEmailTaskUnknown(String id, LocalDateTime now) {
+        String sql = """
+                UPDATE im_channel_task
+                SET status='UNKNOWN',last_error_code='DELIVERY_RESULT_UNKNOWN',
+                    last_error_message='邮件发送过程异常中断，发送结果不确定，请人工核对',updated_time=:now
+                WHERE id=:id AND channel_type='EMAIL' AND status='PROCESSING'
+                """;
+        return jdbc.update(sql, Map.of("id", id, "now", now));
+    }
+
+    public void updateMessageAggregate(String messageId,
+                                       String status,
+                                       int successChannels,
+                                       int failedChannels,
+                                       LocalDateTime now) {
+        String sql = """
+                UPDATE im_message_task
+                SET status=:status,success_channels=:successChannels,failed_channels=:failedChannels,updated_time=:now
+                WHERE id=:messageId
+                """;
+        jdbc.update(sql, Map.of(
+                "messageId", messageId,
+                "status", status,
+                "successChannels", successChannels,
+                "failedChannels", failedChannels,
+                "now", now
+        ));
+    }
+
+    public List<OutboxRecord> findDueOutbox(LocalDateTime now, int limit) {
+        String sql = """
+                SELECT * FROM im_outbox_event
+                WHERE status IN ('PENDING','RETRYING')
+                  AND (next_retry_time IS NULL OR next_retry_time<=:now)
+                ORDER BY created_time,id
+                LIMIT :limit
+                """;
+        return jdbc.query(sql, Map.of("now", now, "limit", limit), DataClassRowMapper.newInstance(OutboxRecord.class));
+    }
+
+    public int claimOutbox(String id) {
+        String sql = """
+                UPDATE im_outbox_event
+                SET status='PROCESSING'
+                WHERE id=:id AND status IN ('PENDING','RETRYING')
+                """;
+        return jdbc.update(sql, Map.of("id", id));
+    }
+
+    public void markOutboxPublished(String id, LocalDateTime now) {
+        jdbc.update(
+                "UPDATE im_outbox_event SET status='PUBLISHED',published_time=:now,last_error=NULL WHERE id=:id",
+                Map.of("id", id, "now", now)
+        );
+    }
+
+    public void markOutboxRetry(String id, int retryCount, LocalDateTime nextRetryTime, String error) {
+        String sql = """
+                UPDATE im_outbox_event
+                SET status='RETRYING',retry_count=:retryCount,next_retry_time=:nextRetryTime,last_error=:error
+                WHERE id=:id
+                """;
+        jdbc.update(sql, new MapSqlParameterSource()
+                .addValue("id", id)
+                .addValue("retryCount", retryCount)
+                .addValue("nextRetryTime", nextRetryTime)
+                .addValue("error", truncate(error, 1000)));
+    }
+
+    public void markOutboxDead(String id, int retryCount, String error) {
+        String sql = """
+                UPDATE im_outbox_event
+                SET status='DEAD',retry_count=:retryCount,last_error=:error
+                WHERE id=:id
+                """;
+        jdbc.update(sql, new MapSqlParameterSource()
+                .addValue("id", id)
+                .addValue("retryCount", retryCount)
+                .addValue("error", truncate(error, 1000)));
+    }
+
+    public int insertLocalNotificationIfAbsent(LocalNotificationRecord record) {
+        String sql = """
+                INSERT IGNORE INTO im_local_notification (
+                    id,message_id,recipient_id,user_id,title,content,message_type,business_type,business_id,
+                    action_url,push_status,read_status,read_time,created_time
+                ) VALUES (
+                    :id,:messageId,:recipientId,:userId,:title,:content,:messageType,:businessType,:businessId,
+                    :actionUrl,:pushStatus,:readStatus,:readTime,:createdTime
+                )
+                """;
+        return jdbc.update(sql, beanParams(record));
+    }
+
+    public long countLocalNotifications(String userId, String readStatus) {
+        String sql = "SELECT COUNT(*) FROM im_local_notification WHERE user_id=:userId"
+                + (readStatus == null ? "" : " AND read_status=:readStatus");
+        MapSqlParameterSource params = new MapSqlParameterSource().addValue("userId", userId);
+        if (readStatus != null) {
+            params.addValue("readStatus", readStatus);
+        }
+        Long value = jdbc.queryForObject(sql, params, Long.class);
+        return value == null ? 0L : value;
+    }
+
+    public List<LocalNotificationRecord> listLocalNotifications(String userId,
+                                                                 String readStatus,
+                                                                 int offset,
+                                                                 int size) {
+        String sql = "SELECT * FROM im_local_notification WHERE user_id=:userId"
+                + (readStatus == null ? "" : " AND read_status=:readStatus")
+                + " ORDER BY created_time DESC,id DESC LIMIT :size OFFSET :offset";
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("userId", userId)
+                .addValue("size", size)
+                .addValue("offset", offset);
+        if (readStatus != null) {
+            params.addValue("readStatus", readStatus);
+        }
+        return jdbc.query(sql, params, DataClassRowMapper.newInstance(LocalNotificationRecord.class));
+    }
+
+    public int markNotificationRead(String notificationId, String userId, LocalDateTime now) {
+        String sql = """
+                UPDATE im_local_notification
+                SET read_status='READ',read_time=:now
+                WHERE id=:notificationId AND user_id=:userId AND read_status='UNREAD'
+                """;
+        return jdbc.update(sql, Map.of("notificationId", notificationId, "userId", userId, "now", now));
+    }
+
+    public int markAllNotificationsRead(String userId, LocalDateTime now) {
+        String sql = """
+                UPDATE im_local_notification
+                SET read_status='READ',read_time=:now
+                WHERE user_id=:userId AND read_status='UNREAD'
+                """;
+        return jdbc.update(sql, Map.of("userId", userId, "now", now));
+    }
+
+    public Optional<TemplateRecord> findLatestEnabledTemplate(String templateCode) {
+        String sql = """
+                SELECT * FROM im_message_template
+                WHERE template_code=:templateCode AND status='ENABLED'
+                ORDER BY version DESC LIMIT 1
+                """;
+        return queryOne(sql, Map.of("templateCode", templateCode), TemplateRecord.class);
+    }
+
+    public void upsertTemplate(TemplateRecord record) {
+        String sql = """
+                INSERT INTO im_message_template (
+                    id,template_code,template_name,message_type,local_title_template,local_body_template,
+                    email_subject_template,email_body_template,default_channels,version,status,created_time,updated_time
+                ) VALUES (
+                    :id,:templateCode,:templateName,:messageType,:localTitleTemplate,:localBodyTemplate,
+                    :emailSubjectTemplate,:emailBodyTemplate,:defaultChannels,:version,:status,:createdTime,:updatedTime
+                )
+                ON DUPLICATE KEY UPDATE
+                    template_name=VALUES(template_name),message_type=VALUES(message_type),
+                    local_title_template=VALUES(local_title_template),local_body_template=VALUES(local_body_template),
+                    email_subject_template=VALUES(email_subject_template),email_body_template=VALUES(email_body_template),
+                    default_channels=VALUES(default_channels),status=VALUES(status),updated_time=VALUES(updated_time)
+                """;
+        jdbc.update(sql, beanParams(record));
+    }
+
+    public List<TemplateRecord> listTemplates() {
+        return jdbc.query(
+                "SELECT * FROM im_message_template ORDER BY template_code,version DESC",
+                Map.of(),
+                DataClassRowMapper.newInstance(TemplateRecord.class)
+        );
+    }
+
+    private <T> Optional<T> queryOne(String sql, Map<String, ?> params, Class<T> type) {
+        List<T> values = jdbc.query(sql, params, DataClassRowMapper.newInstance(type));
+        return values.stream().findFirst();
+    }
+
+    private MapSqlParameterSource beanParams(Object bean) {
+        if (bean == null || !bean.getClass().isRecord()) {
+            throw new IllegalArgumentException("Only Java records are supported as SQL parameter beans");
+        }
+        MapSqlParameterSource source = new MapSqlParameterSource();
+        try {
+            for (java.lang.reflect.RecordComponent component : bean.getClass().getRecordComponents()) {
+                source.addValue(component.getName(), component.getAccessor().invoke(bean));
+            }
+            return source;
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to read SQL parameter record", e);
+        }
+    }
+
+    private String truncate(String value, int maxLength) {
+        if (value == null || value.length() <= maxLength) {
+            return value;
+        }
+        return value.substring(0, maxLength);
+    }
+}

--- a/im-service/src/main/java/single/cjj/im/security/OpenApiSignatureFilter.java
+++ b/im-service/src/main/java/single/cjj/im/security/OpenApiSignatureFilter.java
@@ -1,0 +1,213 @@
+package single.cjj.im.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StreamUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.HexFormat;
+import java.util.Map;
+
+@Component
+public class OpenApiSignatureFilter extends OncePerRequestFilter {
+
+    public static final String APP_CODE_ATTRIBUTE = "im.openApi.appCode";
+
+    private final OpenApiProperties properties;
+    private final StringRedisTemplate redisTemplate;
+
+    public OpenApiSignatureFilter(OpenApiProperties properties, StringRedisTemplate redisTemplate) {
+        this.properties = properties;
+        this.redisTemplate = redisTemplate;
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return !request.getServletPath().startsWith("/open-api/");
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        CachedBodyRequest wrappedRequest = new CachedBodyRequest(request);
+        String appCode;
+        try {
+            appCode = requiredHeader(request, "X-App-Code");
+            String timestampText = requiredHeader(request, "X-Timestamp");
+            String nonce = requiredHeader(request, "X-Nonce");
+            String signature = requiredHeader(request, "X-Signature");
+
+            String secret = properties.getCredentials().get(appCode);
+            if (!StringUtils.hasText(secret)) {
+                throw new SignatureException("未知或未启用的调用应用");
+            }
+
+            long timestamp = Long.parseLong(timestampText);
+            long now = System.currentTimeMillis();
+            long allowedMillis = properties.getSignatureWindowSeconds() * 1000L;
+            if (Math.abs(now - timestamp) > allowedMillis) {
+                throw new SignatureException("请求时间戳已过期");
+            }
+
+            String nonceKey = "im:open-api:nonce:" + appCode + ":" + nonce;
+            Boolean accepted = redisTemplate.opsForValue().setIfAbsent(
+                    nonceKey,
+                    "1",
+                    Duration.ofSeconds(properties.getSignatureWindowSeconds())
+            );
+            if (!Boolean.TRUE.equals(accepted)) {
+                throw new SignatureException("检测到重复请求");
+            }
+
+            String bodyHash = sha256Hex(wrappedRequest.getCachedBody());
+            String canonical = request.getMethod() + "\n"
+                    + request.getRequestURI() + "\n"
+                    + timestampText + "\n"
+                    + nonce + "\n"
+                    + bodyHash;
+            String expected = hmacSha256Hex(secret, canonical);
+            if (!MessageDigest.isEqual(
+                    expected.getBytes(StandardCharsets.UTF_8),
+                    signature.toLowerCase().getBytes(StandardCharsets.UTF_8))) {
+                redisTemplate.delete(nonceKey);
+                throw new SignatureException("签名校验失败");
+            }
+        } catch (NumberFormatException e) {
+            writeUnauthorized(response, "时间戳格式错误");
+            return;
+        } catch (SignatureException e) {
+            writeUnauthorized(response, e.getMessage());
+            return;
+        } catch (Exception e) {
+            writeUnauthorized(response, "开放接口鉴权失败");
+            return;
+        }
+
+        wrappedRequest.setAttribute(APP_CODE_ATTRIBUTE, appCode);
+        filterChain.doFilter(wrappedRequest, response);
+    }
+
+    private String requiredHeader(HttpServletRequest request, String name) {
+        String value = request.getHeader(name);
+        if (!StringUtils.hasText(value)) {
+            throw new SignatureException("缺少请求头 " + name);
+        }
+        return value.trim();
+    }
+
+    private String sha256Hex(byte[] bytes) throws Exception {
+        return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(bytes));
+    }
+
+    private String hmacSha256Hex(String secret, String content) throws Exception {
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+        return HexFormat.of().formatHex(mac.doFinal(content.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    private void writeUnauthorized(HttpServletResponse response, String message) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.getWriter().write("{\"code\":401,\"message\":\"" + escapeJson(message) + "\",\"data\":null}");
+    }
+
+    private String escapeJson(String value) {
+        return value == null ? "鉴权失败" : value.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
+    private static class SignatureException extends RuntimeException {
+        SignatureException(String message) {
+            super(message);
+        }
+    }
+}
+
+@ConfigurationProperties(prefix = "im.open-api")
+class OpenApiProperties {
+
+    private int signatureWindowSeconds = 300;
+    private Map<String, String> credentials = new HashMap<>();
+
+    public int getSignatureWindowSeconds() {
+        return signatureWindowSeconds;
+    }
+
+    public void setSignatureWindowSeconds(int signatureWindowSeconds) {
+        this.signatureWindowSeconds = signatureWindowSeconds;
+    }
+
+    public Map<String, String> getCredentials() {
+        return credentials;
+    }
+
+    public void setCredentials(Map<String, String> credentials) {
+        this.credentials = credentials == null ? new HashMap<>() : credentials;
+    }
+}
+
+class CachedBodyRequest extends HttpServletRequestWrapper {
+
+    private final byte[] cachedBody;
+
+    CachedBodyRequest(HttpServletRequest request) throws IOException {
+        super(request);
+        this.cachedBody = StreamUtils.copyToByteArray(request.getInputStream());
+    }
+
+    byte[] getCachedBody() {
+        return cachedBody.clone();
+    }
+
+    @Override
+    public ServletInputStream getInputStream() {
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(cachedBody);
+        return new ServletInputStream() {
+            @Override
+            public boolean isFinished() {
+                return inputStream.available() == 0;
+            }
+
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public void setReadListener(ReadListener readListener) {
+                // Synchronous request body wrapper; async callbacks are not required.
+            }
+
+            @Override
+            public int read() {
+                return inputStream.read();
+            }
+        };
+    }
+
+    @Override
+    public BufferedReader getReader() {
+        return new BufferedReader(new InputStreamReader(getInputStream(), StandardCharsets.UTF_8));
+    }
+}

--- a/im-service/src/main/java/single/cjj/im/service/ChannelDispatchService.java
+++ b/im-service/src/main/java/single/cjj/im/service/ChannelDispatchService.java
@@ -1,0 +1,224 @@
+package single.cjj.im.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionTemplate;
+import single.cjj.im.config.ChannelDeliveryConfiguration.ChannelHandler;
+import single.cjj.im.domain.ImModels.ChannelSendResult;
+import single.cjj.im.domain.ImModels.ChannelStatus;
+import single.cjj.im.domain.ImModels.ChannelTaskRecord;
+import single.cjj.im.domain.ImModels.MessageRecord;
+import single.cjj.im.domain.ImModels.MessageStatus;
+import single.cjj.im.domain.ImModels.OutboxRecord;
+import single.cjj.im.domain.ImModels.OutboxStatus;
+import single.cjj.im.domain.ImModels.RecipientRecord;
+import single.cjj.im.repository.ImMessageRepository;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+public class ChannelDispatchService {
+
+    private static final Set<String> FINAL_CHANNEL_STATUSES = Set.of(
+            ChannelStatus.SUCCESS,
+            ChannelStatus.DEAD,
+            ChannelStatus.UNKNOWN,
+            ChannelStatus.CANCELLED,
+            ChannelStatus.EXPIRED
+    );
+
+    private final ImMessageRepository repository;
+    private final Map<String, ChannelHandler> handlers;
+    private final ObjectMapper objectMapper;
+    private final TransactionTemplate transactionTemplate;
+
+    public ChannelDispatchService(ImMessageRepository repository,
+                                  List<ChannelHandler> handlers,
+                                  ObjectMapper objectMapper,
+                                  TransactionTemplate transactionTemplate) {
+        this.repository = repository;
+        Map<String, ChannelHandler> handlerMap = new HashMap<>();
+        for (ChannelHandler handler : handlers) {
+            if (handler.supports("LOCAL")) {
+                handlerMap.put("LOCAL", handler);
+            }
+            if (handler.supports("EMAIL")) {
+                handlerMap.put("EMAIL", handler);
+            }
+        }
+        this.handlers = Map.copyOf(handlerMap);
+        this.objectMapper = objectMapper;
+        this.transactionTemplate = transactionTemplate;
+    }
+
+    public void dispatch(String channelTaskId) {
+        ChannelTaskRecord initialTask = repository.findChannelTask(channelTaskId)
+                .orElseThrow(() -> new ImBusinessException("渠道任务不存在: " + channelTaskId));
+        if (FINAL_CHANNEL_STATUSES.contains(initialTask.status())) {
+            return;
+        }
+
+        MessageRecord message = repository.findMessageById(initialTask.messageId())
+                .orElseThrow(() -> new ImBusinessException("消息主任务不存在"));
+        LocalDateTime now = LocalDateTime.now();
+        if (message.expireTime() != null && !message.expireTime().isAfter(now)) {
+            repository.markChannelExpired(channelTaskId, now);
+            refreshMessageStatus(message.id());
+            return;
+        }
+
+        if (repository.claimChannelTask(channelTaskId, now) == 0) {
+            return;
+        }
+
+        ChannelTaskRecord claimedTask = repository.findChannelTask(channelTaskId).orElse(initialTask);
+        RecipientRecord recipient = repository.findRecipient(claimedTask.recipientId())
+                .orElseThrow(() -> new ImBusinessException("消息接收人不存在"));
+        ChannelHandler handler = handlers.get(claimedTask.channelType());
+        if (handler == null) {
+            repository.markChannelDead(channelTaskId, claimedTask.retryCount(),
+                    "CHANNEL_NOT_SUPPORTED", "未注册渠道处理器: " + claimedTask.channelType(), now);
+            refreshMessageStatus(message.id());
+            return;
+        }
+
+        ChannelSendResult dispatchResult;
+        try {
+            dispatchResult = handler.send(message, recipient, claimedTask);
+        } catch (Exception e) {
+            dispatchResult = ChannelSendResult.retryable("CHANNEL_HANDLER_ERROR", safeMessage(e));
+        }
+        final ChannelSendResult result = dispatchResult;
+
+        if (result.success()) {
+            repository.markChannelSuccess(channelTaskId, result.providerMessageId(), LocalDateTime.now());
+            refreshMessageStatus(message.id());
+            return;
+        }
+
+        int nextRetryCount = claimedTask.retryCount() + 1;
+        if (result.retryable() && nextRetryCount < claimedTask.maxRetryCount()) {
+            LocalDateTime nextRetryTime = RetryBackoffPolicy.nextRetryTime(nextRetryCount, LocalDateTime.now());
+            transactionTemplate.executeWithoutResult(status -> {
+                repository.markChannelRetry(
+                        channelTaskId,
+                        nextRetryCount,
+                        nextRetryTime,
+                        result.errorCode(),
+                        result.errorMessage(),
+                        LocalDateTime.now()
+                );
+                repository.insertOutbox(retryOutbox(channelTaskId, nextRetryCount, nextRetryTime));
+            });
+        } else {
+            repository.markChannelDead(
+                    channelTaskId,
+                    nextRetryCount,
+                    result.errorCode(),
+                    result.errorMessage(),
+                    LocalDateTime.now()
+            );
+        }
+        refreshMessageStatus(message.id());
+    }
+
+    public void refreshMessageStatus(String messageId) {
+        List<String> statuses = repository.findChannelStatuses(messageId);
+        if (statuses.isEmpty()) {
+            return;
+        }
+        int success = count(statuses, ChannelStatus.SUCCESS);
+        int unknown = count(statuses, ChannelStatus.UNKNOWN);
+        int failed = countAny(statuses, Set.of(
+                ChannelStatus.FAILED,
+                ChannelStatus.DEAD,
+                ChannelStatus.EXPIRED,
+                ChannelStatus.CANCELLED
+        ));
+        int active = countAny(statuses, Set.of(
+                ChannelStatus.PENDING,
+                ChannelStatus.PROCESSING,
+                ChannelStatus.RETRYING
+        ));
+
+        String aggregateStatus;
+        if (active > 0) {
+            aggregateStatus = MessageStatus.PROCESSING;
+        } else if (unknown > 0) {
+            aggregateStatus = MessageStatus.UNKNOWN;
+        } else if (success == statuses.size()) {
+            aggregateStatus = MessageStatus.SUCCESS;
+        } else if (success > 0) {
+            aggregateStatus = MessageStatus.PARTIAL_SUCCESS;
+        } else {
+            aggregateStatus = MessageStatus.FAILED;
+        }
+        repository.updateMessageAggregate(
+                messageId,
+                aggregateStatus,
+                success,
+                failed + unknown,
+                LocalDateTime.now()
+        );
+    }
+
+    private OutboxRecord retryOutbox(String channelTaskId, int retryCount, LocalDateTime nextRetryTime) {
+        return new OutboxRecord(
+                UUID.randomUUID().toString().replace("-", ""),
+                "channel-task-retry:" + channelTaskId + ":" + retryCount,
+                "CHANNEL_TASK",
+                channelTaskId,
+                "CHANNEL_TASK_RETRY",
+                payload(channelTaskId),
+                OutboxStatus.PENDING,
+                0,
+                nextRetryTime,
+                null,
+                LocalDateTime.now(),
+                null
+        );
+    }
+
+    private String payload(String channelTaskId) {
+        try {
+            return objectMapper.writeValueAsString(Map.of("channelTaskId", channelTaskId));
+        } catch (JsonProcessingException e) {
+            throw new ImBusinessException("重试事件序列化失败", e);
+        }
+    }
+
+    private int count(List<String> statuses, String target) {
+        return (int) statuses.stream().filter(target::equals).count();
+    }
+
+    private int countAny(List<String> statuses, Set<String> targets) {
+        return (int) statuses.stream().filter(targets::contains).count();
+    }
+
+    private String safeMessage(Exception e) {
+        String message = e.getMessage();
+        return message == null || message.isBlank() ? e.getClass().getSimpleName() : message;
+    }
+
+    static final class RetryBackoffPolicy {
+        private RetryBackoffPolicy() {
+        }
+
+        static LocalDateTime nextRetryTime(int retryCount, LocalDateTime baseTime) {
+            long minutes = switch (retryCount) {
+                case 1 -> 1;
+                case 2 -> 5;
+                case 3 -> 15;
+                case 4 -> 60;
+                default -> 360;
+            };
+            return baseTime.plusMinutes(minutes);
+        }
+    }
+}

--- a/im-service/src/main/java/single/cjj/im/service/ImBusinessException.java
+++ b/im-service/src/main/java/single/cjj/im/service/ImBusinessException.java
@@ -1,0 +1,12 @@
+package single.cjj.im.service;
+
+public class ImBusinessException extends RuntimeException {
+
+    public ImBusinessException(String message) {
+        super(message);
+    }
+
+    public ImBusinessException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/im-service/src/main/java/single/cjj/im/service/MessageCommandService.java
+++ b/im-service/src/main/java/single/cjj/im/service/MessageCommandService.java
@@ -1,0 +1,387 @@
+package single.cjj.im.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import single.cjj.im.domain.ImModels.AcceptedResponse;
+import single.cjj.im.domain.ImModels.BusinessRef;
+import single.cjj.im.domain.ImModels.ChannelStatus;
+import single.cjj.im.domain.ImModels.ChannelTaskRecord;
+import single.cjj.im.domain.ImModels.ChannelType;
+import single.cjj.im.domain.ImModels.LocalNotificationRecord;
+import single.cjj.im.domain.ImModels.MessageRecord;
+import single.cjj.im.domain.ImModels.MessageStatus;
+import single.cjj.im.domain.ImModels.MessageStatusResponse;
+import single.cjj.im.domain.ImModels.OutboxRecord;
+import single.cjj.im.domain.ImModels.OutboxStatus;
+import single.cjj.im.domain.ImModels.PagedResult;
+import single.cjj.im.domain.ImModels.ReadStatus;
+import single.cjj.im.domain.ImModels.RecipientRecord;
+import single.cjj.im.domain.ImModels.RecipientRequest;
+import single.cjj.im.domain.ImModels.SendMessageRequest;
+import single.cjj.im.domain.ImModels.TemplateRecord;
+import single.cjj.im.domain.ImModels.TemplateUpsertRequest;
+import single.cjj.im.repository.ImMessageRepository;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+public class MessageCommandService {
+
+    private static final Set<String> SUPPORTED_CHANNELS = Set.of(ChannelType.LOCAL, ChannelType.EMAIL);
+
+    private final ImMessageRepository repository;
+    private final ObjectMapper objectMapper;
+    private final int maxRetryCount;
+
+    public MessageCommandService(ImMessageRepository repository,
+                                 ObjectMapper objectMapper,
+                                 @Value("${im.channel.max-retry-count:5}") int maxRetryCount) {
+        this.repository = repository;
+        this.objectMapper = objectMapper;
+        this.maxRetryCount = Math.max(1, maxRetryCount);
+    }
+
+    @Transactional
+    public AcceptedResponse acceptDirect(String appCode, SendMessageRequest request) {
+        return accept(appCode, request, false);
+    }
+
+    @Transactional
+    public AcceptedResponse acceptTemplate(String appCode, SendMessageRequest request) {
+        return accept(appCode, request, true);
+    }
+
+    public MessageStatusResponse queryStatus(String appCode, String messageNo) {
+        MessageRecord message = repository.findMessageByNo(messageNo)
+                .orElseThrow(() -> new ImBusinessException("消息不存在"));
+        if (!message.appCode().equals(appCode)) {
+            throw new ImBusinessException("无权查询该消息");
+        }
+        return new MessageStatusResponse(
+                message.messageNo(),
+                message.requestId(),
+                message.status(),
+                message.totalChannels(),
+                message.successChannels(),
+                message.failedChannels(),
+                repository.findChannelStatusResponses(message.id()),
+                message.createdTime(),
+                message.updatedTime()
+        );
+    }
+
+    @Transactional
+    public TemplateRecord upsertTemplate(TemplateUpsertRequest request) {
+        validateChannels(request.defaultChannels());
+        LocalDateTime now = LocalDateTime.now();
+        TemplateRecord record = new TemplateRecord(
+                id(),
+                request.templateCode().trim(),
+                request.templateName().trim(),
+                request.messageType().trim(),
+                request.localTitleTemplate(),
+                request.localBodyTemplate(),
+                request.emailSubjectTemplate(),
+                request.emailBodyTemplate(),
+                normalizeChannels(request.defaultChannels()).stream().collect(Collectors.joining(",")),
+                request.version(),
+                StringUtils.hasText(request.status()) ? request.status().trim().toUpperCase(Locale.ROOT) : "ENABLED",
+                now,
+                now
+        );
+        repository.upsertTemplate(record);
+        return repository.findLatestEnabledTemplate(record.templateCode()).orElse(record);
+    }
+
+    public List<TemplateRecord> listTemplates() {
+        return repository.listTemplates();
+    }
+
+    public PagedResult<LocalNotificationRecord> listNotifications(String userId,
+                                                                   String readStatus,
+                                                                   int page,
+                                                                   int size) {
+        requireUserId(userId);
+        int safePage = Math.max(1, page);
+        int safeSize = Math.min(100, Math.max(1, size));
+        String normalizedReadStatus = StringUtils.hasText(readStatus)
+                ? readStatus.trim().toUpperCase(Locale.ROOT)
+                : null;
+        long total = repository.countLocalNotifications(userId, normalizedReadStatus);
+        List<LocalNotificationRecord> records = repository.listLocalNotifications(
+                userId,
+                normalizedReadStatus,
+                (safePage - 1) * safeSize,
+                safeSize
+        );
+        return new PagedResult<>(total, safePage, safeSize, records);
+    }
+
+    public long unreadCount(String userId) {
+        requireUserId(userId);
+        return repository.countLocalNotifications(userId, ReadStatus.UNREAD);
+    }
+
+    @Transactional
+    public boolean markRead(String notificationId, String userId) {
+        requireUserId(userId);
+        return repository.markNotificationRead(notificationId, userId, LocalDateTime.now()) > 0;
+    }
+
+    @Transactional
+    public int markAllRead(String userId) {
+        requireUserId(userId);
+        return repository.markAllNotificationsRead(userId, LocalDateTime.now());
+    }
+
+    private AcceptedResponse accept(String appCode, SendMessageRequest request, boolean templateMode) {
+        if (!StringUtils.hasText(appCode)) {
+            throw new ImBusinessException("调用应用不能为空");
+        }
+        MessageRecord existing = repository.findMessageByAppRequest(appCode, request.requestId()).orElse(null);
+        if (existing != null) {
+            return new AcceptedResponse(existing.messageNo(), existing.requestId(), existing.status(), true);
+        }
+
+        TemplateRecord template = null;
+        if (templateMode) {
+            if (!StringUtils.hasText(request.templateCode())) {
+                throw new ImBusinessException("模板发送时 templateCode 不能为空");
+            }
+            template = repository.findLatestEnabledTemplate(request.templateCode().trim())
+                    .orElseThrow(() -> new ImBusinessException("消息模板不存在或未启用"));
+        } else {
+            if (!StringUtils.hasText(request.messageType())) {
+                throw new ImBusinessException("直接发送时 messageType 不能为空");
+            }
+            if (!StringUtils.hasText(request.title()) || !StringUtils.hasText(request.content())) {
+                throw new ImBusinessException("直接发送时 title 和 content 不能为空");
+            }
+        }
+
+        Set<String> channels = resolveChannels(request.channels(), template);
+        validateRecipients(request.recipients(), channels);
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime scheduledTime = request.scheduledTime() == null ? now : request.scheduledTime();
+        if (request.expireTime() != null && !request.expireTime().isAfter(scheduledTime)) {
+            throw new ImBusinessException("expireTime 必须晚于 scheduledTime");
+        }
+
+        String messageId = id();
+        String messageNo = messageNo();
+        BusinessRef business = request.business();
+        int totalChannels = request.recipients().size() * channels.size();
+        MessageRecord message = new MessageRecord(
+                messageId,
+                messageNo,
+                textOrDefault(request.tenantId(), "default"),
+                appCode,
+                request.requestId().trim(),
+                template == null ? request.messageType().trim() : template.messageType(),
+                template == null ? request.templateCode() : template.templateCode(),
+                template == null ? request.title() : render(template.localTitleTemplate(), request.templateParams()),
+                template == null ? request.content() : render(template.localBodyTemplate(), request.templateParams()),
+                textOrDefault(request.priority(), "NORMAL").toUpperCase(Locale.ROOT),
+                scheduledTime,
+                request.expireTime(),
+                business == null ? null : business.type(),
+                business == null ? null : business.id(),
+                business == null ? null : business.actionUrl(),
+                MessageStatus.ACCEPTED,
+                totalChannels,
+                0,
+                0,
+                request.callbackUrl(),
+                null,
+                now,
+                now
+        );
+        repository.insertMessage(message);
+
+        for (RecipientRequest recipientRequest : request.recipients()) {
+            RecipientRecord recipient = new RecipientRecord(
+                    id(),
+                    messageId,
+                    StringUtils.hasText(recipientRequest.userId()) ? "USER" : "EMAIL",
+                    StringUtils.hasText(recipientRequest.userId()) ? recipientRequest.userId().trim() : recipientRequest.email().trim(),
+                    recipientRequest.receiverName(),
+                    recipientRequest.email(),
+                    ReadStatus.UNREAD,
+                    null,
+                    now
+            );
+            repository.insertRecipient(recipient);
+
+            for (String channel : channels) {
+                String subject = template == null
+                        ? request.title()
+                        : render(ChannelType.EMAIL.equals(channel)
+                                ? template.emailSubjectTemplate()
+                                : template.localTitleTemplate(), request.templateParams());
+                String body = template == null
+                        ? request.content()
+                        : render(ChannelType.EMAIL.equals(channel)
+                                ? template.emailBodyTemplate()
+                                : template.localBodyTemplate(), request.templateParams());
+                if (!StringUtils.hasText(subject) || !StringUtils.hasText(body)) {
+                    throw new ImBusinessException("渠道 " + channel + " 的模板标题或正文为空");
+                }
+
+                String channelTaskId = id();
+                ChannelTaskRecord channelTask = new ChannelTaskRecord(
+                        channelTaskId,
+                        messageId,
+                        recipient.id(),
+                        channel,
+                        subject,
+                        body,
+                        ChannelStatus.PENDING,
+                        0,
+                        maxRetryCount,
+                        scheduledTime,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        now,
+                        now
+                );
+                repository.insertChannelTask(channelTask);
+                repository.insertOutbox(new OutboxRecord(
+                        id(),
+                        "channel-task-created:" + channelTaskId,
+                        "CHANNEL_TASK",
+                        channelTaskId,
+                        "CHANNEL_TASK_CREATED",
+                        outboxPayload(channelTaskId),
+                        OutboxStatus.PENDING,
+                        0,
+                        scheduledTime,
+                        null,
+                        now,
+                        null
+                ));
+            }
+        }
+        return new AcceptedResponse(messageNo, request.requestId(), MessageStatus.ACCEPTED, false);
+    }
+
+    private Set<String> resolveChannels(Set<String> requested, TemplateRecord template) {
+        if (requested != null && !requested.isEmpty()) {
+            return normalizeChannels(requested);
+        }
+        if (template == null || !StringUtils.hasText(template.defaultChannels())) {
+            throw new ImBusinessException("发送渠道不能为空");
+        }
+        return normalizeChannels(Set.of(template.defaultChannels().split(",")));
+    }
+
+    private Set<String> normalizeChannels(Set<String> channels) {
+        return channels.stream()
+                .filter(StringUtils::hasText)
+                .map(value -> value.trim().toUpperCase(Locale.ROOT))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    private void validateChannels(Set<String> channels) {
+        Set<String> normalized = normalizeChannels(channels);
+        if (normalized.isEmpty()) {
+            throw new ImBusinessException("发送渠道不能为空");
+        }
+        List<String> unsupported = normalized.stream().filter(value -> !SUPPORTED_CHANNELS.contains(value)).toList();
+        if (!unsupported.isEmpty()) {
+            throw new ImBusinessException("暂不支持的渠道: " + String.join(",", unsupported));
+        }
+    }
+
+    private void validateRecipients(List<RecipientRequest> recipients, Set<String> channels) {
+        validateChannels(channels);
+        if (recipients == null || recipients.isEmpty()) {
+            throw new ImBusinessException("接收人不能为空");
+        }
+        List<String> errors = new ArrayList<>();
+        Set<String> localUsers = new java.util.HashSet<>();
+        Set<String> emailAddresses = new java.util.HashSet<>();
+        for (int i = 0; i < recipients.size(); i++) {
+            RecipientRequest recipient = recipients.get(i);
+            if (recipient == null) {
+                errors.add("第" + (i + 1) + "个接收人为空");
+                continue;
+            }
+            if (channels.contains(ChannelType.LOCAL)) {
+                if (!StringUtils.hasText(recipient.userId())) {
+                    errors.add("第" + (i + 1) + "个接收人缺少 userId，无法发送本地提醒");
+                } else if (!localUsers.add(recipient.userId().trim())) {
+                    errors.add("本地提醒接收人重复: " + recipient.userId().trim());
+                }
+            }
+            if (channels.contains(ChannelType.EMAIL)) {
+                if (!StringUtils.hasText(recipient.email())) {
+                    errors.add("第" + (i + 1) + "个接收人缺少 email，无法发送邮件");
+                } else if (!emailAddresses.add(recipient.email().trim().toLowerCase(Locale.ROOT))) {
+                    errors.add("邮件接收人重复: " + recipient.email().trim());
+                }
+            }
+        }
+        if (!errors.isEmpty()) {
+            throw new ImBusinessException(String.join("；", errors));
+        }
+    }
+
+    private String render(String template, Map<String, Object> params) {
+        if (template == null) {
+            return null;
+        }
+        String result = template;
+        if (params != null) {
+            for (Map.Entry<String, Object> entry : params.entrySet()) {
+                result = result.replace("${" + entry.getKey() + "}", String.valueOf(entry.getValue()));
+            }
+        }
+        return result;
+    }
+
+    private String outboxPayload(String channelTaskId) {
+        try {
+            return objectMapper.writeValueAsString(Map.of("channelTaskId", channelTaskId));
+        } catch (JsonProcessingException e) {
+            throw new ImBusinessException("消息事件序列化失败", e);
+        }
+    }
+
+    private void requireUserId(String userId) {
+        if (!StringUtils.hasText(userId)) {
+            throw new ImBusinessException("缺少当前用户身份");
+        }
+    }
+
+    private String textOrDefault(String value, String defaultValue) {
+        return StringUtils.hasText(value) ? value.trim() : defaultValue;
+    }
+
+    private String id() {
+        return UUID.randomUUID().toString().replace("-", "");
+    }
+
+    private String messageNo() {
+        return "MSG" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"))
+                + UUID.randomUUID().toString().replace("-", "").substring(0, 8).toUpperCase(Locale.ROOT);
+    }
+}

--- a/im-service/src/main/java/single/cjj/im/worker/ImWorkerConfiguration.java
+++ b/im-service/src/main/java/single/cjj/im/worker/ImWorkerConfiguration.java
@@ -1,0 +1,223 @@
+package single.cjj.im.worker;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rabbitmq.client.Channel;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.transaction.support.TransactionTemplate;
+import single.cjj.im.config.ImRabbitConfiguration;
+import single.cjj.im.domain.ImModels.ChannelTaskRecord;
+import single.cjj.im.domain.ImModels.ChannelType;
+import single.cjj.im.domain.ImModels.OutboxRecord;
+import single.cjj.im.domain.ImModels.OutboxStatus;
+import single.cjj.im.repository.ImMessageRepository;
+import single.cjj.im.service.ChannelDispatchService;
+import single.cjj.im.service.ImBusinessException;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class ImWorkerConfiguration {
+
+    @Bean
+    OutboxDispatcher outboxDispatcher(ImMessageRepository repository,
+                                      RabbitTemplate rabbitTemplate,
+                                      @Value("${im.outbox.batch-size:100}") int batchSize) {
+        return new OutboxDispatcher(repository, rabbitTemplate, batchSize);
+    }
+
+    @Bean
+    ChannelTaskConsumer channelTaskConsumer(ObjectMapper objectMapper,
+                                            ChannelDispatchService dispatchService) {
+        return new ChannelTaskConsumer(objectMapper, dispatchService);
+    }
+
+    @Bean
+    StaleTaskRecoveryJob staleTaskRecoveryJob(ImMessageRepository repository,
+                                              ChannelDispatchService dispatchService,
+                                              ObjectMapper objectMapper,
+                                              TransactionTemplate transactionTemplate,
+                                              @Value("${im.channel.processing-timeout-minutes:10}") int timeoutMinutes) {
+        return new StaleTaskRecoveryJob(
+                repository,
+                dispatchService,
+                objectMapper,
+                transactionTemplate,
+                Math.max(1, timeoutMinutes)
+        );
+    }
+}
+
+class OutboxDispatcher {
+
+    private static final int MAX_RETRY_COUNT = 10;
+
+    private final ImMessageRepository repository;
+    private final RabbitTemplate rabbitTemplate;
+    private final int batchSize;
+
+    OutboxDispatcher(ImMessageRepository repository, RabbitTemplate rabbitTemplate, int batchSize) {
+        this.repository = repository;
+        this.rabbitTemplate = rabbitTemplate;
+        this.batchSize = Math.max(1, batchSize);
+    }
+
+    @Scheduled(fixedDelayString = "${im.outbox.fixed-delay-ms:3000}")
+    public void publishDueEvents() {
+        LocalDateTime now = LocalDateTime.now();
+        List<OutboxRecord> events = repository.findDueOutbox(now, batchSize);
+        for (OutboxRecord event : events) {
+            if (repository.claimOutbox(event.id()) == 0) {
+                continue;
+            }
+            try {
+                CorrelationData correlationData = new CorrelationData(event.eventId());
+                rabbitTemplate.convertAndSend(
+                        ImRabbitConfiguration.EXCHANGE,
+                        ImRabbitConfiguration.CHANNEL_TASK_ROUTING_KEY,
+                        event.payloadJson(),
+                        correlationData
+                );
+                CorrelationData.Confirm confirm = correlationData.getFuture().get(5, TimeUnit.SECONDS);
+                if (!confirm.isAck()) {
+                    throw new IllegalStateException("RabbitMQ publisher confirm rejected: " + confirm.getReason());
+                }
+                repository.markOutboxPublished(event.id(), LocalDateTime.now());
+            } catch (Exception e) {
+                int retryCount = event.retryCount() + 1;
+                if (retryCount >= MAX_RETRY_COUNT) {
+                    repository.markOutboxDead(event.id(), retryCount, safeMessage(e));
+                } else {
+                    repository.markOutboxRetry(
+                            event.id(),
+                            retryCount,
+                            LocalDateTime.now().plusMinutes(Math.min(60, retryCount * 2L)),
+                            safeMessage(e)
+                    );
+                }
+            }
+        }
+    }
+
+    private String safeMessage(Exception e) {
+        return e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
+    }
+}
+
+class ChannelTaskConsumer {
+
+    private final ObjectMapper objectMapper;
+    private final ChannelDispatchService dispatchService;
+
+    ChannelTaskConsumer(ObjectMapper objectMapper, ChannelDispatchService dispatchService) {
+        this.objectMapper = objectMapper;
+        this.dispatchService = dispatchService;
+    }
+
+    @RabbitListener(queues = ImRabbitConfiguration.CHANNEL_TASK_QUEUE)
+    public void consume(String payload, Channel channel, Message amqpMessage) throws IOException {
+        long deliveryTag = amqpMessage.getMessageProperties().getDeliveryTag();
+        try {
+            JsonNode root = objectMapper.readTree(payload);
+            String channelTaskId = root.path("channelTaskId").asText();
+            if (channelTaskId.isBlank()) {
+                channel.basicReject(deliveryTag, false);
+                return;
+            }
+            dispatchService.dispatch(channelTaskId);
+            channel.basicAck(deliveryTag, false);
+        } catch (ImBusinessException e) {
+            channel.basicReject(deliveryTag, false);
+        } catch (Exception e) {
+            channel.basicNack(deliveryTag, false, true);
+        }
+    }
+}
+
+class StaleTaskRecoveryJob {
+
+    private final ImMessageRepository repository;
+    private final ChannelDispatchService dispatchService;
+    private final ObjectMapper objectMapper;
+    private final TransactionTemplate transactionTemplate;
+    private final int timeoutMinutes;
+
+    StaleTaskRecoveryJob(ImMessageRepository repository,
+                         ChannelDispatchService dispatchService,
+                         ObjectMapper objectMapper,
+                         TransactionTemplate transactionTemplate,
+                         int timeoutMinutes) {
+        this.repository = repository;
+        this.dispatchService = dispatchService;
+        this.objectMapper = objectMapper;
+        this.transactionTemplate = transactionTemplate;
+        this.timeoutMinutes = timeoutMinutes;
+    }
+
+    @Scheduled(fixedDelay = 60000L)
+    public void recover() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime deadline = now.minusMinutes(timeoutMinutes);
+        recoverLocalTasks(repository.findStaleChannelTasks(ChannelType.LOCAL, deadline, 100), now);
+        markUnknownEmailTasks(repository.findStaleChannelTasks(ChannelType.EMAIL, deadline, 100), now);
+    }
+
+    private void recoverLocalTasks(List<ChannelTaskRecord> tasks, LocalDateTime now) {
+        for (ChannelTaskRecord task : tasks) {
+            int nextRetryCount = task.retryCount() + 1;
+            if (nextRetryCount >= task.maxRetryCount()) {
+                repository.markChannelDead(task.id(), nextRetryCount,
+                        "PROCESSING_TIMEOUT", "本地提醒执行多次超时，已停止自动重试", now);
+                dispatchService.refreshMessageStatus(task.messageId());
+                continue;
+            }
+            transactionTemplate.executeWithoutResult(status -> {
+                if (repository.recoverStaleLocalTask(task.id(), nextRetryCount, now, now) == 0) {
+                    return;
+                }
+                repository.insertOutbox(new OutboxRecord(
+                        UUID.randomUUID().toString().replace("-", ""),
+                        "stale-local-retry:" + task.id() + ":" + now,
+                        "CHANNEL_TASK",
+                        task.id(),
+                        "CHANNEL_TASK_RECOVERED",
+                        payload(task.id()),
+                        OutboxStatus.PENDING,
+                        0,
+                        now,
+                        null,
+                        now,
+                        null
+                ));
+            });
+        }
+    }
+
+    private void markUnknownEmailTasks(List<ChannelTaskRecord> tasks, LocalDateTime now) {
+        for (ChannelTaskRecord task : tasks) {
+            if (repository.markStaleEmailTaskUnknown(task.id(), now) > 0) {
+                dispatchService.refreshMessageStatus(task.messageId());
+            }
+        }
+    }
+
+    private String payload(String channelTaskId) {
+        try {
+            return objectMapper.writeValueAsString(Map.of("channelTaskId", channelTaskId));
+        } catch (Exception e) {
+            throw new ImBusinessException("恢复事件序列化失败", e);
+        }
+    }
+}

--- a/im-service/src/main/resources/application.yml
+++ b/im-service/src/main/resources/application.yml
@@ -1,0 +1,67 @@
+server:
+  port: ${IM_SERVER_PORT:10005}
+  servlet:
+    context-path: /api
+
+spring:
+  application:
+    name: im-service
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:dev}
+  config:
+    import: "optional:nacos:${spring.application.name}"
+  cloud:
+    nacos:
+      discovery:
+        server-addr: ${NACOS_ADDR:117.72.216.168:8848}
+        group: ${NACOS_GROUP:DEV_GROUP}
+        namespace: ${NACOS_NAMESPACE:public}
+      config:
+        server-addr: ${NACOS_ADDR:117.72.216.168:8848}
+        file-extension: yaml
+        group: ${NACOS_GROUP:DEV_GROUP}
+        namespace: ${NACOS_NAMESPACE:public}
+  rabbitmq:
+    host: ${RABBITMQ_HOST:127.0.0.1}
+    port: ${RABBITMQ_PORT:5672}
+    username: ${RABBITMQ_USERNAME:guest}
+    password: ${RABBITMQ_PASSWORD:guest}
+    publisher-confirm-type: correlated
+    publisher-returns: true
+    listener:
+      simple:
+        acknowledge-mode: manual
+        prefetch: 20
+  data:
+    redis:
+      host: ${REDIS_HOST:127.0.0.1}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}
+  mail:
+    host: ${MAIL_HOST:localhost}
+    port: ${MAIL_PORT:25}
+    username: ${MAIL_USERNAME:}
+    password: ${MAIL_PASSWORD:}
+    properties:
+      mail.smtp.auth: ${MAIL_SMTP_AUTH:false}
+      mail.smtp.starttls.enable: ${MAIL_STARTTLS:false}
+
+im:
+  open-api:
+    signature-window-seconds: ${IM_SIGNATURE_WINDOW_SECONDS:300}
+    credentials:
+      matrix: ${IM_MATRIX_APP_SECRET:change-me-before-use}
+  outbox:
+    batch-size: ${IM_OUTBOX_BATCH_SIZE:100}
+    fixed-delay-ms: ${IM_OUTBOX_FIXED_DELAY_MS:3000}
+  channel:
+    max-retry-count: ${IM_CHANNEL_MAX_RETRY_COUNT:5}
+    processing-timeout-minutes: ${IM_PROCESSING_TIMEOUT_MINUTES:10}
+  email:
+    from: ${IM_EMAIL_FROM:${MAIL_USERNAME:}}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,prometheus

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <module>scheduler-service</module>
         <module>workflow-service</module>
         <module>botp-service</module>
+        <module>im-service</module>
         <module>common</module>
         <module>infra</module>
         <module>config</module>


### PR DESCRIPTION
## Summary

- add a new `im-service` module for unified notification delivery
- support direct and template-based sends for Matrix services and external systems
- split message tasks from per-recipient channel tasks for independent LOCAL and EMAIL results
- add HMAC-SHA256 request signing, timestamp validation, and Redis nonce replay protection
- persist local notifications with unread/read APIs
- send HTML email through Spring Mail
- add transactional Outbox storage, RabbitMQ publisher confirms, manual consumer acknowledgements, retries, stale-task recovery, and `UNKNOWN` handling for uncertain SMTP results
- add MySQL schema, integration documentation, and an IM module GitHub Actions workflow

## Why

Matrix needs a reusable notification platform that can be called by internal services and external business systems without coupling callers to SMTP configuration, retry rules, or channel status handling.

## Validation

- XML and YAML files parse successfully
- Java syntax was checked locally with `javac --release 17`
- GitHub Actions `mvn -q -Dstyle.color=never -pl im-service -am test` passes
- IM Service CI, Scheduler Service CI, Workflow Service CI, and BOTP CI all pass
- branch is based on the current `dev` history; the parent POM preserves `scheduler-service`, `workflow-service`, and `botp-service`, and only adds `im-service`
- pull request is mergeable

## Phase boundary

Phase one provides reliable in-app notification persistence/read APIs and email delivery. WebSocket online popup delivery and client ACK are intentionally deferred to phase two.

## Follow-up

- add WebSocket online popup delivery and client ACK
- add application credential management, IP allowlists, and rate limiting
- add callback delivery and an operator console for retries/manual replay
