### PR TITLE
feat: add workflow return resubmit and cancel lifecycle

### DIFF
--- a/docs/business/workflow/workflow-phase2-resubmit.md
+++ b/docs/business/workflow/workflow-phase2-resubmit.md
@@ -1,0 +1,174 @@
+# Workflow Phase 2: Return, Resubmit and Cancel
+
+## Scope
+
+This phase completes the document correction loop on top of the workflow MVP:
+
+```text
+RUNNING
+  ├─ APPROVE → next node / COMPLETED
+  ├─ REJECT → REJECTED
+  ├─ RETURN_TO_INITIATOR → WAITING_RESUBMIT
+  └─ CANCEL by initiator → CANCELLED
+
+WAITING_RESUBMIT
+  ├─ RESUBMIT → RUNNING at the original approval node
+  └─ CANCEL by initiator → CANCELLED
+```
+
+The workflow definition is not changed when a task is returned. The engine records the original approval node in reserved runtime variables and creates a synthetic `__RESUBMIT__` task assigned to the initiator.
+
+## New task action
+
+### Return to initiator
+
+```http
+POST /api/workflow/tasks/{taskId}/actions
+X-Request-Id: return-expense-001
+Content-Type: application/json
+```
+
+```json
+{
+  "action": "RETURN_TO_INITIATOR",
+  "operatorId": "reviewer-1001",
+  "comment": "The invoice image is unreadable",
+  "variables": {}
+}
+```
+
+Effects:
+
+1. The current approval task becomes `RETURNED`.
+2. The current node instance becomes `COMPLETED` with the return action in its output.
+3. The workflow instance changes from `RUNNING` to `WAITING_RESUBMIT`.
+4. A synthetic `__RESUBMIT__` task is created for the initiator.
+5. `INSTANCE_RETURNED` is written to the Outbox in the same transaction.
+
+## Resubmit API
+
+```http
+POST /api/workflow/instances/{instanceId}/resubmit
+X-Request-Id: resubmit-expense-001
+Content-Type: application/json
+```
+
+```json
+{
+  "operatorId": "initiator-2001",
+  "comment": "Invoice image replaced",
+  "variables": {
+    "attachmentCount": 3,
+    "amount": 12000
+  }
+}
+```
+
+Rules:
+
+- Only the workflow initiator may resubmit.
+- The instance must be in `WAITING_RESUBMIT`.
+- The open `__RESUBMIT__` task is completed with status `RESUBMITTED` using optimistic locking.
+- The instance returns to the approval node that issued the return.
+- A fresh approval node instance and task are created; the historical returned task is never reused.
+- `INSTANCE_RESUBMITTED` is written to the Outbox.
+
+## Cancel API
+
+```http
+POST /api/workflow/instances/{instanceId}/cancel
+X-Request-Id: cancel-expense-001
+Content-Type: application/json
+```
+
+```json
+{
+  "operatorId": "initiator-2001",
+  "reason": "The business document was voided"
+}
+```
+
+Rules:
+
+- Only the initiator may cancel.
+- Cancellation is allowed in `RUNNING` and `WAITING_RESUBMIT`.
+- The instance update uses `status + version` as the compare-and-set condition.
+- All open tasks and active node instances are marked `CANCELLED` in the same transaction.
+- `INSTANCE_CANCELLED` is written to the Outbox.
+
+## Runtime states
+
+### Workflow instance
+
+| Status | Meaning |
+|---|---|
+| `RUNNING` | The process has an active approval or automatic node |
+| `WAITING_RESUBMIT` | The initiator must modify the business document and resubmit |
+| `COMPLETED` | The process reached an end node successfully |
+| `REJECTED` | An approver rejected the whole process |
+| `CANCELLED` | The initiator cancelled the process |
+
+### Task
+
+| Status | Meaning |
+|---|---|
+| `PENDING` | Waiting for processing |
+| `CLAIMED` | Claimed by a processor |
+| `APPROVED` | Approval completed successfully |
+| `REJECTED` | Approval rejected the process |
+| `RETURNED` | Approval returned the document to the initiator |
+| `RESUBMITTED` | Initiator completed the correction task |
+| `CANCELLED` | Task closed because the workflow was cancelled |
+
+## Callback events
+
+Business systems can receive the following additional events through the existing Outbox dispatcher:
+
+```text
+INSTANCE_RETURNED
+INSTANCE_RESUBMITTED
+INSTANCE_CANCELLED
+```
+
+The payload includes:
+
+```json
+{
+  "eventId": "...",
+  "eventType": "INSTANCE_RETURNED",
+  "instanceId": "...",
+  "tenantId": "default",
+  "sourceSystem": "fi-service",
+  "businessType": "expense_claim",
+  "businessId": "EXP-20260722-001",
+  "status": "WAITING_RESUBMIT",
+  "variables": {},
+  "occurredAt": "2026-07-22T17:00:00"
+}
+```
+
+Recommended business status mapping:
+
+| Event | Business status |
+|---|---|
+| `INSTANCE_RETURNED` | `RETURNED` |
+| `INSTANCE_RESUBMITTED` | `APPROVING` |
+| `INSTANCE_CANCELLED` | `CANCELLED` or `DRAFT`, according to business rules |
+
+## Concurrency guarantees
+
+- Approval, return and resubmit tasks use conditional updates on `task.status` and `task.version`.
+- Return, resubmit and cancel instance transitions use conditional updates on `instance.status` and `instance.version`.
+- Historical tasks are immutable after completion; resubmission creates a new approval task.
+- Instance state changes, action logs, tasks and Outbox events are committed in one local database transaction.
+
+## Deferred items
+
+The following remain outside this phase:
+
+- Return to an arbitrary earlier node
+- Transfer, add-sign, countersign and parallel gateways
+- Attachment metadata and presigned upload APIs
+- Role membership verification through Auth Service
+- Callback HMAC signatures
+- Business document integration in `fi-service`

--- a/workflow-service/src/main/java/single/cjj/workflow/api/WorkflowContracts.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/api/WorkflowContracts.java
@@ -61,9 +61,26 @@ public final class WorkflowContracts {
         }
     }
 
+    public record ResubmitInstanceRequest(
+            @NotBlank String operatorId,
+            String comment,
+            Map<String, Object> variables
+    ) {
+        public Map<String, Object> safeVariables() {
+            return variables == null ? Map.of() : variables;
+        }
+    }
+
+    public record CancelInstanceRequest(
+            @NotBlank String operatorId,
+            String reason
+    ) {
+    }
+
     public enum TaskAction {
         APPROVE,
-        REJECT
+        REJECT,
+        RETURN_TO_INITIATOR
     }
 
     public record InstanceResponse(
@@ -77,6 +94,7 @@ public final class WorkflowContracts {
             String initiatorId,
             String currentNodeKey,
             String status,
+            int version,
             Map<String, Object> variables,
             LocalDateTime startedAt,
             LocalDateTime endedAt

--- a/workflow-service/src/main/java/single/cjj/workflow/controller/WorkflowInstanceController.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/controller/WorkflowInstanceController.java
@@ -30,6 +30,22 @@ public class WorkflowInstanceController {
         return ApiResponse.success(workflowService.startWorkflow(request, idempotencyKey));
     }
 
+    @PostMapping("/instances/{instanceId}/resubmit")
+    public ApiResponse<WorkflowContracts.InstanceResponse> resubmit(
+            @PathVariable("instanceId") String instanceId,
+            @RequestHeader(value = "X-Request-Id", required = false) String requestId,
+            @Valid @RequestBody WorkflowContracts.ResubmitInstanceRequest request) {
+        return ApiResponse.success(workflowService.resubmitInstance(instanceId, request, requestId));
+    }
+
+    @PostMapping("/instances/{instanceId}/cancel")
+    public ApiResponse<WorkflowContracts.InstanceResponse> cancel(
+            @PathVariable("instanceId") String instanceId,
+            @RequestHeader(value = "X-Request-Id", required = false) String requestId,
+            @Valid @RequestBody WorkflowContracts.CancelInstanceRequest request) {
+        return ApiResponse.success(workflowService.cancelInstance(instanceId, request, requestId));
+    }
+
     @GetMapping("/instances/{instanceId}")
     public ApiResponse<WorkflowContracts.InstanceResponse> get(
             @PathVariable("instanceId") String instanceId) {

--- a/workflow-service/src/main/java/single/cjj/workflow/repository/WorkflowRepository.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/repository/WorkflowRepository.java
@@ -154,6 +154,14 @@ public class WorkflowRepository {
                 """, outputJson, nodeInstanceId);
     }
 
+    public int cancelActiveNodes(String instanceId) {
+        return jdbcTemplate.update("""
+                UPDATE wf_node_instance
+                SET status = 'CANCELLED', ended_at = NOW()
+                WHERE instance_id = ? AND status = 'ACTIVE'
+                """, instanceId);
+    }
+
     public void insertTask(TaskRow row) {
         jdbcTemplate.update("""
                 INSERT INTO wf_task
@@ -170,12 +178,29 @@ public class WorkflowRepository {
                 this::mapTask, taskId));
     }
 
+    public Optional<TaskRow> findOpenTaskByInstanceAndNode(String instanceId, String nodeKey) {
+        return first(jdbcTemplate.query("""
+                SELECT * FROM wf_task
+                WHERE instance_id = ? AND node_key = ? AND status IN ('PENDING', 'CLAIMED')
+                ORDER BY created_at DESC
+                LIMIT 1
+                """, this::mapTask, instanceId, nodeKey));
+    }
+
     public int completeTask(String taskId, int expectedVersion, String terminalStatus) {
         return jdbcTemplate.update("""
                 UPDATE wf_task
                 SET status = ?, version = version + 1, completed_at = NOW()
                 WHERE id = ? AND status IN ('PENDING', 'CLAIMED') AND version = ?
                 """, terminalStatus, taskId, expectedVersion);
+    }
+
+    public int cancelOpenTasks(String instanceId) {
+        return jdbcTemplate.update("""
+                UPDATE wf_task
+                SET status = 'CANCELLED', version = version + 1, completed_at = NOW()
+                WHERE instance_id = ? AND status IN ('PENDING', 'CLAIMED')
+                """, instanceId);
     }
 
     public void updateInstancePosition(String instanceId,
@@ -186,6 +211,40 @@ public class WorkflowRepository {
                 SET current_node_key = ?, variables_json = CAST(? AS JSON), version = version + 1
                 WHERE id = ? AND status = 'RUNNING'
                 """, currentNodeKey, variablesJson, instanceId);
+    }
+
+    public int returnInstanceToInitiator(String instanceId,
+                                         int expectedVersion,
+                                         String variablesJson) {
+        return jdbcTemplate.update("""
+                UPDATE wf_instance
+                SET status = 'WAITING_RESUBMIT', current_node_key = '__RESUBMIT__',
+                    variables_json = CAST(? AS JSON), version = version + 1
+                WHERE id = ? AND status = 'RUNNING' AND version = ?
+                """, variablesJson, instanceId, expectedVersion);
+    }
+
+    public int resumeInstance(String instanceId,
+                              int expectedVersion,
+                              String resumeNodeKey,
+                              String variablesJson) {
+        return jdbcTemplate.update("""
+                UPDATE wf_instance
+                SET status = 'RUNNING', current_node_key = ?, variables_json = CAST(? AS JSON),
+                    ended_at = NULL, version = version + 1
+                WHERE id = ? AND status = 'WAITING_RESUBMIT' AND version = ?
+                """, resumeNodeKey, variablesJson, instanceId, expectedVersion);
+    }
+
+    public int cancelInstance(String instanceId,
+                              int expectedVersion,
+                              String variablesJson) {
+        return jdbcTemplate.update("""
+                UPDATE wf_instance
+                SET status = 'CANCELLED', current_node_key = NULL,
+                    variables_json = CAST(? AS JSON), ended_at = NOW(), version = version + 1
+                WHERE id = ? AND status IN ('RUNNING', 'WAITING_RESUBMIT') AND version = ?
+                """, variablesJson, instanceId, expectedVersion);
     }
 
     public int finishInstance(String instanceId,

--- a/workflow-service/src/main/java/single/cjj/workflow/service/WorkflowService.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/service/WorkflowService.java
@@ -16,9 +16,9 @@ import single.cjj.workflow.repository.WorkflowRepository;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -27,8 +27,16 @@ import java.util.UUID;
 public class WorkflowService {
 
     private static final String INSTANCE_RUNNING = "RUNNING";
+    private static final String INSTANCE_WAITING_RESUBMIT = "WAITING_RESUBMIT";
     private static final String INSTANCE_COMPLETED = "COMPLETED";
     private static final String INSTANCE_REJECTED = "REJECTED";
+    private static final String INSTANCE_CANCELLED = "CANCELLED";
+
+    private static final String RESUBMIT_NODE_KEY = "__RESUBMIT__";
+    private static final String VAR_RESUME_NODE_KEY = "_workflowResumeNodeKey";
+    private static final String VAR_RETURNED_BY = "_workflowReturnedBy";
+    private static final String VAR_RETURN_COMMENT = "_workflowReturnComment";
+    private static final String VAR_RETURNED_AT = "_workflowReturnedAt";
 
     private final WorkflowRepository repository;
     private final WorkflowConditionEvaluator conditionEvaluator;
@@ -182,30 +190,125 @@ public class WorkflowService {
 
         Map<String, Object> variables = readMap(instance.variablesJson());
         variables.putAll(request.safeVariables());
-        String taskTerminalStatus = request.action() == WorkflowContracts.TaskAction.APPROVE
-                ? "APPROVED" : "REJECTED";
+        String taskTerminalStatus = switch (request.action()) {
+            case APPROVE -> "APPROVED";
+            case REJECT -> "REJECTED";
+            case RETURN_TO_INITIATOR -> "RETURNED";
+        };
         int affected = repository.completeTask(taskId, task.version(), taskTerminalStatus);
         if (affected != 1) {
             throw new BizException("任务已被其他请求处理，请刷新后重试");
         }
-        repository.completeNode(task.nodeInstanceId(), writeJson(Map.of(
-                "action", request.action().name(),
-                "operatorId", request.operatorId()
-        )));
+
+        Map<String, Object> nodeOutput = new LinkedHashMap<>();
+        nodeOutput.put("action", request.action().name());
+        nodeOutput.put("operatorId", request.operatorId());
+        nodeOutput.put("comment", request.comment());
+        repository.completeNode(task.nodeInstanceId(), writeJson(nodeOutput));
         repository.insertActionLog(
                 newId(), instance.id(), task.id(), request.action().name(),
                 request.operatorId(), request.comment(), task.status(), taskTerminalStatus, requestId
         );
 
-        if (request.action() == WorkflowContracts.TaskAction.REJECT) {
-            int finished = repository.finishInstance(instance.id(), INSTANCE_REJECTED, writeJson(variables));
-            if (finished != 1) {
-                throw new BizException("流程实例状态已变化，请刷新后重试");
-            }
-            emitTerminalEvent(instance, INSTANCE_REJECTED, variables);
-        } else {
-            advanceFrom(instance, definition, task.nodeKey(), variables);
+        switch (request.action()) {
+            case REJECT -> rejectInstance(instance, variables);
+            case RETURN_TO_INITIATOR -> returnToInitiator(instance, task, request, variables);
+            case APPROVE -> advanceFrom(instance, definition, task.nodeKey(), variables);
         }
+        return getInstance(instance.id());
+    }
+
+    @Transactional
+    public WorkflowContracts.InstanceResponse resubmitInstance(
+            String instanceId,
+            WorkflowContracts.ResubmitInstanceRequest request,
+            String requestId) {
+        WorkflowRepository.InstanceRow instance = repository.findInstance(instanceId)
+                .orElseThrow(() -> new BizException("流程实例不存在"));
+        if (!INSTANCE_WAITING_RESUBMIT.equals(instance.status())) {
+            throw new BizException("只有待重新提交的流程可以执行重提");
+        }
+        validateInitiator(instance, request.operatorId());
+
+        WorkflowRepository.TaskRow resubmitTask = repository
+                .findOpenTaskByInstanceAndNode(instanceId, RESUBMIT_NODE_KEY)
+                .orElseThrow(() -> new BizException("重新提交任务不存在或已经处理"));
+        int completed = repository.completeTask(resubmitTask.id(), resubmitTask.version(), "RESUBMITTED");
+        if (completed != 1) {
+            throw new BizException("重新提交任务已被其他请求处理，请刷新后重试");
+        }
+
+        Map<String, Object> variables = readMap(instance.variablesJson());
+        Object resumeNodeValue = variables.remove(VAR_RESUME_NODE_KEY);
+        if (resumeNodeValue == null || !StringUtils.hasText(String.valueOf(resumeNodeValue))) {
+            throw new BizException("流程缺少重新进入的目标节点");
+        }
+        String resumeNodeKey = String.valueOf(resumeNodeValue);
+        variables.remove(VAR_RETURNED_BY);
+        variables.remove(VAR_RETURN_COMMENT);
+        variables.remove(VAR_RETURNED_AT);
+        variables.putAll(request.safeVariables());
+        variables.put("lastResubmittedAt", LocalDateTime.now().toString());
+
+        WorkflowRepository.DefinitionVersionRow definitionRow = repository
+                .findDefinition(instance.tenantId(), instance.definitionKey(), instance.definitionVersion())
+                .orElseThrow(() -> new BizException("流程实例对应的定义版本不存在"));
+        WorkflowDefinition definition = readDefinition(definitionRow.definitionJson());
+        WorkflowDefinition.Node resumeNode = definition.requireNode(resumeNodeKey);
+        if (resumeNode.getType() != WorkflowDefinition.NodeType.USER_TASK) {
+            throw new BizException("重新提交目标必须是人工审批节点");
+        }
+
+        Map<String, Object> nodeOutput = new LinkedHashMap<>();
+        nodeOutput.put("action", "RESUBMIT");
+        nodeOutput.put("operatorId", request.operatorId());
+        nodeOutput.put("comment", request.comment());
+        repository.completeNode(resubmitTask.nodeInstanceId(), writeJson(nodeOutput));
+
+        int resumed = repository.resumeInstance(
+                instance.id(), instance.version(), resumeNodeKey, writeJson(variables)
+        );
+        if (resumed != 1) {
+            throw new BizException("流程状态已变化，请刷新后重试");
+        }
+        repository.insertActionLog(
+                newId(), instance.id(), resubmitTask.id(), "RESUBMIT", request.operatorId(),
+                request.comment(), INSTANCE_WAITING_RESUBMIT, INSTANCE_RUNNING, requestId
+        );
+        activateUserTask(instance, resumeNode, variables);
+        emitInstanceEvent(instance, "RESUBMITTED", INSTANCE_RUNNING, variables);
+        return getInstance(instance.id());
+    }
+
+    @Transactional
+    public WorkflowContracts.InstanceResponse cancelInstance(
+            String instanceId,
+            WorkflowContracts.CancelInstanceRequest request,
+            String requestId) {
+        WorkflowRepository.InstanceRow instance = repository.findInstance(instanceId)
+                .orElseThrow(() -> new BizException("流程实例不存在"));
+        if (!(INSTANCE_RUNNING.equals(instance.status())
+                || INSTANCE_WAITING_RESUBMIT.equals(instance.status()))) {
+            throw new BizException("当前流程状态不允许撤销");
+        }
+        validateInitiator(instance, request.operatorId());
+
+        Map<String, Object> variables = readMap(instance.variablesJson());
+        variables.put("cancelledBy", request.operatorId());
+        variables.put("cancelReason", request.reason());
+        variables.put("cancelledAt", LocalDateTime.now().toString());
+
+        int cancelled = repository.cancelInstance(instance.id(), instance.version(), writeJson(variables));
+        if (cancelled != 1) {
+            throw new BizException("流程状态已变化，请刷新后重试");
+        }
+        repository.cancelOpenTasks(instance.id());
+        repository.cancelActiveNodes(instance.id());
+        repository.insertActionLog(
+                newId(), instance.id(), null, "CANCEL", request.operatorId(), request.reason(),
+                instance.status(), INSTANCE_CANCELLED, requestId
+        );
+        emitInstanceEvent(instance, "CANCELLED", INSTANCE_CANCELLED, variables);
         return getInstance(instance.id());
     }
 
@@ -230,6 +333,64 @@ public class WorkflowService {
                 .orElseThrow(() -> new BizException("待办任务不存在"));
     }
 
+    private void rejectInstance(WorkflowRepository.InstanceRow instance,
+                                Map<String, Object> variables) {
+        int finished = repository.finishInstance(instance.id(), INSTANCE_REJECTED, writeJson(variables));
+        if (finished != 1) {
+            throw new BizException("流程实例状态已变化，请刷新后重试");
+        }
+        emitInstanceEvent(instance, "REJECTED", INSTANCE_REJECTED, variables);
+    }
+
+    private void returnToInitiator(WorkflowRepository.InstanceRow instance,
+                                   WorkflowRepository.TaskRow task,
+                                   WorkflowContracts.TaskActionRequest request,
+                                   Map<String, Object> variables) {
+        variables.put(VAR_RESUME_NODE_KEY, task.nodeKey());
+        variables.put(VAR_RETURNED_BY, request.operatorId());
+        variables.put(VAR_RETURN_COMMENT, request.comment());
+        variables.put(VAR_RETURNED_AT, LocalDateTime.now().toString());
+
+        int returned = repository.returnInstanceToInitiator(
+                instance.id(), instance.version(), writeJson(variables)
+        );
+        if (returned != 1) {
+            throw new BizException("流程实例状态已变化，请刷新后重试");
+        }
+        activateResubmitTask(instance, variables);
+        emitInstanceEvent(instance, "RETURNED", INSTANCE_WAITING_RESUBMIT, variables);
+    }
+
+    private void activateResubmitTask(WorkflowRepository.InstanceRow instance,
+                                      Map<String, Object> variables) {
+        String nodeInstanceId = newId();
+        repository.insertNodeInstance(new WorkflowRepository.NodeInstanceRow(
+                nodeInstanceId,
+                instance.id(),
+                RESUBMIT_NODE_KEY,
+                "修改并重新提交",
+                WorkflowDefinition.NodeType.USER_TASK.name(),
+                "ACTIVE",
+                null,
+                writeJson(variables),
+                LocalDateTime.now()
+        ));
+        repository.insertTask(new WorkflowRepository.TaskRow(
+                newId(),
+                instance.tenantId(),
+                instance.id(),
+                nodeInstanceId,
+                RESUBMIT_NODE_KEY,
+                "修改并重新提交",
+                "USER",
+                instance.initiatorId(),
+                "PENDING",
+                0,
+                LocalDateTime.now(),
+                null
+        ));
+    }
+
     private void advanceFrom(WorkflowRepository.InstanceRow instance,
                              WorkflowDefinition definition,
                              String completedNodeKey,
@@ -251,7 +412,8 @@ public class WorkflowService {
                     WorkflowNodeHandler.ExecutionResult result = handlerRegistry
                             .require(node.getHandlerKey())
                             .execute(new WorkflowNodeHandler.ExecutionContext(
-                                    instance.id(), node, Map.copyOf(variables)
+                                    instance.id(), node,
+                                    Collections.unmodifiableMap(new LinkedHashMap<>(variables))
                             ));
                     if (!result.success()) {
                         throw new BizException(result.message());
@@ -276,7 +438,7 @@ public class WorkflowService {
                     if (finished != 1) {
                         throw new BizException("流程实例状态已变化，请刷新后重试");
                     }
-                    emitTerminalEvent(instance, INSTANCE_COMPLETED, variables);
+                    emitInstanceEvent(instance, "COMPLETED", INSTANCE_COMPLETED, variables);
                     return;
                 }
             }
@@ -351,22 +513,31 @@ public class WorkflowService {
         // ROLE 类型由网关或权限服务校验角色成员关系；工作流服务保留最终任务并发校验。
     }
 
-    private void emitTerminalEvent(WorkflowRepository.InstanceRow instance,
-                                   String status,
+    private void validateInitiator(WorkflowRepository.InstanceRow instance, String operatorId) {
+        if (!instance.initiatorId().equals(operatorId)) {
+            throw new BizException("只有流程发起人可以执行该操作");
+        }
+    }
+
+    private void emitInstanceEvent(WorkflowRepository.InstanceRow instance,
+                                   String eventSuffix,
+                                   String instanceStatus,
                                    Map<String, Object> variables) {
         String eventId = newId();
+        String eventType = "INSTANCE_" + eventSuffix;
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("eventId", eventId);
-        payload.put("eventType", "INSTANCE_" + status);
+        payload.put("eventType", eventType);
         payload.put("instanceId", instance.id());
         payload.put("tenantId", instance.tenantId());
         payload.put("sourceSystem", instance.sourceSystem());
         payload.put("businessType", instance.businessType());
         payload.put("businessId", instance.businessId());
+        payload.put("status", instanceStatus);
         payload.put("callbackUrl", instance.callbackUrl());
         payload.put("variables", variables);
         payload.put("occurredAt", LocalDateTime.now().toString());
-        repository.insertOutbox(newId(), eventId, instance.id(), "INSTANCE_" + status, writeJson(payload));
+        repository.insertOutbox(newId(), eventId, instance.id(), eventType, writeJson(payload));
     }
 
     private void validateDefinition(WorkflowDefinition definition) {
@@ -430,7 +601,7 @@ public class WorkflowService {
         return new WorkflowContracts.InstanceResponse(
                 row.id(), row.tenantId(), row.definitionKey(), row.definitionVersion(),
                 row.sourceSystem(), row.businessType(), row.businessId(), row.initiatorId(),
-                row.currentNodeKey(), row.status(), readMap(row.variablesJson()),
+                row.currentNodeKey(), row.status(), row.version(), readMap(row.variablesJson()),
                 row.startedAt(), row.endedAt()
         );
     }

--- a/workflow-service/src/test/java/single/cjj/workflow/service/WorkflowServiceLifecycleTest.java
+++ b/workflow-service/src/test/java/single/cjj/workflow/service/WorkflowServiceLifecycleTest.java
@@ -1,0 +1,199 @@
+package single.cjj.workflow.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import single.cjj.workflow.api.WorkflowContracts;
+import single.cjj.workflow.engine.WorkflowConditionEvaluator;
+import single.cjj.workflow.engine.WorkflowNodeHandlerRegistry;
+import single.cjj.workflow.repository.WorkflowRepository;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WorkflowServiceLifecycleTest {
+
+    private static final String DEFINITION_JSON = """
+            {
+              "nodes": [
+                {"key":"start","name":"开始","type":"START"},
+                {"key":"firstReview","name":"初审","type":"USER_TASK",
+                 "assigneeRule":{"type":"USER","value":"reviewer-1"}},
+                {"key":"end","name":"结束","type":"END"}
+              ],
+              "transitions": [
+                {"from":"start","to":"firstReview","priority":0},
+                {"from":"firstReview","to":"end","priority":0}
+              ]
+            }
+            """;
+
+    @Mock
+    private WorkflowRepository repository;
+    @Mock
+    private WorkflowConditionEvaluator conditionEvaluator;
+    @Mock
+    private WorkflowNodeHandlerRegistry handlerRegistry;
+
+    private WorkflowService workflowService;
+
+    @BeforeEach
+    void setUp() {
+        workflowService = new WorkflowService(
+                repository, conditionEvaluator, handlerRegistry, new ObjectMapper()
+        );
+    }
+
+    @Test
+    void returnToInitiatorCreatesResubmitTask() {
+        WorkflowRepository.TaskRow reviewTask = task(
+                "task-1", "instance-1", "node-1", "firstReview", "reviewer-1", "PENDING", 0
+        );
+        WorkflowRepository.InstanceRow running = instance(
+                "instance-1", "RUNNING", "firstReview", "{}", 3
+        );
+        WorkflowRepository.InstanceRow waiting = instance(
+                "instance-1", "WAITING_RESUBMIT", "__RESUBMIT__",
+                "{\"_workflowResumeNodeKey\":\"firstReview\"}", 4
+        );
+
+        when(repository.findTask("task-1")).thenReturn(Optional.of(reviewTask));
+        when(repository.findInstance("instance-1")).thenReturn(Optional.of(running), Optional.of(waiting));
+        when(repository.findDefinition("tenant-1", "expense", 1))
+                .thenReturn(Optional.of(definitionRow()));
+        when(repository.completeTask("task-1", 0, "RETURNED")).thenReturn(1);
+        when(repository.returnInstanceToInitiator(anyString(), anyInt(), anyString())).thenReturn(1);
+
+        WorkflowContracts.InstanceResponse response = workflowService.actOnTask(
+                "task-1",
+                new WorkflowContracts.TaskActionRequest(
+                        WorkflowContracts.TaskAction.RETURN_TO_INITIATOR,
+                        "reviewer-1",
+                        "影像不清晰",
+                        Map.of()
+                ),
+                "request-return-1"
+        );
+
+        ArgumentCaptor<WorkflowRepository.TaskRow> taskCaptor =
+                ArgumentCaptor.forClass(WorkflowRepository.TaskRow.class);
+        verify(repository).insertTask(taskCaptor.capture());
+        assertThat(taskCaptor.getValue().nodeKey()).isEqualTo("__RESUBMIT__");
+        assertThat(taskCaptor.getValue().assigneeType()).isEqualTo("USER");
+        assertThat(taskCaptor.getValue().assigneeValue()).isEqualTo("initiator-1");
+        assertThat(response.status()).isEqualTo("WAITING_RESUBMIT");
+        verify(repository).insertOutbox(anyString(), anyString(), anyString(),
+                org.mockito.ArgumentMatchers.eq("INSTANCE_RETURNED"), anyString());
+    }
+
+    @Test
+    void resubmitRecreatesOriginalApprovalTask() {
+        WorkflowRepository.InstanceRow waiting = instance(
+                "instance-1", "WAITING_RESUBMIT", "__RESUBMIT__",
+                "{\"_workflowResumeNodeKey\":\"firstReview\"}", 4
+        );
+        WorkflowRepository.InstanceRow running = instance(
+                "instance-1", "RUNNING", "firstReview", "{\"amount\":12000}", 6
+        );
+        WorkflowRepository.TaskRow resubmitTask = task(
+                "task-resubmit", "instance-1", "node-resubmit", "__RESUBMIT__",
+                "initiator-1", "PENDING", 0
+        );
+
+        when(repository.findInstance("instance-1")).thenReturn(Optional.of(waiting), Optional.of(running));
+        when(repository.findOpenTaskByInstanceAndNode("instance-1", "__RESUBMIT__"))
+                .thenReturn(Optional.of(resubmitTask));
+        when(repository.completeTask("task-resubmit", 0, "RESUBMITTED")).thenReturn(1);
+        when(repository.findDefinition("tenant-1", "expense", 1))
+                .thenReturn(Optional.of(definitionRow()));
+        when(repository.resumeInstance(anyString(), anyInt(), anyString(), anyString())).thenReturn(1);
+
+        WorkflowContracts.InstanceResponse response = workflowService.resubmitInstance(
+                "instance-1",
+                new WorkflowContracts.ResubmitInstanceRequest(
+                        "initiator-1", "已补充影像", Map.of("amount", 12000)
+                ),
+                "request-resubmit-1"
+        );
+
+        ArgumentCaptor<WorkflowRepository.TaskRow> taskCaptor =
+                ArgumentCaptor.forClass(WorkflowRepository.TaskRow.class);
+        verify(repository).insertTask(taskCaptor.capture());
+        assertThat(taskCaptor.getValue().nodeKey()).isEqualTo("firstReview");
+        assertThat(taskCaptor.getValue().assigneeValue()).isEqualTo("reviewer-1");
+        assertThat(response.status()).isEqualTo("RUNNING");
+        verify(repository).insertOutbox(anyString(), anyString(), anyString(),
+                org.mockito.ArgumentMatchers.eq("INSTANCE_RESUBMITTED"), anyString());
+    }
+
+    @Test
+    void initiatorCanCancelRunningInstance() {
+        WorkflowRepository.InstanceRow running = instance(
+                "instance-1", "RUNNING", "firstReview", "{}", 3
+        );
+        WorkflowRepository.InstanceRow cancelled = instance(
+                "instance-1", "CANCELLED", null,
+                "{\"cancelReason\":\"业务单据作废\"}", 4
+        );
+
+        when(repository.findInstance("instance-1")).thenReturn(Optional.of(running), Optional.of(cancelled));
+        when(repository.cancelInstance(anyString(), anyInt(), anyString())).thenReturn(1);
+
+        WorkflowContracts.InstanceResponse response = workflowService.cancelInstance(
+                "instance-1",
+                new WorkflowContracts.CancelInstanceRequest("initiator-1", "业务单据作废"),
+                "request-cancel-1"
+        );
+
+        assertThat(response.status()).isEqualTo("CANCELLED");
+        verify(repository).cancelOpenTasks("instance-1");
+        verify(repository).cancelActiveNodes("instance-1");
+        verify(repository).insertOutbox(anyString(), anyString(), anyString(),
+                org.mockito.ArgumentMatchers.eq("INSTANCE_CANCELLED"), anyString());
+    }
+
+    private WorkflowRepository.DefinitionVersionRow definitionRow() {
+        return new WorkflowRepository.DefinitionVersionRow(
+                "tenant-1", "expense", "费用报销", 1,
+                DEFINITION_JSON, "PUBLISHED", LocalDateTime.now(), LocalDateTime.now()
+        );
+    }
+
+    private WorkflowRepository.InstanceRow instance(String id,
+                                                      String status,
+                                                      String currentNode,
+                                                      String variables,
+                                                      int version) {
+        return new WorkflowRepository.InstanceRow(
+                id, "tenant-1", "expense", 1,
+                "fi-service", "expense_claim", "EXP-1", "fi-service:expense_claim:EXP-1",
+                "idem-1", "initiator-1", currentNode, status, variables,
+                "https://example.test/callback", version, LocalDateTime.now(), null
+        );
+    }
+
+    private WorkflowRepository.TaskRow task(String id,
+                                            String instanceId,
+                                            String nodeInstanceId,
+                                            String nodeKey,
+                                            String assignee,
+                                            String status,
+                                            int version) {
+        return new WorkflowRepository.TaskRow(
+                id, "tenant-1", instanceId, nodeInstanceId, nodeKey,
+                nodeKey, "USER", assignee, status, version, LocalDateTime.now(), null
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- add `RETURN_TO_INITIATOR` as an approval task action
- add `WAITING_RESUBMIT` and `CANCELLED` workflow instance lifecycle support
- create a synthetic initiator correction task after an approval return
- add resubmit API that returns the process to the original approval node with a fresh task
- add initiator-only cancellation for running and waiting-resubmit instances
- close active tasks and node instances when cancelling
- emit `INSTANCE_RETURNED`, `INSTANCE_RESUBMITTED`, and `INSTANCE_CANCELLED` through the existing transactional Outbox
- expose instance version in API responses and use task/instance compare-and-set updates for concurrency safety
- add lifecycle unit tests and API/state documentation

## API additions

- `POST /api/workflow/instances/{instanceId}/resubmit`
- `POST /api/workflow/instances/{instanceId}/cancel`
- `POST /api/workflow/tasks/{taskId}/actions` now accepts `RETURN_TO_INITIATOR`

## Design notes

Returned approval tasks remain immutable. The engine stores the original approval node in reserved runtime variables, creates a dedicated `__RESUBMIT__` task for the initiator, and creates a new approval node instance/task after resubmission.

## Validation

- return creates an initiator resubmit task
- resubmit recreates the original approval task
- initiator cancellation closes the workflow
- existing Workflow Service CI runs `mvn -B -pl workflow-service -am test`

## Deferred

- arbitrary return-to-node
- attachment upload metadata and presigned URLs
- role membership verification through Auth Service
- callback signatures
- `fi-service` business document integration
