### PR TITLE
feat: add OpenAPI governance and voucher data scopes

### DIFF
--- a/.github/workflows/openapi-ci.yml
+++ b/.github/workflows/openapi-ci.yml
@@ -1,0 +1,41 @@
+name: OpenAPI CI
+
+on:
+  pull_request:
+    branches:
+      - dev
+    paths:
+      - 'openapi-service/**'
+      - 'fi-service/**'
+      - 'gateway/**'
+      - 'common/**'
+      - 'sql/matrix_open_api_*.sql'
+      - 'pom.xml'
+      - '.github/workflows/openapi-ci.yml'
+  push:
+    branches:
+      - agent/openapi-governance-v2
+    paths:
+      - 'openapi-service/**'
+      - 'fi-service/**'
+      - 'gateway/**'
+      - 'common/**'
+      - 'pom.xml'
+      - '.github/workflows/openapi-ci.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+
+      - name: Test OpenAPI modules
+        run: mvn -B -pl openapi-service,fi-service,gateway -am test

--- a/common/src/main/java/single/cjj/openapi/contract/OpenVoucherQuery.java
+++ b/common/src/main/java/single/cjj/openapi/contract/OpenVoucherQuery.java
@@ -11,6 +11,8 @@ public class OpenVoucherQuery {
     private Integer pageSize = 20;
     private String voucherNumber;
     private String status;
+    private String organizationId;
+    private String bookId;
     private LocalDate startDate;
     private LocalDate endDate;
 }

--- a/common/src/main/java/single/cjj/openapi/contract/OpenVoucherResponse.java
+++ b/common/src/main/java/single/cjj/openapi/contract/OpenVoucherResponse.java
@@ -14,8 +14,12 @@ import java.time.LocalDateTime;
 public class OpenVoucherResponse {
 
     private String voucherId;
+    private String tenantId;
+    private String organizationId;
+    private String bookId;
     private String voucherNumber;
     private LocalDate voucherDate;
+    private String period;
     private String summary;
     private BigDecimal amount;
     private String status;

--- a/docs/bus/platform/openapi/governance-v2.md
+++ b/docs/bus/platform/openapi/governance-v2.md
@@ -1,0 +1,73 @@
+# Matrix OpenAPI 治理 V2
+
+## 1. 本期目标
+
+将第一期凭证只读接口升级为可运营、可排查、可控制的开放平台：
+
+- 应用配置维护与 AppSecret 轮换。
+- API 授权修改、停用和撤销。
+- 调用日志分页查询、Request ID 定位。
+- 24 小时/自定义窗口调用看板。
+- 凭证租户、组织、账簿 SQL 级数据权限。
+
+## 2. 数据权限
+
+应用固定绑定一个 `tenantId`，外部请求不能覆盖租户。
+
+授权 JSON：
+
+```json
+{
+  "allowedStatuses": ["POSTED"],
+  "organizationIds": ["ORG-001", "ORG-002"],
+  "bookIds": ["BOOK-001"],
+  "maxHistoryMonths": 24
+}
+```
+
+规则：
+
+1. 最终范围等于请求条件与授权范围的交集。
+2. 租户、组织、账簿、状态条件由 `fi-service` 写入 SQL。
+3. `organizationIds` 或 `bookIds` 缺失时，为兼容 V1 授权，按应用租户内通配处理。
+4. 新建和修改授权时，前台应显式提交组织与账簿范围。
+5. 系统最大凭证状态仍固定为 `POSTED`，授权不能扩大为草稿、提交或审核状态。
+
+## 3. 管理接口
+
+- `PUT /api/openapi/admin/apps/{id}`：维护应用名称、有效期、IP、QPS、分页上限。
+- `POST /api/openapi/admin/apps/{id}/rotate-secret`：立即轮换 AppSecret，明文仅返回一次。
+- `PUT /api/openapi/admin/grants/{id}`：修改授权。
+- `DELETE /api/openapi/admin/grants/{id}`：将授权标记为 `REVOKED`。
+- `GET /api/openapi/admin/logs`：分页检索调用日志。
+- `GET /api/openapi/admin/logs/{requestId}`：按 Request ID 查询调用详情。
+- `GET /api/openapi/admin/dashboard`：查询调用量、成功率、平均耗时、P95、热门 API 和错误码。
+
+## 4. 日志与看板
+
+日志支持以下过滤条件：
+
+- Request ID
+- App ID
+- API 编码
+- 客户端 IP
+- 成功/失败
+- 错误码
+- 开始与结束时间
+
+看板单次最多聚合最近 10000 条调用记录，达到上限时返回 `sampleTruncated=true`，提示管理端缩小时间窗口。
+
+## 5. 数据库迁移
+
+按顺序执行：
+
+1. `sql/matrix_open_api_v1.sql`
+2. `sql/matrix_open_api_v2.sql`
+
+V2 会给凭证增加 `tenant_id`、`org_id`、`book_id`，并增加开放查询所需的组合索引。
+
+## 6. 安全边界
+
+- AppSecret 轮换后旧密钥立即失效；接入方应先停流或具备快速配置切换能力。
+- 管理接口继续经过 Gateway Bearer JWT 认证。
+- 外部 OpenAPI 仍只支持 GET，不开放凭证写入、审核、过账和冲销。

--- a/docs/bus/platform/openapi/manifest.json
+++ b/docs/bus/platform/openapi/manifest.json
@@ -4,12 +4,13 @@
   "bizCode": "openapi",
   "bizName": "开放平台",
   "status": "development",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "busDocs": [
     "business.md",
     "rules.md",
     "api.md",
-    "deployment.md"
+    "deployment.md",
+    "governance-v2.md"
   ],
   "promptDocs": [
     "docs/prompt/platform/openapi/backend.md",

--- a/fi-service/src/main/java/single/cjj/fi/gl/controller/BizfiFiVoucherOpenApiController.java
+++ b/fi-service/src/main/java/single/cjj/fi/gl/controller/BizfiFiVoucherOpenApiController.java
@@ -1,6 +1,8 @@
 package single.cjj.fi.gl.controller;
 
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,23 +21,25 @@ import single.cjj.openapi.contract.OpenVoucherResponse;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
  * 仅供 openapi-service 调用的凭证只读适配器。
- * 不暴露任何新增、修改、审核、过账、冲销和删除能力。
+ * 所有租户、组织、账簿和状态权限均在 SQL 条件中执行。
  */
 @RestController
 @RequestMapping("/internal/openapi/v1/vouchers")
 public class BizfiFiVoucherOpenApiController {
 
+    private static final String TENANT_HEADER = "X-OpenApi-Tenant-Id";
     private static final String ALLOWED_STATUS_HEADER = "X-OpenApi-Allowed-Statuses";
+    private static final String ALLOWED_ORG_HEADER = "X-OpenApi-Allowed-Organizations";
+    private static final String ALLOWED_BOOK_HEADER = "X-OpenApi-Allowed-Books";
     private static final Set<String> DEFAULT_ALLOWED_STATUSES = Set.of("POSTED");
+    private static final Set<String> WILDCARD_SCOPE = Set.of("*");
 
     private final BizfiFiVoucherService voucherService;
 
@@ -49,49 +53,89 @@ public class BizfiFiVoucherOpenApiController {
             @RequestParam(value = "pageSize", defaultValue = "20") int pageSize,
             @RequestParam(value = "voucherNumber", required = false) String voucherNumber,
             @RequestParam(value = "status", required = false) String status,
+            @RequestParam(value = "organizationId", required = false) String organizationId,
+            @RequestParam(value = "bookId", required = false) String bookId,
             @RequestParam(value = "startDate", required = false) String startDate,
             @RequestParam(value = "endDate", required = false) String endDate,
-            @RequestHeader(value = ALLOWED_STATUS_HEADER, required = false) String allowedStatusesHeader) {
+            @RequestHeader(TENANT_HEADER) String tenantId,
+            @RequestHeader(value = ALLOWED_STATUS_HEADER, required = false) String allowedStatusesHeader,
+            @RequestHeader(value = ALLOWED_ORG_HEADER, required = false) String allowedOrganizationsHeader,
+            @RequestHeader(value = ALLOWED_BOOK_HEADER, required = false) String allowedBooksHeader) {
 
-        Set<String> allowedStatuses = parseAllowedStatuses(allowedStatusesHeader);
-        String effectiveStatus = resolveEffectiveStatus(status, allowedStatuses);
+        Set<String> allowedStatuses = parseScope(allowedStatusesHeader, DEFAULT_ALLOWED_STATUSES, true);
+        Set<String> allowedOrganizations = parseScope(allowedOrganizationsHeader, WILDCARD_SCOPE, false);
+        Set<String> allowedBooks = parseScope(allowedBooksHeader, WILDCARD_SCOPE, false);
+        String effectiveStatus = resolveRequestedValue(status, allowedStatuses, "凭证状态", true);
+        String effectiveOrganization = resolveRequestedValue(
+                organizationId, allowedOrganizations, "组织", false
+        );
+        String effectiveBook = resolveRequestedValue(bookId, allowedBooks, "账簿", false);
 
-        Map<String, Object> query = new HashMap<>();
-        query.put("number", voucherNumber);
-        query.put("status", effectiveStatus);
-        query.put("startDate", startDate);
-        query.put("endDate", endDate);
+        LambdaQueryWrapper<BizfiFiVoucher> wrapper = new LambdaQueryWrapper<>();
+        wrapper.eq(BizfiFiVoucher::getTenantId, tenantId.trim());
+        if (StringUtils.hasText(voucherNumber)) {
+            wrapper.like(BizfiFiVoucher::getFnumber, voucherNumber.trim());
+        }
+        if (StringUtils.hasText(effectiveStatus)) {
+            wrapper.eq(BizfiFiVoucher::getFstatus, effectiveStatus);
+        } else {
+            wrapper.in(BizfiFiVoucher::getFstatus, allowedStatuses);
+        }
+        applyOrganizationScope(wrapper, effectiveOrganization, allowedOrganizations);
+        applyBookScope(wrapper, effectiveBook, allowedBooks);
+        if (StringUtils.hasText(startDate)) {
+            wrapper.ge(BizfiFiVoucher::getFdate, startDate);
+        }
+        if (StringUtils.hasText(endDate)) {
+            wrapper.le(BizfiFiVoucher::getFdate, endDate);
+        }
+        wrapper.orderByDesc(BizfiFiVoucher::getFdate).orderByDesc(BizfiFiVoucher::getFid);
 
         int safePageNo = Math.max(pageNo, 1);
         int safePageSize = Math.max(1, Math.min(pageSize, 500));
-        IPage<BizfiFiVoucher> page = voucherService.list(safePageNo, safePageSize, query);
-
+        IPage<BizfiFiVoucher> page = voucherService.page(
+                new Page<>(safePageNo, safePageSize), wrapper
+        );
         List<OpenVoucherResponse> items = page.getRecords().stream()
-                .filter(voucher -> allowedStatuses.contains(voucher.getFstatus()))
                 .map(this::toOpenVoucher)
                 .collect(Collectors.toList());
 
         return ApiResponse.success(OpenApiPageResponse.of(
-                page.getTotal(),
-                safePageNo,
-                safePageSize,
-                items
+                page.getTotal(), safePageNo, safePageSize, items
         ));
     }
 
     @GetMapping("/{voucherId}")
     public ApiResponse<OpenVoucherResponse> detail(
             @PathVariable("voucherId") Long voucherId,
-            @RequestHeader(value = ALLOWED_STATUS_HEADER, required = false) String allowedStatusesHeader) {
-        BizfiFiVoucher voucher = requireAllowedVoucher(voucherId, parseAllowedStatuses(allowedStatusesHeader));
+            @RequestHeader(TENANT_HEADER) String tenantId,
+            @RequestHeader(value = ALLOWED_STATUS_HEADER, required = false) String allowedStatusesHeader,
+            @RequestHeader(value = ALLOWED_ORG_HEADER, required = false) String allowedOrganizationsHeader,
+            @RequestHeader(value = ALLOWED_BOOK_HEADER, required = false) String allowedBooksHeader) {
+        BizfiFiVoucher voucher = requireAllowedVoucher(
+                voucherId,
+                tenantId,
+                parseScope(allowedStatusesHeader, DEFAULT_ALLOWED_STATUSES, true),
+                parseScope(allowedOrganizationsHeader, WILDCARD_SCOPE, false),
+                parseScope(allowedBooksHeader, WILDCARD_SCOPE, false)
+        );
         return ApiResponse.success(toOpenVoucher(voucher));
     }
 
     @GetMapping("/{voucherId}/lines")
     public ApiResponse<List<OpenVoucherLineResponse>> lines(
             @PathVariable("voucherId") Long voucherId,
-            @RequestHeader(value = ALLOWED_STATUS_HEADER, required = false) String allowedStatusesHeader) {
-        requireAllowedVoucher(voucherId, parseAllowedStatuses(allowedStatusesHeader));
+            @RequestHeader(TENANT_HEADER) String tenantId,
+            @RequestHeader(value = ALLOWED_STATUS_HEADER, required = false) String allowedStatusesHeader,
+            @RequestHeader(value = ALLOWED_ORG_HEADER, required = false) String allowedOrganizationsHeader,
+            @RequestHeader(value = ALLOWED_BOOK_HEADER, required = false) String allowedBooksHeader) {
+        requireAllowedVoucher(
+                voucherId,
+                tenantId,
+                parseScope(allowedStatusesHeader, DEFAULT_ALLOWED_STATUSES, true),
+                parseScope(allowedOrganizationsHeader, WILDCARD_SCOPE, false),
+                parseScope(allowedBooksHeader, WILDCARD_SCOPE, false)
+        );
         List<BizfiFiVoucherLine> lines = voucherService.listLines(voucherId);
         if (lines == null || lines.isEmpty()) {
             return ApiResponse.success(Collections.emptyList());
@@ -99,49 +143,89 @@ public class BizfiFiVoucherOpenApiController {
         return ApiResponse.success(lines.stream().map(this::toOpenLine).collect(Collectors.toList()));
     }
 
-    private BizfiFiVoucher requireAllowedVoucher(Long voucherId, Set<String> allowedStatuses) {
-        BizfiFiVoucher voucher = voucherService.get(voucherId);
-        if (voucher == null) {
-            throw new BizException("凭证不存在");
+    private BizfiFiVoucher requireAllowedVoucher(Long voucherId,
+                                                  String tenantId,
+                                                  Set<String> statuses,
+                                                  Set<String> organizations,
+                                                  Set<String> books) {
+        LambdaQueryWrapper<BizfiFiVoucher> wrapper = new LambdaQueryWrapper<>();
+        wrapper.eq(BizfiFiVoucher::getFid, voucherId)
+                .eq(BizfiFiVoucher::getTenantId, tenantId.trim())
+                .in(BizfiFiVoucher::getFstatus, statuses);
+        if (!organizations.contains("*")) {
+            wrapper.in(BizfiFiVoucher::getOrganizationId, organizations);
         }
-        if (!allowedStatuses.contains(voucher.getFstatus())) {
-            throw new BizException("凭证不在应用授权的数据范围内");
+        if (!books.contains("*")) {
+            wrapper.in(BizfiFiVoucher::getBookId, books);
+        }
+        BizfiFiVoucher voucher = voucherService.getOne(wrapper, false);
+        if (voucher == null) {
+            throw new BizException("凭证不存在或不在应用授权的数据范围内");
         }
         return voucher;
     }
 
-    private String resolveEffectiveStatus(String requestedStatus, Set<String> allowedStatuses) {
-        if (StringUtils.hasText(requestedStatus)) {
-            String normalized = requestedStatus.trim().toUpperCase();
-            if (!allowedStatuses.contains(normalized)) {
-                throw new BizException("请求的凭证状态不在应用授权范围内");
-            }
-            return normalized;
+    private void applyOrganizationScope(LambdaQueryWrapper<BizfiFiVoucher> wrapper,
+                                        String requested,
+                                        Set<String> allowed) {
+        if (StringUtils.hasText(requested)) {
+            wrapper.eq(BizfiFiVoucher::getOrganizationId, requested);
+        } else if (!allowed.contains("*")) {
+            wrapper.in(BizfiFiVoucher::getOrganizationId, allowed);
         }
-        if (allowedStatuses.size() == 1) {
-            return allowedStatuses.iterator().next();
-        }
-        // 现有凭证服务只支持单状态查询。多状态授权时先不下推状态，结果仍会二次过滤。
-        return null;
     }
 
-    private Set<String> parseAllowedStatuses(String header) {
+    private void applyBookScope(LambdaQueryWrapper<BizfiFiVoucher> wrapper,
+                                String requested,
+                                Set<String> allowed) {
+        if (StringUtils.hasText(requested)) {
+            wrapper.eq(BizfiFiVoucher::getBookId, requested);
+        } else if (!allowed.contains("*")) {
+            wrapper.in(BizfiFiVoucher::getBookId, allowed);
+        }
+    }
+
+    private String resolveRequestedValue(String requested,
+                                         Set<String> allowed,
+                                         String label,
+                                         boolean uppercase) {
+        if (!StringUtils.hasText(requested)) {
+            return null;
+        }
+        String normalized = uppercase ? requested.trim().toUpperCase() : requested.trim();
+        if (!allowed.contains("*") && !allowed.contains(normalized)) {
+            throw new BizException("请求的" + label + "不在应用授权范围内");
+        }
+        return normalized;
+    }
+
+    private Set<String> parseScope(String header, Set<String> defaults, boolean uppercase) {
         if (!StringUtils.hasText(header)) {
-            return DEFAULT_ALLOWED_STATUSES;
+            return defaults;
         }
         Set<String> result = Arrays.stream(header.split(","))
                 .map(String::trim)
                 .filter(StringUtils::hasText)
-                .map(String::toUpperCase)
+                .map(value -> uppercase ? value.toUpperCase() : value)
                 .collect(Collectors.toCollection(LinkedHashSet::new));
-        return result.isEmpty() ? DEFAULT_ALLOWED_STATUSES : result;
+        if (result.contains("*")) {
+            return WILDCARD_SCOPE;
+        }
+        return result.isEmpty() ? defaults : result;
     }
 
     private OpenVoucherResponse toOpenVoucher(BizfiFiVoucher voucher) {
+        String period = voucher.getFdate() == null
+                ? null
+                : String.format("%d-%02d", voucher.getFdate().getYear(), voucher.getFdate().getMonthValue());
         return new OpenVoucherResponse(
                 String.valueOf(voucher.getFid()),
+                voucher.getTenantId(),
+                voucher.getOrganizationId(),
+                voucher.getBookId(),
                 voucher.getFnumber(),
                 voucher.getFdate(),
+                period,
                 voucher.getFsummary(),
                 voucher.getFamount(),
                 voucher.getFstatus(),

--- a/fi-service/src/main/java/single/cjj/fi/gl/entity/BizfiFiVoucher.java
+++ b/fi-service/src/main/java/single/cjj/fi/gl/entity/BizfiFiVoucher.java
@@ -1,5 +1,6 @@
 package single.cjj.fi.gl.entity;
 
+import com.baomidou.mybatisplus.annotation.TableField;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
 import lombok.AllArgsConstructor;
@@ -24,6 +25,18 @@ public class BizfiFiVoucher implements Serializable {
     /** 主键ID */
     @TableId("fid")
     private Long fid;
+
+    /** 租户 */
+    @TableField("tenant_id")
+    private String tenantId;
+
+    /** 业务组织 */
+    @TableField("org_id")
+    private String organizationId;
+
+    /** 账簿 */
+    @TableField("book_id")
+    private String bookId;
 
     /** 凭证编号 */
     private String fnumber;

--- a/openapi-service/src/main/java/single/cjj/openapi/client/FiVoucherOpenClient.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/client/FiVoucherOpenClient.java
@@ -26,20 +26,31 @@ public interface FiVoucherOpenClient {
             @RequestParam("pageSize") int pageSize,
             @RequestParam(value = "voucherNumber", required = false) String voucherNumber,
             @RequestParam(value = "status", required = false) String status,
+            @RequestParam(value = "organizationId", required = false) String organizationId,
+            @RequestParam(value = "bookId", required = false) String bookId,
             @RequestParam(value = "startDate", required = false) String startDate,
             @RequestParam(value = "endDate", required = false) String endDate,
-            @RequestHeader("X-OpenApi-Allowed-Statuses") String allowedStatuses
+            @RequestHeader("X-OpenApi-Tenant-Id") String tenantId,
+            @RequestHeader("X-OpenApi-Allowed-Statuses") String allowedStatuses,
+            @RequestHeader("X-OpenApi-Allowed-Organizations") String allowedOrganizations,
+            @RequestHeader("X-OpenApi-Allowed-Books") String allowedBooks
     );
 
     @GetMapping("/{voucherId}")
     ApiResponse<OpenVoucherResponse> detail(
             @PathVariable("voucherId") Long voucherId,
-            @RequestHeader("X-OpenApi-Allowed-Statuses") String allowedStatuses
+            @RequestHeader("X-OpenApi-Tenant-Id") String tenantId,
+            @RequestHeader("X-OpenApi-Allowed-Statuses") String allowedStatuses,
+            @RequestHeader("X-OpenApi-Allowed-Organizations") String allowedOrganizations,
+            @RequestHeader("X-OpenApi-Allowed-Books") String allowedBooks
     );
 
     @GetMapping("/{voucherId}/lines")
     ApiResponse<List<OpenVoucherLineResponse>> lines(
             @PathVariable("voucherId") Long voucherId,
-            @RequestHeader("X-OpenApi-Allowed-Statuses") String allowedStatuses
+            @RequestHeader("X-OpenApi-Tenant-Id") String tenantId,
+            @RequestHeader("X-OpenApi-Allowed-Statuses") String allowedStatuses,
+            @RequestHeader("X-OpenApi-Allowed-Organizations") String allowedOrganizations,
+            @RequestHeader("X-OpenApi-Allowed-Books") String allowedBooks
     );
 }

--- a/openapi-service/src/main/java/single/cjj/openapi/controller/OpenApiGovernanceController.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/controller/OpenApiGovernanceController.java
@@ -1,0 +1,367 @@
+package single.cjj.openapi.controller;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import single.cjj.bizfi.entity.ApiResponse;
+import single.cjj.openapi.contract.OpenApiPageResponse;
+import single.cjj.openapi.entity.OpenApiApp;
+import single.cjj.openapi.entity.OpenApiGrant;
+import single.cjj.openapi.entity.OpenApiRequestLog;
+import single.cjj.openapi.exception.OpenApiCallException;
+import single.cjj.openapi.mapper.OpenApiAppMapper;
+import single.cjj.openapi.mapper.OpenApiGrantMapper;
+import single.cjj.openapi.mapper.OpenApiRequestLogMapper;
+import single.cjj.openapi.service.OpenApiSecretService;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * OpenAPI 第二期治理能力。
+ * 管理端接口继续由 Gateway JWT 认证保护。
+ */
+@RestController
+@RequestMapping("/openapi/admin")
+public class OpenApiGovernanceController {
+
+    private static final int MAX_DASHBOARD_SAMPLE = 10000;
+
+    private final OpenApiAppMapper appMapper;
+    private final OpenApiGrantMapper grantMapper;
+    private final OpenApiRequestLogMapper requestLogMapper;
+    private final OpenApiSecretService secretService;
+
+    public OpenApiGovernanceController(OpenApiAppMapper appMapper,
+                                       OpenApiGrantMapper grantMapper,
+                                       OpenApiRequestLogMapper requestLogMapper,
+                                       OpenApiSecretService secretService) {
+        this.appMapper = appMapper;
+        this.grantMapper = grantMapper;
+        this.requestLogMapper = requestLogMapper;
+        this.secretService = secretService;
+    }
+
+    @PutMapping("/apps/{id}")
+    public ApiResponse<Boolean> updateApp(@PathVariable("id") Long id,
+                                          @RequestBody UpdateAppRequest request) {
+        OpenApiApp app = requireApp(id);
+        if (request == null) {
+            throw badRequest("应用参数不能为空");
+        }
+        if (StringUtils.hasText(request.appName())) {
+            app.setAppName(request.appName().trim());
+        }
+        app.setValidFrom(request.validFrom());
+        app.setValidTo(request.validTo());
+        app.setIpWhitelist(normalizeNullable(request.ipWhitelist()));
+        if (request.qpsLimit() != null) {
+            app.setQpsLimit(normalizePositive(request.qpsLimit(), 1, 10000, "QPS"));
+        }
+        if (request.maxPageSize() != null) {
+            app.setMaxPageSize(normalizePositive(request.maxPageSize(), 1, 500, "分页上限"));
+        }
+        app.setUpdatedAt(LocalDateTime.now());
+        return ApiResponse.success(appMapper.updateById(app) > 0);
+    }
+
+    @PostMapping("/apps/{id}/rotate-secret")
+    public ApiResponse<RotateSecretResponse> rotateSecret(@PathVariable("id") Long id) {
+        OpenApiApp app = requireApp(id);
+        OpenApiSecretService.GeneratedSecret secret = secretService.generateSecret();
+        app.setAppSecretCipher(secret.appSecretCipher());
+        app.setUpdatedAt(LocalDateTime.now());
+        appMapper.updateById(app);
+        return ApiResponse.success(new RotateSecretResponse(
+                app.getId(), app.getAppId(), app.getAppKey(), secret.appSecret(), app.getUpdatedAt()
+        ));
+    }
+
+    @PutMapping("/grants/{id}")
+    public ApiResponse<OpenApiGrant> updateGrant(@PathVariable("id") Long id,
+                                                 @RequestBody UpdateGrantRequest request) {
+        OpenApiGrant grant = requireGrant(id);
+        if (request == null) {
+            throw badRequest("授权参数不能为空");
+        }
+        if (StringUtils.hasText(request.status())) {
+            grant.setStatus(normalizeGrantStatus(request.status()));
+        }
+        if (request.dataPermissionJson() != null) {
+            grant.setDataPermissionJson(request.dataPermissionJson());
+        }
+        if (request.fieldPermissionJson() != null) {
+            grant.setFieldPermissionJson(request.fieldPermissionJson());
+        }
+        grant.setValidFrom(request.validFrom());
+        grant.setValidTo(request.validTo());
+        grant.setUpdatedAt(LocalDateTime.now());
+        grantMapper.updateById(grant);
+        return ApiResponse.success(grant);
+    }
+
+    @DeleteMapping("/grants/{id}")
+    public ApiResponse<Boolean> revokeGrant(@PathVariable("id") Long id) {
+        OpenApiGrant grant = requireGrant(id);
+        grant.setStatus("REVOKED");
+        grant.setUpdatedAt(LocalDateTime.now());
+        return ApiResponse.success(grantMapper.updateById(grant) > 0);
+    }
+
+    @GetMapping("/logs")
+    public ApiResponse<OpenApiPageResponse<OpenApiRequestLog>> listLogs(
+            @RequestParam(value = "pageNo", defaultValue = "1") int pageNo,
+            @RequestParam(value = "pageSize", defaultValue = "20") int pageSize,
+            @RequestParam(value = "requestId", required = false) String requestId,
+            @RequestParam(value = "appId", required = false) String appId,
+            @RequestParam(value = "apiCode", required = false) String apiCode,
+            @RequestParam(value = "clientIp", required = false) String clientIp,
+            @RequestParam(value = "responseCode", required = false) String responseCode,
+            @RequestParam(value = "success", required = false) Boolean success,
+            @RequestParam(value = "startTime", required = false) LocalDateTime startTime,
+            @RequestParam(value = "endTime", required = false) LocalDateTime endTime) {
+        int safePageNo = Math.max(1, pageNo);
+        int safePageSize = Math.max(1, Math.min(pageSize, 200));
+        LambdaQueryWrapper<OpenApiRequestLog> wrapper = buildLogWrapper(
+                requestId, appId, apiCode, clientIp, responseCode, success, startTime, endTime
+        ).orderByDesc(OpenApiRequestLog::getRequestTime)
+                .orderByDesc(OpenApiRequestLog::getId);
+        IPage<OpenApiRequestLog> page = requestLogMapper.selectPage(
+                new Page<>(safePageNo, safePageSize), wrapper
+        );
+        return ApiResponse.success(OpenApiPageResponse.of(
+                page.getTotal(), safePageNo, safePageSize, page.getRecords()
+        ));
+    }
+
+    @GetMapping("/logs/{requestId}")
+    public ApiResponse<OpenApiRequestLog> getLog(@PathVariable("requestId") String requestId) {
+        OpenApiRequestLog log = requestLogMapper.selectOne(
+                new LambdaQueryWrapper<OpenApiRequestLog>()
+                        .eq(OpenApiRequestLog::getRequestId, requestId)
+        );
+        if (log == null) {
+            throw new OpenApiCallException("OPENAPI_40401", "调用日志不存在", 404);
+        }
+        return ApiResponse.success(log);
+    }
+
+    @GetMapping("/dashboard")
+    public ApiResponse<DashboardView> dashboard(
+            @RequestParam(value = "hours", defaultValue = "24") int hours,
+            @RequestParam(value = "appId", required = false) String appId) {
+        int safeHours = Math.max(1, Math.min(hours, 24 * 31));
+        LocalDateTime from = LocalDateTime.now().minusHours(safeHours);
+        LambdaQueryWrapper<OpenApiRequestLog> wrapper = new LambdaQueryWrapper<OpenApiRequestLog>()
+                .ge(OpenApiRequestLog::getRequestTime, from)
+                .orderByDesc(OpenApiRequestLog::getRequestTime)
+                .last("LIMIT " + MAX_DASHBOARD_SAMPLE);
+        if (StringUtils.hasText(appId)) {
+            wrapper.eq(OpenApiRequestLog::getAppId, appId.trim());
+        }
+        List<OpenApiRequestLog> logs = requestLogMapper.selectList(wrapper);
+
+        long total = logs.size();
+        long successCount = logs.stream().filter(item -> Boolean.TRUE.equals(item.getSuccess())).count();
+        long failureCount = total - successCount;
+        long averageDurationMs = Math.round(logs.stream()
+                .filter(item -> item.getDurationMs() != null)
+                .mapToLong(OpenApiRequestLog::getDurationMs)
+                .average()
+                .orElse(0));
+        long p95DurationMs = percentile95(logs);
+        double successRate = total == 0 ? 0D : round2(successCount * 100D / total);
+
+        Map<String, Long> apiCounts = countAndSort(
+                logs, OpenApiRequestLog::getApiCode, 8, true
+        );
+        Map<String, Long> errorCounts = countAndSort(
+                logs.stream().filter(item -> !Boolean.TRUE.equals(item.getSuccess())).toList(),
+                item -> StringUtils.hasText(item.getResponseCode()) ? item.getResponseCode() : "UNKNOWN",
+                8,
+                false
+        );
+
+        return ApiResponse.success(new DashboardView(
+                safeHours,
+                total,
+                successCount,
+                failureCount,
+                successRate,
+                averageDurationMs,
+                p95DurationMs,
+                apiCounts,
+                errorCounts,
+                total >= MAX_DASHBOARD_SAMPLE
+        ));
+    }
+
+    private LambdaQueryWrapper<OpenApiRequestLog> buildLogWrapper(
+            String requestId,
+            String appId,
+            String apiCode,
+            String clientIp,
+            String responseCode,
+            Boolean success,
+            LocalDateTime startTime,
+            LocalDateTime endTime) {
+        LambdaQueryWrapper<OpenApiRequestLog> wrapper = new LambdaQueryWrapper<>();
+        if (StringUtils.hasText(requestId)) {
+            wrapper.eq(OpenApiRequestLog::getRequestId, requestId.trim());
+        }
+        if (StringUtils.hasText(appId)) {
+            wrapper.eq(OpenApiRequestLog::getAppId, appId.trim());
+        }
+        if (StringUtils.hasText(apiCode)) {
+            wrapper.eq(OpenApiRequestLog::getApiCode, apiCode.trim());
+        }
+        if (StringUtils.hasText(clientIp)) {
+            wrapper.eq(OpenApiRequestLog::getClientIp, clientIp.trim());
+        }
+        if (StringUtils.hasText(responseCode)) {
+            wrapper.eq(OpenApiRequestLog::getResponseCode, responseCode.trim());
+        }
+        if (success != null) {
+            wrapper.eq(OpenApiRequestLog::getSuccess, success);
+        }
+        if (startTime != null) {
+            wrapper.ge(OpenApiRequestLog::getRequestTime, startTime);
+        }
+        if (endTime != null) {
+            wrapper.le(OpenApiRequestLog::getRequestTime, endTime);
+        }
+        return wrapper;
+    }
+
+    private long percentile95(List<OpenApiRequestLog> logs) {
+        List<Long> durations = logs.stream()
+                .map(OpenApiRequestLog::getDurationMs)
+                .filter(value -> value != null && value >= 0)
+                .sorted()
+                .collect(Collectors.toCollection(ArrayList::new));
+        if (durations.isEmpty()) {
+            return 0L;
+        }
+        int index = (int) Math.ceil(durations.size() * 0.95D) - 1;
+        return durations.get(Math.max(0, Math.min(index, durations.size() - 1)));
+    }
+
+    private Map<String, Long> countAndSort(List<OpenApiRequestLog> logs,
+                                           Function<OpenApiRequestLog, String> classifier,
+                                           int limit,
+                                           boolean ignoreBlank) {
+        Map<String, Long> grouped = logs.stream()
+                .map(item -> Map.entry(item, classifier.apply(item)))
+                .filter(entry -> !ignoreBlank || StringUtils.hasText(entry.getValue()))
+                .collect(Collectors.groupingBy(
+                        entry -> StringUtils.hasText(entry.getValue()) ? entry.getValue() : "UNKNOWN",
+                        Collectors.counting()
+                ));
+        return grouped.entrySet().stream()
+                .sorted(Map.Entry.<String, Long>comparingByValue(Comparator.reverseOrder()))
+                .limit(limit)
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        Map.Entry::getValue,
+                        (left, right) -> left,
+                        LinkedHashMap::new
+                ));
+    }
+
+    private OpenApiApp requireApp(Long id) {
+        OpenApiApp app = appMapper.selectById(id);
+        if (app == null) {
+            throw new OpenApiCallException("OPENAPI_40401", "应用不存在", 404);
+        }
+        return app;
+    }
+
+    private OpenApiGrant requireGrant(Long id) {
+        OpenApiGrant grant = grantMapper.selectById(id);
+        if (grant == null) {
+            throw new OpenApiCallException("OPENAPI_40401", "授权不存在", 404);
+        }
+        return grant;
+    }
+
+    private String normalizeGrantStatus(String status) {
+        String normalized = status.trim().toUpperCase();
+        if (!List.of("ENABLED", "DISABLED", "REVOKED").contains(normalized)) {
+            throw badRequest("授权状态只能是ENABLED、DISABLED或REVOKED");
+        }
+        return normalized;
+    }
+
+    private int normalizePositive(int value, int min, int max, String label) {
+        if (value < min || value > max) {
+            throw badRequest(label + "必须在" + min + "到" + max + "之间");
+        }
+        return value;
+    }
+
+    private String normalizeNullable(String value) {
+        return StringUtils.hasText(value) ? value.trim() : null;
+    }
+
+    private double round2(double value) {
+        return Math.round(value * 100D) / 100D;
+    }
+
+    private OpenApiCallException badRequest(String message) {
+        return new OpenApiCallException("OPENAPI_40001", message, 400);
+    }
+
+    public record UpdateAppRequest(
+            String appName,
+            LocalDateTime validFrom,
+            LocalDateTime validTo,
+            String ipWhitelist,
+            Integer qpsLimit,
+            Integer maxPageSize) {
+    }
+
+    public record RotateSecretResponse(
+            Long id,
+            String appId,
+            String appKey,
+            String appSecret,
+            LocalDateTime rotatedAt) {
+    }
+
+    public record UpdateGrantRequest(
+            String status,
+            String dataPermissionJson,
+            String fieldPermissionJson,
+            LocalDateTime validFrom,
+            LocalDateTime validTo) {
+    }
+
+    public record DashboardView(
+            int hours,
+            long total,
+            long successCount,
+            long failureCount,
+            double successRate,
+            long averageDurationMs,
+            long p95DurationMs,
+            Map<String, Long> topApis,
+            Map<String, Long> errorCodes,
+            boolean sampleTruncated) {
+    }
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/controller/OpenApiGovernanceController.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/controller/OpenApiGovernanceController.java
@@ -30,7 +30,6 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -188,16 +187,6 @@ public class OpenApiGovernanceController {
         long p95DurationMs = percentile95(logs);
         double successRate = total == 0 ? 0D : round2(successCount * 100D / total);
 
-        Map<String, Long> apiCounts = countAndSort(
-                logs, OpenApiRequestLog::getApiCode, 8, true
-        );
-        Map<String, Long> errorCounts = countAndSort(
-                logs.stream().filter(item -> !Boolean.TRUE.equals(item.getSuccess())).toList(),
-                item -> StringUtils.hasText(item.getResponseCode()) ? item.getResponseCode() : "UNKNOWN",
-                8,
-                false
-        );
-
         return ApiResponse.success(new DashboardView(
                 safeHours,
                 total,
@@ -206,8 +195,8 @@ public class OpenApiGovernanceController {
                 successRate,
                 averageDurationMs,
                 p95DurationMs,
-                apiCounts,
-                errorCounts,
+                countTopApis(logs),
+                countErrorCodes(logs),
                 total >= MAX_DASHBOARD_SAMPLE
         ));
     }
@@ -262,17 +251,25 @@ public class OpenApiGovernanceController {
         return durations.get(Math.max(0, Math.min(index, durations.size() - 1)));
     }
 
-    private Map<String, Long> countAndSort(List<OpenApiRequestLog> logs,
-                                           Function<OpenApiRequestLog, String> classifier,
-                                           int limit,
-                                           boolean ignoreBlank) {
+    private Map<String, Long> countTopApis(List<OpenApiRequestLog> logs) {
         Map<String, Long> grouped = logs.stream()
-                .map(item -> Map.entry(item, classifier.apply(item)))
-                .filter(entry -> !ignoreBlank || StringUtils.hasText(entry.getValue()))
-                .collect(Collectors.groupingBy(
-                        entry -> StringUtils.hasText(entry.getValue()) ? entry.getValue() : "UNKNOWN",
-                        Collectors.counting()
-                ));
+                .map(OpenApiRequestLog::getApiCode)
+                .filter(StringUtils::hasText)
+                .collect(Collectors.groupingBy(value -> value, Collectors.counting()));
+        return sortCounts(grouped, 8);
+    }
+
+    private Map<String, Long> countErrorCodes(List<OpenApiRequestLog> logs) {
+        Map<String, Long> grouped = logs.stream()
+                .filter(item -> !Boolean.TRUE.equals(item.getSuccess()))
+                .map(item -> StringUtils.hasText(item.getResponseCode())
+                        ? item.getResponseCode()
+                        : "UNKNOWN")
+                .collect(Collectors.groupingBy(value -> value, Collectors.counting()));
+        return sortCounts(grouped, 8);
+    }
+
+    private Map<String, Long> sortCounts(Map<String, Long> grouped, int limit) {
         return grouped.entrySet().stream()
                 .sorted(Map.Entry.<String, Long>comparingByValue(Comparator.reverseOrder()))
                 .limit(limit)

--- a/openapi-service/src/main/java/single/cjj/openapi/controller/VoucherOpenApiController.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/controller/VoucherOpenApiController.java
@@ -46,9 +46,14 @@ public class VoucherOpenApiController {
             HttpServletRequest request) {
         OpenApiContext context = context(request);
         OpenApiPermissionService.VoucherPermission permission =
-                permissionService.resolveVoucherPermission(context.getGrant());
+                permissionService.resolveVoucherPermission(context.getApp(), context.getGrant());
 
         String status = resolveStatus(query.getStatus(), permission.allowedStatuses());
+        String organizationId = resolveScope(
+                query.getOrganizationId(), permission.organizationIds(), "组织"
+        );
+        String bookId = resolveScope(query.getBookId(), permission.bookIds(), "账簿");
+
         LocalDate today = LocalDate.now();
         LocalDate cutoff = today.minusMonths(permission.maxHistoryMonths());
         LocalDate startDate = query.getStartDate() == null || query.getStartDate().isBefore(cutoff)
@@ -70,9 +75,14 @@ public class VoucherOpenApiController {
                 pageSize,
                 query.getVoucherNumber(),
                 status,
+                organizationId,
+                bookId,
                 startDate.toString(),
                 endDate.toString(),
-                statusHeader(permission.allowedStatuses())
+                permission.tenantId(),
+                scopeHeader(permission.allowedStatuses()),
+                scopeHeader(permission.organizationIds()),
+                scopeHeader(permission.bookIds())
         );
         return OpenApiEnvelope.success(context.getRequestId(), unwrap(response));
     }
@@ -83,7 +93,7 @@ public class VoucherOpenApiController {
             HttpServletRequest request) {
         OpenApiContext context = context(request);
         OpenApiPermissionService.VoucherPermission permission =
-                permissionService.resolveVoucherPermission(context.getGrant());
+                permissionService.resolveVoucherPermission(context.getApp(), context.getGrant());
         OpenVoucherResponse voucher = loadAndValidateVoucher(voucherId, permission);
         return OpenApiEnvelope.success(context.getRequestId(), voucher);
     }
@@ -94,11 +104,14 @@ public class VoucherOpenApiController {
             HttpServletRequest request) {
         OpenApiContext context = context(request);
         OpenApiPermissionService.VoucherPermission permission =
-                permissionService.resolveVoucherPermission(context.getGrant());
+                permissionService.resolveVoucherPermission(context.getApp(), context.getGrant());
         loadAndValidateVoucher(voucherId, permission);
         ApiResponse<List<OpenVoucherLineResponse>> response = voucherClient.lines(
                 voucherId,
-                statusHeader(permission.allowedStatuses())
+                permission.tenantId(),
+                scopeHeader(permission.allowedStatuses()),
+                scopeHeader(permission.organizationIds()),
+                scopeHeader(permission.bookIds())
         );
         return OpenApiEnvelope.success(context.getRequestId(), unwrap(response));
     }
@@ -108,7 +121,10 @@ public class VoucherOpenApiController {
             OpenApiPermissionService.VoucherPermission permission) {
         ApiResponse<OpenVoucherResponse> response = voucherClient.detail(
                 voucherId,
-                statusHeader(permission.allowedStatuses())
+                permission.tenantId(),
+                scopeHeader(permission.allowedStatuses()),
+                scopeHeader(permission.organizationIds()),
+                scopeHeader(permission.bookIds())
         );
         OpenVoucherResponse voucher = unwrap(response);
         if (voucher == null) {
@@ -132,6 +148,19 @@ public class VoucherOpenApiController {
         return allowedStatuses.iterator().next();
     }
 
+    private String resolveScope(String requestedValue, Set<String> allowedValues, String label) {
+        if (!StringUtils.hasText(requestedValue)) {
+            return null;
+        }
+        String normalized = requestedValue.trim();
+        if (!allowedValues.contains("*") && !allowedValues.contains(normalized)) {
+            throw new OpenApiCallException(
+                    "OPENAPI_40303", "请求的" + label + "不在授权范围内", 403
+            );
+        }
+        return normalized;
+    }
+
     private int resolvePageSizeLimit(OpenApiContext context) {
         int appLimit = context.getApp().getMaxPageSize() == null || context.getApp().getMaxPageSize() <= 0
                 ? 200
@@ -143,8 +172,8 @@ public class VoucherOpenApiController {
         return Math.max(1, Math.min(systemMaxPageSize, Math.min(appLimit, apiLimit)));
     }
 
-    private String statusHeader(Set<String> statuses) {
-        return statuses.stream().sorted().collect(Collectors.joining(","));
+    private String scopeHeader(Set<String> values) {
+        return values.stream().sorted().collect(Collectors.joining(","));
     }
 
     private OpenApiContext context(HttpServletRequest request) {

--- a/openapi-service/src/main/java/single/cjj/openapi/service/OpenApiPermissionService.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/service/OpenApiPermissionService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
+import single.cjj.openapi.entity.OpenApiApp;
 import single.cjj.openapi.entity.OpenApiGrant;
 import single.cjj.openapi.exception.OpenApiCallException;
 
@@ -14,6 +15,7 @@ import java.util.Set;
 public class OpenApiPermissionService {
 
     private static final Set<String> VOUCHER_API_MAX_STATUSES = Set.of("POSTED");
+    private static final Set<String> WILDCARD_SCOPE = Set.of("*");
     private static final int DEFAULT_HISTORY_MONTHS = 24;
 
     private final ObjectMapper objectMapper;
@@ -22,8 +24,14 @@ public class OpenApiPermissionService {
         this.objectMapper = objectMapper;
     }
 
-    public VoucherPermission resolveVoucherPermission(OpenApiGrant grant) {
+    public VoucherPermission resolveVoucherPermission(OpenApiApp app, OpenApiGrant grant) {
+        if (app == null || !StringUtils.hasText(app.getTenantId())) {
+            throw new OpenApiCallException("OPENAPI_50001", "应用租户配置缺失", 500);
+        }
+
         Set<String> statuses = new LinkedHashSet<>(VOUCHER_API_MAX_STATUSES);
+        Set<String> organizationIds = new LinkedHashSet<>(WILDCARD_SCOPE);
+        Set<String> bookIds = new LinkedHashSet<>(WILDCARD_SCOPE);
         int maxHistoryMonths = DEFAULT_HISTORY_MONTHS;
 
         if (grant != null && StringUtils.hasText(grant.getDataPermissionJson())) {
@@ -39,8 +47,12 @@ public class OpenApiPermissionService {
                     });
                     statuses.retainAll(requested);
                 }
+                organizationIds = parseScope(root.path("organizationIds"));
+                bookIds = parseScope(root.path("bookIds"));
                 int configuredMonths = root.path("maxHistoryMonths").asInt(DEFAULT_HISTORY_MONTHS);
                 maxHistoryMonths = Math.max(1, Math.min(configuredMonths, 120));
+            } catch (OpenApiCallException e) {
+                throw e;
             } catch (Exception e) {
                 throw new OpenApiCallException("OPENAPI_50001", "应用数据权限配置格式错误", 500);
             }
@@ -49,9 +61,47 @@ public class OpenApiPermissionService {
         if (statuses.isEmpty()) {
             throw new OpenApiCallException("OPENAPI_40303", "应用没有可查询的凭证状态", 403);
         }
-        return new VoucherPermission(statuses, maxHistoryMonths);
+        if (organizationIds.isEmpty() || bookIds.isEmpty()) {
+            throw new OpenApiCallException("OPENAPI_40303", "应用没有可查询的组织或账簿范围", 403);
+        }
+        return new VoucherPermission(
+                app.getTenantId().trim(),
+                statuses,
+                organizationIds,
+                bookIds,
+                maxHistoryMonths
+        );
     }
 
-    public record VoucherPermission(Set<String> allowedStatuses, int maxHistoryMonths) {
+    private Set<String> parseScope(JsonNode node) {
+        if (!node.isArray() || node.isEmpty()) {
+            return new LinkedHashSet<>(WILDCARD_SCOPE);
+        }
+        Set<String> result = new LinkedHashSet<>();
+        node.forEach(item -> {
+            if (item.isTextual() && StringUtils.hasText(item.asText())) {
+                result.add(item.asText().trim());
+            }
+        });
+        if (result.contains("*")) {
+            return new LinkedHashSet<>(WILDCARD_SCOPE);
+        }
+        return result;
+    }
+
+    public record VoucherPermission(
+            String tenantId,
+            Set<String> allowedStatuses,
+            Set<String> organizationIds,
+            Set<String> bookIds,
+            int maxHistoryMonths) {
+
+        public boolean allowsOrganization(String organizationId) {
+            return organizationIds.contains("*") || organizationIds.contains(organizationId);
+        }
+
+        public boolean allowsBook(String bookId) {
+            return bookIds.contains("*") || bookIds.contains(bookId);
+        }
     }
 }

--- a/openapi-service/src/main/java/single/cjj/openapi/service/OpenApiSecretService.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/service/OpenApiSecretService.java
@@ -27,15 +27,19 @@ public class OpenApiSecretService {
     }
 
     public GeneratedCredential generateCredential() {
-        byte[] secretBytes = new byte[32];
         byte[] keyBytes = new byte[18];
-        secureRandom.nextBytes(secretBytes);
         secureRandom.nextBytes(keyBytes);
-
-        String appSecret = Base64.getUrlEncoder().withoutPadding().encodeToString(secretBytes);
+        GeneratedSecret secret = generateSecret();
         String appKey = "mk_" + Base64.getUrlEncoder().withoutPadding().encodeToString(keyBytes);
         String appId = "app_" + UUID.randomUUID().toString().replace("-", "");
-        return new GeneratedCredential(appId, appKey, appSecret, encrypt(appSecret));
+        return new GeneratedCredential(appId, appKey, secret.appSecret(), secret.appSecretCipher());
+    }
+
+    public GeneratedSecret generateSecret() {
+        byte[] secretBytes = new byte[32];
+        secureRandom.nextBytes(secretBytes);
+        String appSecret = Base64.getUrlEncoder().withoutPadding().encodeToString(secretBytes);
+        return new GeneratedSecret(appSecret, encrypt(appSecret));
     }
 
     public String encrypt(String plainText) {
@@ -84,5 +88,8 @@ public class OpenApiSecretService {
     }
 
     public record GeneratedCredential(String appId, String appKey, String appSecret, String appSecretCipher) {
+    }
+
+    public record GeneratedSecret(String appSecret, String appSecretCipher) {
     }
 }

--- a/openapi-service/src/test/java/single/cjj/openapi/service/OpenApiPermissionServiceTest.java
+++ b/openapi-service/src/test/java/single/cjj/openapi/service/OpenApiPermissionServiceTest.java
@@ -1,0 +1,70 @@
+package single.cjj.openapi.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import single.cjj.openapi.entity.OpenApiApp;
+import single.cjj.openapi.entity.OpenApiGrant;
+import single.cjj.openapi.exception.OpenApiCallException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OpenApiPermissionServiceTest {
+
+    private final OpenApiPermissionService service = new OpenApiPermissionService(new ObjectMapper());
+
+    @Test
+    void shouldResolveTenantOrganizationAndBookScopes() {
+        OpenApiApp app = new OpenApiApp();
+        app.setTenantId("tenant-a");
+        OpenApiGrant grant = new OpenApiGrant();
+        grant.setDataPermissionJson("""
+                {
+                  "allowedStatuses": ["POSTED"],
+                  "organizationIds": ["ORG-001", "ORG-002"],
+                  "bookIds": ["BOOK-001"],
+                  "maxHistoryMonths": 18
+                }
+                """);
+
+        OpenApiPermissionService.VoucherPermission permission =
+                service.resolveVoucherPermission(app, grant);
+
+        assertEquals("tenant-a", permission.tenantId());
+        assertEquals(18, permission.maxHistoryMonths());
+        assertTrue(permission.allowedStatuses().contains("POSTED"));
+        assertTrue(permission.allowsOrganization("ORG-002"));
+        assertFalse(permission.allowsOrganization("ORG-999"));
+        assertTrue(permission.allowsBook("BOOK-001"));
+    }
+
+    @Test
+    void shouldTreatMissingOrganizationAndBookScopesAsTenantWildcard() {
+        OpenApiApp app = new OpenApiApp();
+        app.setTenantId("default");
+        OpenApiGrant grant = new OpenApiGrant();
+        grant.setDataPermissionJson("{\"allowedStatuses\":[\"POSTED\"]}");
+
+        OpenApiPermissionService.VoucherPermission permission =
+                service.resolveVoucherPermission(app, grant);
+
+        assertTrue(permission.allowsOrganization("ANY-ORG"));
+        assertTrue(permission.allowsBook("ANY-BOOK"));
+    }
+
+    @Test
+    void shouldRejectStatusesOutsideSystemMaximum() {
+        OpenApiApp app = new OpenApiApp();
+        app.setTenantId("default");
+        OpenApiGrant grant = new OpenApiGrant();
+        grant.setDataPermissionJson("{\"allowedStatuses\":[\"DRAFT\"]}");
+
+        OpenApiCallException exception = assertThrows(
+                OpenApiCallException.class,
+                () -> service.resolveVoucherPermission(app, grant)
+        );
+        assertEquals("OPENAPI_40303", exception.getCode());
+    }
+}

--- a/sql/matrix_open_api_v2.sql
+++ b/sql/matrix_open_api_v2.sql
@@ -1,0 +1,28 @@
+-- Matrix OpenAPI V2
+-- 第二阶段：治理、调用日志、租户/组织/账簿数据权限
+
+ALTER TABLE bizfi_fi_voucher
+    ADD COLUMN tenant_id VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '租户' AFTER fid,
+    ADD COLUMN org_id VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '业务组织' AFTER tenant_id,
+    ADD COLUMN book_id VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '账簿' AFTER org_id,
+    ADD KEY idx_voucher_openapi_scope (tenant_id, org_id, book_id, fstatus, fdate),
+    ADD KEY idx_voucher_openapi_number (tenant_id, fnumber);
+
+UPDATE bizfi_fi_voucher
+SET tenant_id = COALESCE(NULLIF(tenant_id, ''), 'default'),
+    org_id = COALESCE(NULLIF(org_id, ''), 'default'),
+    book_id = COALESCE(NULLIF(book_id, ''), 'default');
+
+ALTER TABLE matrix_open_api_request_log
+    ADD KEY idx_open_api_log_success_time (success, request_time),
+    ADD KEY idx_open_api_log_code_time (response_code, request_time),
+    ADD KEY idx_open_api_log_ip_time (client_ip, request_time);
+
+-- 旧授权未配置组织/账簿时按租户内全范围处理。
+-- 新授权建议显式写入：
+-- {
+--   "allowedStatuses": ["POSTED"],
+--   "organizationIds": ["ORG-001"],
+--   "bookIds": ["BOOK-001"],
+--   "maxHistoryMonths": 24
+-- }


### PR DESCRIPTION
This draft was replaced by PR #32, which replays the same 14 OpenAPI governance changes on a newer `dev` baseline. Do not merge this historical branch.