### PR TITLE
feat: add workflow attachment center

### DIFF
--- a/docs/business/workflow/workflow-phase2-attachments.md
+++ b/docs/business/workflow/workflow-phase2-attachments.md
@@ -1,0 +1,152 @@
+# Workflow Phase 2 — Attachment Center
+
+## Goal
+
+Provide a workflow-owned attachment metadata and relation layer without coupling workflow APIs to a specific object-storage vendor.
+
+The development provider stores bytes on the local filesystem. Upload and preview URLs are HMAC-signed and time limited. A MinIO, OSS, COS, or S3 provider can later implement `WorkflowStorageProvider` without changing the external API.
+
+## Upload lifecycle
+
+```text
+PENDING -> STORED -> UPLOADED
+```
+
+1. The business client requests an upload URL.
+2. Workflow Service creates `wf_file` and `wf_attachment_relation` records.
+3. The client performs a direct `PUT` to the signed URL.
+4. Workflow Service streams the body to the configured storage provider and verifies size/SHA-256.
+5. The client confirms the upload.
+6. Only `UPLOADED` and `CLEAN` files satisfy workflow attachment checks.
+
+## Database migration
+
+Run:
+
+```text
+workflow-service/src/main/resources/sql/workflow_v2_attachments.sql
+```
+
+It creates:
+
+- `wf_file`
+- `wf_attachment_relation`
+
+## Request an upload URL
+
+```http
+POST /api/workflow/files/upload-url
+Content-Type: application/json
+```
+
+```json
+{
+  "tenantId": "default",
+  "sourceSystem": "fi-service",
+  "businessType": "expense_claim",
+  "businessId": "EXP202607220028",
+  "categoryCode": "INVOICE",
+  "fileName": "invoice.pdf",
+  "contentType": "application/pdf",
+  "fileSize": 42861,
+  "operatorId": "10001"
+}
+```
+
+The response contains a time-limited `PUT` URL.
+
+## Upload bytes
+
+```http
+PUT {uploadUrl}
+Content-Type: application/pdf
+Content-Length: 42861
+
+<binary body>
+```
+
+## Confirm upload
+
+```http
+POST /api/workflow/files/{fileId}/confirm
+Content-Type: application/json
+```
+
+```json
+{
+  "operatorId": "10001",
+  "sha256": "optional-client-sha256"
+}
+```
+
+Confirmation is idempotent. The response contains a time-limited preview/download URL.
+
+## Query attachments
+
+By business object:
+
+```http
+GET /api/workflow/files/business/fi-service/expense_claim/EXP202607220028?tenantId=default
+```
+
+By process instance:
+
+```http
+GET /api/workflow/files/instances/{instanceId}
+```
+
+Attachments uploaded before process startup are visible by instance because the repository matches the workflow instance's tenant/source/business tuple.
+
+## Delete an attachment relation
+
+```http
+DELETE /api/workflow/files/relations/{relationId}?operatorId=10001
+```
+
+Deletion is logical. The relation remains available for audit but no longer satisfies required-category checks.
+
+## Required-category node configuration
+
+Backward-compatible single-file rules:
+
+```json
+{
+  "requiredCategories": ["INVOICE", "PAYMENT_PROOF"]
+}
+```
+
+Quantity-aware rules:
+
+```json
+{
+  "requiredCategories": [
+    {"category": "INVOICE", "minimumCount": 2},
+    {"category": "PAYMENT_PROOF", "minimumCount": 1}
+  ]
+}
+```
+
+The `attachment-check` handler reads persisted, confirmed, clean attachment relations. Legacy `attachmentCategories` variables are still accepted during migration.
+
+## Configuration
+
+```yaml
+workflow:
+  attachment:
+    base-url: http://localhost:10006
+    local-root: ./data/workflow-attachments
+    signing-secret: replace-in-every-environment
+    upload-ttl-seconds: 900
+    download-ttl-seconds: 300
+    max-file-size-bytes: 52428800
+```
+
+Production must replace `WORKFLOW_ATTACHMENT_SIGNING_SECRET` and use an HTTPS external base URL.
+
+## Deferred
+
+- MinIO/OSS provider implementation and bucket lifecycle policies
+- malware scanning integration; the local provider marks confirmed files `CLEAN`
+- administrator deletion and retention rules
+- multipart/chunked uploads for very large files
+- image OCR and invoice recognition

--- a/workflow-service/src/main/java/single/cjj/workflow/attachment/AttachmentContracts.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/attachment/AttachmentContracts.java
@@ -1,0 +1,67 @@
+package single.cjj.workflow.attachment;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import java.time.LocalDateTime;
+
+public final class AttachmentContracts {
+
+    private AttachmentContracts() {
+    }
+
+    public record CreateUploadRequest(
+            @NotBlank String tenantId,
+            @NotBlank String sourceSystem,
+            @NotBlank String businessType,
+            @NotBlank String businessId,
+            String instanceId,
+            String taskId,
+            @NotBlank String categoryCode,
+            @NotBlank String fileName,
+            @NotBlank String contentType,
+            @NotNull @Positive Long fileSize,
+            String sha256,
+            @NotBlank String operatorId
+    ) {
+    }
+
+    public record UploadUrlResponse(
+            String fileId,
+            String relationId,
+            String method,
+            String uploadUrl,
+            LocalDateTime expiresAt,
+            String uploadStatus
+    ) {
+    }
+
+    public record ConfirmUploadRequest(
+            @NotBlank String operatorId,
+            String sha256
+    ) {
+    }
+
+    public record AttachmentResponse(
+            String relationId,
+            String fileId,
+            String tenantId,
+            String sourceSystem,
+            String businessType,
+            String businessId,
+            String instanceId,
+            String taskId,
+            String categoryCode,
+            String originalName,
+            String contentType,
+            long fileSize,
+            String sha256,
+            String uploadStatus,
+            String scanStatus,
+            String downloadUrl,
+            LocalDateTime createdAt,
+            LocalDateTime uploadedAt
+    ) {
+    }
+}

--- a/workflow-service/src/main/java/single/cjj/workflow/attachment/LocalWorkflowStorageProvider.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/attachment/LocalWorkflowStorageProvider.java
@@ -1,0 +1,88 @@
+package single.cjj.workflow.attachment;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+@Component
+public class LocalWorkflowStorageProvider implements WorkflowStorageProvider {
+
+    private final Path root;
+
+    public LocalWorkflowStorageProvider(
+            @Value("${workflow.attachment.local-root:./data/workflow-attachments}") String root) {
+        this.root = Path.of(root).toAbsolutePath().normalize();
+    }
+
+    @Override
+    public String providerKey() {
+        return "LOCAL";
+    }
+
+    @Override
+    public StoredObject put(String objectKey, InputStream inputStream, long maximumBytes) throws IOException {
+        Path target = resolve(objectKey);
+        Files.createDirectories(target.getParent());
+        Path temporary = Files.createTempFile(target.getParent(), ".upload-", ".tmp");
+        MessageDigest digest = sha256Digest();
+        long total = 0;
+        try (OutputStream output = Files.newOutputStream(temporary)) {
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = inputStream.read(buffer)) >= 0) {
+                total += read;
+                if (total > maximumBytes) {
+                    throw new IOException("上传文件超过允许大小");
+                }
+                digest.update(buffer, 0, read);
+                output.write(buffer, 0, read);
+            }
+        } catch (IOException ex) {
+            Files.deleteIfExists(temporary);
+            throw ex;
+        }
+        Files.move(temporary, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+        return new StoredObject(total, HexFormat.of().formatHex(digest.digest()));
+    }
+
+    @Override
+    public Resource load(String objectKey) throws IOException {
+        Path path = resolve(objectKey);
+        if (!Files.isRegularFile(path)) {
+            throw new IOException("文件不存在");
+        }
+        return new FileSystemResource(path);
+    }
+
+    @Override
+    public void delete(String objectKey) throws IOException {
+        Files.deleteIfExists(resolve(objectKey));
+    }
+
+    private Path resolve(String objectKey) throws IOException {
+        Path path = root.resolve(objectKey).normalize();
+        if (!path.startsWith(root)) {
+            throw new IOException("非法存储路径");
+        }
+        return path;
+    }
+
+    private MessageDigest sha256Digest() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("JVM 不支持 SHA-256", ex);
+        }
+    }
+}

--- a/workflow-service/src/main/java/single/cjj/workflow/attachment/WorkflowAttachmentController.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/attachment/WorkflowAttachmentController.java
@@ -1,0 +1,100 @@
+package single.cjj.workflow.attachment;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import single.cjj.bizfi.entity.ApiResponse;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+@RestController
+@RequestMapping("/workflow/files")
+public class WorkflowAttachmentController {
+
+    private final WorkflowAttachmentService attachmentService;
+
+    public WorkflowAttachmentController(WorkflowAttachmentService attachmentService) {
+        this.attachmentService = attachmentService;
+    }
+
+    @PostMapping("/upload-url")
+    public ApiResponse<AttachmentContracts.UploadUrlResponse> createUploadUrl(
+            @Valid @RequestBody AttachmentContracts.CreateUploadRequest request) {
+        return ApiResponse.success(attachmentService.createUploadUrl(request));
+    }
+
+    @PutMapping(value = "/{fileId}/content", consumes = MediaType.ALL_VALUE)
+    public ResponseEntity<Void> upload(
+            @PathVariable("fileId") String fileId,
+            @RequestParam("expires") long expires,
+            @RequestParam("signature") String signature,
+            HttpServletRequest request) throws IOException {
+        attachmentService.upload(
+                fileId, expires, signature, request.getContentType(), request.getContentLengthLong(),
+                request.getInputStream()
+        );
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/{fileId}/content")
+    public ResponseEntity<Resource> download(
+            @PathVariable("fileId") String fileId,
+            @RequestParam("expires") long expires,
+            @RequestParam("signature") String signature) {
+        WorkflowAttachmentService.DownloadObject object = attachmentService.download(fileId, expires, signature);
+        ContentDisposition disposition = ContentDisposition.inline()
+                .filename(object.fileName(), StandardCharsets.UTF_8)
+                .build();
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType(object.contentType()))
+                .contentLength(object.fileSize())
+                .header(HttpHeaders.CONTENT_DISPOSITION, disposition.toString())
+                .body(object.resource());
+    }
+
+    @PostMapping("/{fileId}/confirm")
+    public ApiResponse<AttachmentContracts.AttachmentResponse> confirm(
+            @PathVariable("fileId") String fileId,
+            @Valid @RequestBody AttachmentContracts.ConfirmUploadRequest request) {
+        return ApiResponse.success(attachmentService.confirm(fileId, request));
+    }
+
+    @GetMapping("/instances/{instanceId}")
+    public ApiResponse<List<AttachmentContracts.AttachmentResponse>> listByInstance(
+            @PathVariable("instanceId") String instanceId) {
+        return ApiResponse.success(attachmentService.listByInstance(instanceId));
+    }
+
+    @GetMapping("/business/{sourceSystem}/{businessType}/{businessId}")
+    public ApiResponse<List<AttachmentContracts.AttachmentResponse>> listByBusiness(
+            @PathVariable("sourceSystem") String sourceSystem,
+            @PathVariable("businessType") String businessType,
+            @PathVariable("businessId") String businessId,
+            @RequestParam("tenantId") String tenantId) {
+        return ApiResponse.success(attachmentService.listByBusiness(
+                tenantId, sourceSystem, businessType, businessId));
+    }
+
+    @DeleteMapping("/relations/{relationId}")
+    public ApiResponse<Void> deleteRelation(
+            @PathVariable("relationId") String relationId,
+            @RequestParam("operatorId") String operatorId) {
+        attachmentService.deleteRelation(relationId, operatorId);
+        return ApiResponse.success(null);
+    }
+}

--- a/workflow-service/src/main/java/single/cjj/workflow/attachment/WorkflowAttachmentRepository.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/attachment/WorkflowAttachmentRepository.java
@@ -120,7 +120,9 @@ public class WorkflowAttachmentRepository {
                         AND r.business_id = i.business_id)
                   )
                 GROUP BY r.category_code
-                """, rs -> result.put(rs.getString("category_code"), rs.getLong("attachment_count")), instanceId);
+                """, rs -> {
+                    result.put(rs.getString("category_code"), rs.getLong("attachment_count"));
+                }, instanceId);
         return result;
     }
 

--- a/workflow-service/src/main/java/single/cjj/workflow/attachment/WorkflowAttachmentRepository.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/attachment/WorkflowAttachmentRepository.java
@@ -132,22 +132,29 @@ public class WorkflowAttachmentRepository {
                 """, operatorId, relationId);
     }
 
-    public boolean hasActiveRelation(String fileId) {
-        Integer count = jdbcTemplate.queryForObject(
-                "SELECT COUNT(*) FROM wf_attachment_relation WHERE file_id = ? AND status = 'ACTIVE'",
-                Integer.class, fileId);
-        return count != null && count > 0;
+    public Optional<RelationRow> findRelation(String relationId) {
+        return first(jdbcTemplate.query(
+                "SELECT * FROM wf_attachment_relation WHERE id = ?",
+                this::mapRelation, relationId));
     }
 
-    public Optional<RelationRow> findRelation(String relationId) {
-        return first(jdbcTemplate.query("SELECT * FROM wf_attachment_relation WHERE id = ?", (rs, rowNum) ->
-                new RelationRow(
-                        rs.getString("id"), rs.getString("file_id"), rs.getString("tenant_id"),
-                        rs.getString("source_system"), rs.getString("business_type"),
-                        rs.getString("business_id"), rs.getString("instance_id"),
-                        rs.getString("task_id"), rs.getString("category_code"),
-                        rs.getString("created_by"), rs.getObject("created_at", LocalDateTime.class)
-                ), relationId));
+    public Optional<RelationRow> findRelationByFile(String fileId) {
+        return first(jdbcTemplate.query("""
+                SELECT * FROM wf_attachment_relation
+                WHERE file_id = ? AND status = 'ACTIVE'
+                ORDER BY created_at
+                LIMIT 1
+                """, this::mapRelation, fileId));
+    }
+
+    private RelationRow mapRelation(ResultSet rs, int rowNum) throws SQLException {
+        return new RelationRow(
+                rs.getString("id"), rs.getString("file_id"), rs.getString("tenant_id"),
+                rs.getString("source_system"), rs.getString("business_type"),
+                rs.getString("business_id"), rs.getString("instance_id"),
+                rs.getString("task_id"), rs.getString("category_code"),
+                rs.getString("created_by"), rs.getObject("created_at", LocalDateTime.class)
+        );
     }
 
     private FileRow mapFile(ResultSet rs, int rowNum) throws SQLException {

--- a/workflow-service/src/main/java/single/cjj/workflow/attachment/WorkflowAttachmentRepository.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/attachment/WorkflowAttachmentRepository.java
@@ -1,0 +1,204 @@
+package single.cjj.workflow.attachment;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Repository
+public class WorkflowAttachmentRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public WorkflowAttachmentRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public void insertFile(FileRow row) {
+        jdbcTemplate.update("""
+                INSERT INTO wf_file
+                    (id, tenant_id, storage_provider, bucket_name, object_key,
+                     original_name, content_type, expected_size, file_size,
+                     expected_sha256, sha256, upload_status, scan_status,
+                     created_by, version, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, NULL, 'PENDING', 'PENDING', ?, 0, ?)
+                """, row.id(), row.tenantId(), row.storageProvider(), row.bucketName(),
+                row.objectKey(), row.originalName(), row.contentType(), row.expectedSize(),
+                row.expectedSha256(), row.createdBy(), row.createdAt());
+    }
+
+    public void insertRelation(RelationRow row) {
+        jdbcTemplate.update("""
+                INSERT INTO wf_attachment_relation
+                    (id, file_id, tenant_id, source_system, business_type, business_id,
+                     instance_id, task_id, category_code, status, created_by, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'ACTIVE', ?, ?)
+                """, row.id(), row.fileId(), row.tenantId(), row.sourceSystem(), row.businessType(),
+                row.businessId(), row.instanceId(), row.taskId(), row.categoryCode(),
+                row.createdBy(), row.createdAt());
+    }
+
+    public Optional<FileRow> findFile(String fileId) {
+        return first(jdbcTemplate.query("SELECT * FROM wf_file WHERE id = ?", this::mapFile, fileId));
+    }
+
+    public int markStored(String fileId, long fileSize, String sha256) {
+        return jdbcTemplate.update("""
+                UPDATE wf_file
+                SET upload_status = 'STORED', file_size = ?, sha256 = ?, version = version + 1
+                WHERE id = ? AND upload_status = 'PENDING'
+                """, fileSize, sha256, fileId);
+    }
+
+    public int confirmUpload(String fileId, int expectedVersion) {
+        return jdbcTemplate.update("""
+                UPDATE wf_file
+                SET upload_status = 'UPLOADED', scan_status = 'CLEAN',
+                    uploaded_at = NOW(), version = version + 1
+                WHERE id = ? AND upload_status = 'STORED' AND version = ?
+                """, fileId, expectedVersion);
+    }
+
+    public List<AttachmentRow> listByBusiness(String tenantId,
+                                               String sourceSystem,
+                                               String businessType,
+                                               String businessId) {
+        return jdbcTemplate.query("""
+                SELECT r.id relation_id, r.file_id, r.tenant_id, r.source_system,
+                       r.business_type, r.business_id, r.instance_id, r.task_id,
+                       r.category_code, r.created_at relation_created_at, f.*
+                FROM wf_attachment_relation r
+                JOIN wf_file f ON f.id = r.file_id
+                WHERE r.tenant_id = ? AND r.source_system = ?
+                  AND r.business_type = ? AND r.business_id = ?
+                  AND r.status = 'ACTIVE' AND f.upload_status = 'UPLOADED'
+                ORDER BY r.created_at
+                """, this::mapAttachment, tenantId, sourceSystem, businessType, businessId);
+    }
+
+    public List<AttachmentRow> listByInstance(String instanceId) {
+        return jdbcTemplate.query("""
+                SELECT r.id relation_id, r.file_id, r.tenant_id, r.source_system,
+                       r.business_type, r.business_id, r.instance_id, r.task_id,
+                       r.category_code, r.created_at relation_created_at, f.*
+                FROM wf_attachment_relation r
+                JOIN wf_file f ON f.id = r.file_id
+                JOIN wf_instance i ON i.id = ?
+                WHERE r.status = 'ACTIVE' AND f.upload_status = 'UPLOADED'
+                  AND (
+                    r.instance_id = i.id
+                    OR (r.tenant_id = i.tenant_id
+                        AND r.source_system = i.source_system
+                        AND r.business_type = i.business_type
+                        AND r.business_id = i.business_id)
+                  )
+                ORDER BY r.created_at
+                """, this::mapAttachment, instanceId);
+    }
+
+    public Map<String, Long> countUploadedCategories(String instanceId) {
+        Map<String, Long> result = new LinkedHashMap<>();
+        jdbcTemplate.query("""
+                SELECT r.category_code, COUNT(*) attachment_count
+                FROM wf_attachment_relation r
+                JOIN wf_file f ON f.id = r.file_id
+                JOIN wf_instance i ON i.id = ?
+                WHERE r.status = 'ACTIVE'
+                  AND f.upload_status = 'UPLOADED'
+                  AND f.scan_status = 'CLEAN'
+                  AND (
+                    r.instance_id = i.id
+                    OR (r.tenant_id = i.tenant_id
+                        AND r.source_system = i.source_system
+                        AND r.business_type = i.business_type
+                        AND r.business_id = i.business_id)
+                  )
+                GROUP BY r.category_code
+                """, rs -> result.put(rs.getString("category_code"), rs.getLong("attachment_count")), instanceId);
+        return result;
+    }
+
+    public int deactivateRelation(String relationId, String operatorId) {
+        return jdbcTemplate.update("""
+                UPDATE wf_attachment_relation
+                SET status = 'DELETED', deleted_by = ?, deleted_at = NOW()
+                WHERE id = ? AND status = 'ACTIVE'
+                """, operatorId, relationId);
+    }
+
+    public boolean hasActiveRelation(String fileId) {
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM wf_attachment_relation WHERE file_id = ? AND status = 'ACTIVE'",
+                Integer.class, fileId);
+        return count != null && count > 0;
+    }
+
+    public Optional<RelationRow> findRelation(String relationId) {
+        return first(jdbcTemplate.query("SELECT * FROM wf_attachment_relation WHERE id = ?", (rs, rowNum) ->
+                new RelationRow(
+                        rs.getString("id"), rs.getString("file_id"), rs.getString("tenant_id"),
+                        rs.getString("source_system"), rs.getString("business_type"),
+                        rs.getString("business_id"), rs.getString("instance_id"),
+                        rs.getString("task_id"), rs.getString("category_code"),
+                        rs.getString("created_by"), rs.getObject("created_at", LocalDateTime.class)
+                ), relationId));
+    }
+
+    private FileRow mapFile(ResultSet rs, int rowNum) throws SQLException {
+        return new FileRow(
+                rs.getString("id"), rs.getString("tenant_id"), rs.getString("storage_provider"),
+                rs.getString("bucket_name"), rs.getString("object_key"), rs.getString("original_name"),
+                rs.getString("content_type"), rs.getLong("expected_size"), rs.getLong("file_size"),
+                rs.getString("expected_sha256"), rs.getString("sha256"), rs.getString("upload_status"),
+                rs.getString("scan_status"), rs.getString("created_by"), rs.getInt("version"),
+                rs.getObject("created_at", LocalDateTime.class), rs.getObject("uploaded_at", LocalDateTime.class)
+        );
+    }
+
+    private AttachmentRow mapAttachment(ResultSet rs, int rowNum) throws SQLException {
+        return new AttachmentRow(
+                rs.getString("relation_id"), rs.getString("file_id"), rs.getString("tenant_id"),
+                rs.getString("source_system"), rs.getString("business_type"), rs.getString("business_id"),
+                rs.getString("instance_id"), rs.getString("task_id"), rs.getString("category_code"),
+                rs.getString("original_name"), rs.getString("content_type"), rs.getLong("file_size"),
+                rs.getString("sha256"), rs.getString("upload_status"), rs.getString("scan_status"),
+                rs.getString("object_key"), rs.getString("created_by"),
+                rs.getObject("relation_created_at", LocalDateTime.class),
+                rs.getObject("uploaded_at", LocalDateTime.class)
+        );
+    }
+
+    private <T> Optional<T> first(List<T> rows) {
+        return rows.isEmpty() ? Optional.empty() : Optional.of(rows.get(0));
+    }
+
+    public record FileRow(
+            String id, String tenantId, String storageProvider, String bucketName, String objectKey,
+            String originalName, String contentType, long expectedSize, long fileSize,
+            String expectedSha256, String sha256, String uploadStatus, String scanStatus,
+            String createdBy, int version, LocalDateTime createdAt, LocalDateTime uploadedAt
+    ) {
+    }
+
+    public record RelationRow(
+            String id, String fileId, String tenantId, String sourceSystem, String businessType,
+            String businessId, String instanceId, String taskId, String categoryCode,
+            String createdBy, LocalDateTime createdAt
+    ) {
+    }
+
+    public record AttachmentRow(
+            String relationId, String fileId, String tenantId, String sourceSystem,
+            String businessType, String businessId, String instanceId, String taskId,
+            String categoryCode, String originalName, String contentType, long fileSize,
+            String sha256, String uploadStatus, String scanStatus, String objectKey,
+            String createdBy, LocalDateTime createdAt, LocalDateTime uploadedAt
+    ) {
+    }
+}

--- a/workflow-service/src/main/java/single/cjj/workflow/attachment/WorkflowAttachmentService.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/attachment/WorkflowAttachmentService.java
@@ -12,7 +12,7 @@ import java.io.InputStream;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -71,7 +71,7 @@ public class WorkflowAttachmentService {
         long expires = Instant.now().getEpochSecond() + uploadTtlSeconds;
         return new AttachmentContracts.UploadUrlResponse(
                 fileId, relationId, "PUT", signedUrl("UPLOAD", fileId, expires),
-                LocalDateTime.ofInstant(Instant.ofEpochSecond(expires), ZoneOffset.systemDefault()),
+                LocalDateTime.ofInstant(Instant.ofEpochSecond(expires), ZoneId.systemDefault()),
                 "PENDING"
         );
     }

--- a/workflow-service/src/main/java/single/cjj/workflow/attachment/WorkflowAttachmentService.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/attachment/WorkflowAttachmentService.java
@@ -1,0 +1,258 @@
+package single.cjj.workflow.attachment;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import single.cjj.bizfi.exception.BizException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+public class WorkflowAttachmentService {
+
+    private final WorkflowAttachmentRepository repository;
+    private final WorkflowUploadSigner signer;
+    private final Map<String, WorkflowStorageProvider> providers;
+    private final String baseUrl;
+    private final long uploadTtlSeconds;
+    private final long downloadTtlSeconds;
+    private final long maximumBytes;
+
+    public WorkflowAttachmentService(
+            WorkflowAttachmentRepository repository,
+            WorkflowUploadSigner signer,
+            List<WorkflowStorageProvider> providers,
+            @Value("${workflow.attachment.base-url:http://localhost:10006}") String baseUrl,
+            @Value("${workflow.attachment.upload-ttl-seconds:900}") long uploadTtlSeconds,
+            @Value("${workflow.attachment.download-ttl-seconds:300}") long downloadTtlSeconds,
+            @Value("${workflow.attachment.max-file-size-bytes:52428800}") long maximumBytes) {
+        this.repository = repository;
+        this.signer = signer;
+        this.providers = providers.stream().collect(Collectors.toUnmodifiableMap(
+                WorkflowStorageProvider::providerKey, Function.identity()));
+        this.baseUrl = baseUrl.replaceAll("/+$", "");
+        this.uploadTtlSeconds = uploadTtlSeconds;
+        this.downloadTtlSeconds = downloadTtlSeconds;
+        this.maximumBytes = maximumBytes;
+    }
+
+    @Transactional
+    public AttachmentContracts.UploadUrlResponse createUploadUrl(
+            AttachmentContracts.CreateUploadRequest request) {
+        validateCreateRequest(request);
+        String fileId = newId();
+        String relationId = newId();
+        String objectKey = buildObjectKey(request.tenantId(), fileId, request.fileName());
+        LocalDateTime now = LocalDateTime.now();
+        repository.insertFile(new WorkflowAttachmentRepository.FileRow(
+                fileId, request.tenantId(), "LOCAL", "workflow-attachments", objectKey,
+                request.fileName(), request.contentType(), request.fileSize(), 0,
+                normalizeSha(request.sha256()), null, "PENDING", "PENDING",
+                request.operatorId(), 0, now, null
+        ));
+        repository.insertRelation(new WorkflowAttachmentRepository.RelationRow(
+                relationId, fileId, request.tenantId(), request.sourceSystem(),
+                request.businessType(), request.businessId(), request.instanceId(), request.taskId(),
+                request.categoryCode().trim().toUpperCase(Locale.ROOT), request.operatorId(), now
+        ));
+        long expires = Instant.now().getEpochSecond() + uploadTtlSeconds;
+        return new AttachmentContracts.UploadUrlResponse(
+                fileId, relationId, "PUT", signedUrl("UPLOAD", fileId, expires),
+                LocalDateTime.ofInstant(Instant.ofEpochSecond(expires), ZoneOffset.systemDefault()),
+                "PENDING"
+        );
+    }
+
+    public void upload(String fileId,
+                       long expires,
+                       String signature,
+                       String contentType,
+                       long contentLength,
+                       InputStream inputStream) {
+        if (!signer.verify("UPLOAD", fileId, expires, signature)) {
+            throw new BizException("上传地址无效或已经过期");
+        }
+        WorkflowAttachmentRepository.FileRow file = requireFile(fileId);
+        if (!"PENDING".equals(file.uploadStatus())) {
+            throw new BizException("文件已上传或当前状态不允许上传");
+        }
+        if (StringUtils.hasText(contentType) && !file.contentType().equalsIgnoreCase(contentType)) {
+            throw new BizException("上传 Content-Type 与申请信息不一致");
+        }
+        if (contentLength > file.expectedSize() || contentLength > maximumBytes) {
+            throw new BizException("上传文件超过申请大小");
+        }
+        WorkflowStorageProvider provider = requireProvider(file.storageProvider());
+        try {
+            WorkflowStorageProvider.StoredObject stored = provider.put(
+                    file.objectKey(), inputStream, Math.min(file.expectedSize(), maximumBytes));
+            if (stored.size() != file.expectedSize()) {
+                provider.delete(file.objectKey());
+                throw new BizException("上传文件大小与申请信息不一致");
+            }
+            if (StringUtils.hasText(file.expectedSha256())
+                    && !file.expectedSha256().equalsIgnoreCase(stored.sha256())) {
+                provider.delete(file.objectKey());
+                throw new BizException("上传文件摘要校验失败");
+            }
+            if (repository.markStored(fileId, stored.size(), stored.sha256()) != 1) {
+                provider.delete(file.objectKey());
+                throw new BizException("文件状态已变化，请重新申请上传地址");
+            }
+        } catch (IOException ex) {
+            throw new BizException("文件存储失败: " + ex.getMessage());
+        }
+    }
+
+    @Transactional
+    public AttachmentContracts.AttachmentResponse confirm(
+            String fileId,
+            AttachmentContracts.ConfirmUploadRequest request) {
+        WorkflowAttachmentRepository.FileRow file = requireFile(fileId);
+        if (!file.createdBy().equals(request.operatorId())) {
+            throw new BizException("只有上传申请人可以确认文件");
+        }
+        if ("UPLOADED".equals(file.uploadStatus())) {
+            return findAttachmentByFile(fileId);
+        }
+        if (!"STORED".equals(file.uploadStatus())) {
+            throw new BizException("文件内容尚未上传完成");
+        }
+        String suppliedSha = normalizeSha(request.sha256());
+        if (StringUtils.hasText(suppliedSha) && !suppliedSha.equalsIgnoreCase(file.sha256())) {
+            throw new BizException("确认摘要与实际文件不一致");
+        }
+        if (repository.confirmUpload(fileId, file.version()) != 1) {
+            throw new BizException("文件状态已变化，请刷新后重试");
+        }
+        return findAttachmentByFile(fileId);
+    }
+
+    public List<AttachmentContracts.AttachmentResponse> listByInstance(String instanceId) {
+        return repository.listByInstance(instanceId).stream().map(this::toResponse).toList();
+    }
+
+    public List<AttachmentContracts.AttachmentResponse> listByBusiness(
+            String tenantId, String sourceSystem, String businessType, String businessId) {
+        return repository.listByBusiness(tenantId, sourceSystem, businessType, businessId)
+                .stream().map(this::toResponse).toList();
+    }
+
+    @Transactional
+    public void deleteRelation(String relationId, String operatorId) {
+        WorkflowAttachmentRepository.RelationRow relation = repository.findRelation(relationId)
+                .orElseThrow(() -> new BizException("影像关联不存在"));
+        if (!relation.createdBy().equals(operatorId)) {
+            throw new BizException("只有影像上传人可以删除关联");
+        }
+        if (repository.deactivateRelation(relationId, operatorId) != 1) {
+            throw new BizException("影像关联已经删除");
+        }
+    }
+
+    public DownloadObject download(String fileId, long expires, String signature) {
+        if (!signer.verify("DOWNLOAD", fileId, expires, signature)) {
+            throw new BizException("下载地址无效或已经过期");
+        }
+        WorkflowAttachmentRepository.FileRow file = requireFile(fileId);
+        if (!"UPLOADED".equals(file.uploadStatus())) {
+            throw new BizException("文件尚未确认上传");
+        }
+        try {
+            return new DownloadObject(requireProvider(file.storageProvider()).load(file.objectKey()),
+                    file.originalName(), file.contentType(), file.fileSize());
+        } catch (IOException ex) {
+            throw new BizException("读取文件失败: " + ex.getMessage());
+        }
+    }
+
+    private AttachmentContracts.AttachmentResponse findAttachmentByFile(String fileId) {
+        WorkflowAttachmentRepository.FileRow file = requireFile(fileId);
+        WorkflowAttachmentRepository.RelationRow relation = repository.findRelationByFile(fileId)
+                .orElseThrow(() -> new BizException("文件没有影像关联"));
+        return toResponse(new WorkflowAttachmentRepository.AttachmentRow(
+                relation.id(), file.id(), relation.tenantId(), relation.sourceSystem(),
+                relation.businessType(), relation.businessId(), relation.instanceId(), relation.taskId(),
+                relation.categoryCode(), file.originalName(), file.contentType(), file.fileSize(),
+                file.sha256(), file.uploadStatus(), file.scanStatus(), file.objectKey(), file.createdBy(),
+                relation.createdAt(), file.uploadedAt()
+        ));
+    }
+
+    private AttachmentContracts.AttachmentResponse toResponse(WorkflowAttachmentRepository.AttachmentRow row) {
+        long expires = Instant.now().getEpochSecond() + downloadTtlSeconds;
+        return new AttachmentContracts.AttachmentResponse(
+                row.relationId(), row.fileId(), row.tenantId(), row.sourceSystem(),
+                row.businessType(), row.businessId(), row.instanceId(), row.taskId(), row.categoryCode(),
+                row.originalName(), row.contentType(), row.fileSize(), row.sha256(), row.uploadStatus(),
+                row.scanStatus(), signedUrl("DOWNLOAD", row.fileId(), expires),
+                row.createdAt(), row.uploadedAt()
+        );
+    }
+
+    private void validateCreateRequest(AttachmentContracts.CreateUploadRequest request) {
+        if (request.fileSize() > maximumBytes) {
+            throw new BizException("单个影像不能超过 " + maximumBytes + " 字节");
+        }
+        String type = request.contentType().toLowerCase(Locale.ROOT);
+        if (!(type.startsWith("image/") || "application/pdf".equals(type))) {
+            throw new BizException("只允许上传图片或 PDF 文件");
+        }
+        if (request.fileName().contains("/") || request.fileName().contains("\\")) {
+            throw new BizException("文件名不能包含路径字符");
+        }
+    }
+
+    private String signedUrl(String action, String fileId, long expires) {
+        return baseUrl + "/api/workflow/files/" + fileId + "/content?expires=" + expires
+                + "&signature=" + signer.sign(action, fileId, expires);
+    }
+
+    private String buildObjectKey(String tenantId, String fileId, String originalName) {
+        String extension = "";
+        int dot = originalName.lastIndexOf('.');
+        if (dot >= 0 && dot < originalName.length() - 1) {
+            extension = originalName.substring(dot).toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9.]", "");
+        }
+        LocalDate date = LocalDate.now();
+        return tenantId.replaceAll("[^a-zA-Z0-9_-]", "_") + "/"
+                + date.getYear() + "/" + String.format("%02d", date.getMonthValue()) + "/"
+                + String.format("%02d", date.getDayOfMonth()) + "/" + fileId + extension;
+    }
+
+    private WorkflowAttachmentRepository.FileRow requireFile(String fileId) {
+        return repository.findFile(fileId).orElseThrow(() -> new BizException("文件不存在"));
+    }
+
+    private WorkflowStorageProvider requireProvider(String providerKey) {
+        WorkflowStorageProvider provider = providers.get(providerKey);
+        if (provider == null) {
+            throw new BizException("没有可用的存储适配器: " + providerKey);
+        }
+        return provider;
+    }
+
+    private String normalizeSha(String sha256) {
+        return StringUtils.hasText(sha256) ? sha256.trim().toLowerCase(Locale.ROOT) : null;
+    }
+
+    private String newId() {
+        return UUID.randomUUID().toString().replace("-", "");
+    }
+
+    public record DownloadObject(Resource resource, String fileName, String contentType, long fileSize) {
+    }
+}

--- a/workflow-service/src/main/java/single/cjj/workflow/attachment/WorkflowStorageProvider.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/attachment/WorkflowStorageProvider.java
@@ -1,0 +1,20 @@
+package single.cjj.workflow.attachment;
+
+import org.springframework.core.io.Resource;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public interface WorkflowStorageProvider {
+
+    String providerKey();
+
+    StoredObject put(String objectKey, InputStream inputStream, long maximumBytes) throws IOException;
+
+    Resource load(String objectKey) throws IOException;
+
+    void delete(String objectKey) throws IOException;
+
+    record StoredObject(long size, String sha256) {
+    }
+}

--- a/workflow-service/src/main/java/single/cjj/workflow/attachment/WorkflowUploadSigner.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/attachment/WorkflowUploadSigner.java
@@ -1,0 +1,55 @@
+package single.cjj.workflow.attachment;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Instant;
+import java.util.Base64;
+
+@Component
+public class WorkflowUploadSigner {
+
+    private final byte[] secret;
+
+    public WorkflowUploadSigner(
+            @Value("${workflow.attachment.signing-secret:matrix-workflow-change-me}") String secret) {
+        this.secret = secret.getBytes(StandardCharsets.UTF_8);
+    }
+
+    public String sign(String action, String fileId, long expiresEpochSecond) {
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(
+                hmac(payload(action, fileId, expiresEpochSecond))
+        );
+    }
+
+    public boolean verify(String action, String fileId, long expiresEpochSecond, String signature) {
+        if (expiresEpochSecond < Instant.now().getEpochSecond() || signature == null) {
+            return false;
+        }
+        byte[] expected = hmac(payload(action, fileId, expiresEpochSecond));
+        try {
+            byte[] actual = Base64.getUrlDecoder().decode(signature);
+            return MessageDigest.isEqual(expected, actual);
+        } catch (IllegalArgumentException ex) {
+            return false;
+        }
+    }
+
+    private String payload(String action, String fileId, long expiresEpochSecond) {
+        return action + ":" + fileId + ":" + expiresEpochSecond;
+    }
+
+    private byte[] hmac(String value) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(secret, "HmacSHA256"));
+            return mac.doFinal(value.getBytes(StandardCharsets.UTF_8));
+        } catch (Exception ex) {
+            throw new IllegalStateException("无法生成附件签名", ex);
+        }
+    }
+}

--- a/workflow-service/src/main/java/single/cjj/workflow/engine/AttachmentCheckNodeHandler.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/engine/AttachmentCheckNodeHandler.java
@@ -1,16 +1,23 @@
 package single.cjj.workflow.engine;
 
 import org.springframework.stereotype.Component;
+import single.cjj.workflow.attachment.WorkflowAttachmentRepository;
 
 import java.util.Collection;
-import java.util.LinkedHashSet;
+import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 
 @Component
 public class AttachmentCheckNodeHandler implements WorkflowNodeHandler {
 
     public static final String HANDLER_KEY = "attachment-check";
+
+    private final WorkflowAttachmentRepository attachmentRepository;
+
+    public AttachmentCheckNodeHandler(WorkflowAttachmentRepository attachmentRepository) {
+        this.attachmentRepository = attachmentRepository;
+    }
 
     @Override
     public String handlerKey() {
@@ -24,27 +31,56 @@ public class AttachmentCheckNodeHandler implements WorkflowNodeHandler {
             return ExecutionResult.success(Map.of("checked", true));
         }
 
-        Set<String> required = toStringSet(requiredCategories);
-        Object uploadedValue = context.variables().get("attachmentCategories");
-        Set<String> uploaded = uploadedValue instanceof Collection<?> collection
-                ? toStringSet(collection)
-                : Set.of();
+        Map<String, Long> uploaded = new LinkedHashMap<>(
+                attachmentRepository.countUploadedCategories(context.instanceId()));
+        mergeLegacyVariables(context, uploaded);
 
-        Set<String> missing = new LinkedHashSet<>(required);
-        missing.removeAll(uploaded);
-        if (!missing.isEmpty()) {
-            return ExecutionResult.failure("缺少必要影像分类: " + String.join(",", missing));
-        }
-        return ExecutionResult.success(Map.of("checked", true, "categories", uploaded));
-    }
-
-    private Set<String> toStringSet(Collection<?> values) {
-        Set<String> result = new LinkedHashSet<>();
-        for (Object value : values) {
-            if (value != null) {
-                result.add(String.valueOf(value));
+        Map<String, Long> missing = new LinkedHashMap<>();
+        for (Object item : requiredCategories) {
+            Requirement requirement = parseRequirement(item);
+            long actual = uploaded.getOrDefault(requirement.category(), 0L);
+            if (actual < requirement.minimumCount()) {
+                missing.put(requirement.category(), requirement.minimumCount() - actual);
             }
         }
-        return result;
+        if (!missing.isEmpty()) {
+            String message = missing.entrySet().stream()
+                    .map(entry -> entry.getKey() + "缺少" + entry.getValue() + "份")
+                    .reduce((left, right) -> left + "," + right)
+                    .orElse("缺少必要影像");
+            return ExecutionResult.failure("缺少必要影像分类: " + message);
+        }
+        return ExecutionResult.success(Map.of("checked", true, "categoryCounts", uploaded));
+    }
+
+    private Requirement parseRequirement(Object item) {
+        if (item instanceof Map<?, ?> map) {
+            Object categoryValue = map.get("category");
+            if (categoryValue == null) {
+                categoryValue = map.get("categoryCode");
+            }
+            String category = normalize(categoryValue);
+            Object minimumValue = map.get("minimumCount");
+            long minimum = minimumValue instanceof Number number
+                    ? Math.max(1L, number.longValue()) : 1L;
+            return new Requirement(category, minimum);
+        }
+        return new Requirement(normalize(item), 1L);
+    }
+
+    private void mergeLegacyVariables(ExecutionContext context, Map<String, Long> uploaded) {
+        Object value = context.variables().get("attachmentCategories");
+        if (value instanceof Collection<?> categories) {
+            for (Object category : categories) {
+                uploaded.merge(normalize(category), 1L, Long::sum);
+            }
+        }
+    }
+
+    private String normalize(Object value) {
+        return String.valueOf(value).trim().toUpperCase(Locale.ROOT);
+    }
+
+    private record Requirement(String category, long minimumCount) {
     }
 }

--- a/workflow-service/src/main/resources/application.yml
+++ b/workflow-service/src/main/resources/application.yml
@@ -27,6 +27,15 @@ spring:
     password: ${WORKFLOW_DB_PASSWORD:root}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+workflow:
+  attachment:
+    base-url: ${WORKFLOW_ATTACHMENT_BASE_URL:http://localhost:10006}
+    local-root: ${WORKFLOW_ATTACHMENT_LOCAL_ROOT:./data/workflow-attachments}
+    signing-secret: ${WORKFLOW_ATTACHMENT_SIGNING_SECRET:matrix-workflow-change-me}
+    upload-ttl-seconds: ${WORKFLOW_ATTACHMENT_UPLOAD_TTL_SECONDS:900}
+    download-ttl-seconds: ${WORKFLOW_ATTACHMENT_DOWNLOAD_TTL_SECONDS:300}
+    max-file-size-bytes: ${WORKFLOW_ATTACHMENT_MAX_FILE_SIZE_BYTES:52428800}
+
 management:
   endpoints:
     web:

--- a/workflow-service/src/main/resources/sql/workflow_v2_attachments.sql
+++ b/workflow-service/src/main/resources/sql/workflow_v2_attachments.sql
@@ -1,0 +1,43 @@
+CREATE TABLE IF NOT EXISTS wf_file (
+    id VARCHAR(40) PRIMARY KEY,
+    tenant_id VARCHAR(64) NOT NULL,
+    storage_provider VARCHAR(32) NOT NULL,
+    bucket_name VARCHAR(128) NOT NULL,
+    object_key VARCHAR(500) NOT NULL,
+    original_name VARCHAR(255) NOT NULL,
+    content_type VARCHAR(128) NOT NULL,
+    expected_size BIGINT NOT NULL,
+    file_size BIGINT NOT NULL DEFAULT 0,
+    expected_sha256 VARCHAR(64) NULL,
+    sha256 VARCHAR(64) NULL,
+    upload_status VARCHAR(32) NOT NULL,
+    scan_status VARCHAR(32) NOT NULL,
+    created_by VARCHAR(64) NOT NULL,
+    version INT NOT NULL DEFAULT 0,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    uploaded_at DATETIME NULL,
+    UNIQUE KEY uk_wf_file_object (storage_provider, bucket_name, object_key),
+    KEY idx_wf_file_tenant_status (tenant_id, upload_status, created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS wf_attachment_relation (
+    id VARCHAR(40) PRIMARY KEY,
+    file_id VARCHAR(40) NOT NULL,
+    tenant_id VARCHAR(64) NOT NULL,
+    source_system VARCHAR(100) NOT NULL,
+    business_type VARCHAR(100) NOT NULL,
+    business_id VARCHAR(128) NOT NULL,
+    instance_id VARCHAR(40) NULL,
+    task_id VARCHAR(40) NULL,
+    category_code VARCHAR(100) NOT NULL,
+    status VARCHAR(32) NOT NULL DEFAULT 'ACTIVE',
+    created_by VARCHAR(64) NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_by VARCHAR(64) NULL,
+    deleted_at DATETIME NULL,
+    KEY idx_wf_attachment_business
+        (tenant_id, source_system, business_type, business_id, status),
+    KEY idx_wf_attachment_instance (instance_id, status),
+    KEY idx_wf_attachment_file (file_id, status),
+    KEY idx_wf_attachment_category (category_code, status)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/workflow-service/src/test/java/single/cjj/workflow/attachment/WorkflowUploadSignerTest.java
+++ b/workflow-service/src/test/java/single/cjj/workflow/attachment/WorkflowUploadSignerTest.java
@@ -1,0 +1,31 @@
+package single.cjj.workflow.attachment;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WorkflowUploadSignerTest {
+
+    private final WorkflowUploadSigner signer = new WorkflowUploadSigner("test-secret");
+
+    @Test
+    void shouldVerifyMatchingActionFileAndExpiration() {
+        long expires = Instant.now().plusSeconds(60).getEpochSecond();
+        String signature = signer.sign("UPLOAD", "file-1", expires);
+
+        assertTrue(signer.verify("UPLOAD", "file-1", expires, signature));
+        assertFalse(signer.verify("DOWNLOAD", "file-1", expires, signature));
+        assertFalse(signer.verify("UPLOAD", "file-2", expires, signature));
+    }
+
+    @Test
+    void shouldRejectExpiredSignature() {
+        long expires = Instant.now().minusSeconds(1).getEpochSecond();
+        String signature = signer.sign("UPLOAD", "file-1", expires);
+
+        assertFalse(signer.verify("UPLOAD", "file-1", expires, signature));
+    }
+}

--- a/workflow-service/src/test/java/single/cjj/workflow/engine/AttachmentCheckNodeHandlerTest.java
+++ b/workflow-service/src/test/java/single/cjj/workflow/engine/AttachmentCheckNodeHandlerTest.java
@@ -1,0 +1,61 @@
+package single.cjj.workflow.engine;
+
+import org.junit.jupiter.api.Test;
+import single.cjj.workflow.attachment.WorkflowAttachmentRepository;
+import single.cjj.workflow.model.WorkflowDefinition;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AttachmentCheckNodeHandlerTest {
+
+    private final WorkflowAttachmentRepository repository = mock(WorkflowAttachmentRepository.class);
+    private final AttachmentCheckNodeHandler handler = new AttachmentCheckNodeHandler(repository);
+
+    @Test
+    void shouldPassWhenEveryCategoryMeetsMinimumCount() {
+        when(repository.countUploadedCategories("instance-1"))
+                .thenReturn(Map.of("INVOICE", 2L, "PAYMENT_PROOF", 1L));
+
+        WorkflowDefinition.Node node = nodeWithRequirements(List.of(
+                Map.of("category", "INVOICE", "minimumCount", 2),
+                "PAYMENT_PROOF"
+        ));
+
+        WorkflowNodeHandler.ExecutionResult result = handler.execute(
+                new WorkflowNodeHandler.ExecutionContext("instance-1", node, Map.of()));
+
+        assertTrue(result.success());
+    }
+
+    @Test
+    void shouldReportMissingQuantity() {
+        when(repository.countUploadedCategories("instance-1"))
+                .thenReturn(Map.of("INVOICE", 1L));
+
+        WorkflowDefinition.Node node = nodeWithRequirements(List.of(
+                Map.of("categoryCode", "INVOICE", "minimumCount", 2),
+                "PAYMENT_PROOF"
+        ));
+
+        WorkflowNodeHandler.ExecutionResult result = handler.execute(
+                new WorkflowNodeHandler.ExecutionContext("instance-1", node, Map.of()));
+
+        assertFalse(result.success());
+        assertTrue(result.message().contains("INVOICE缺少1份"));
+        assertTrue(result.message().contains("PAYMENT_PROOF缺少1份"));
+    }
+
+    private WorkflowDefinition.Node nodeWithRequirements(List<?> requirements) {
+        WorkflowDefinition.Node node = new WorkflowDefinition.Node();
+        node.setKey("attachmentCheck");
+        node.setType(WorkflowDefinition.NodeType.SERVICE_TASK);
+        node.setConfig(Map.of("requiredCategories", requirements));
+        return node;
+    }
+}


### PR DESCRIPTION
## Summary

- add workflow-owned file metadata and attachment relation tables
- add provider-neutral `WorkflowStorageProvider` abstraction
- add local filesystem storage for development
- add HMAC-signed time-limited upload and download URLs
- stream upload bodies with size and SHA-256 verification
- add explicit upload confirmation and idempotent confirmation behavior
- add business-object and workflow-instance attachment queries
- add logical attachment deletion for auditability
- update `attachment-check` to read persisted confirmed clean attachments and enforce minimum counts
- retain legacy `attachmentCategories` variable compatibility
- add configuration, migration, unit tests, and usage documentation

## API additions

- `POST /api/workflow/files/upload-url`
- `PUT /api/workflow/files/{fileId}/content`
- `POST /api/workflow/files/{fileId}/confirm`
- `GET /api/workflow/files/{fileId}/content`
- `GET /api/workflow/files/instances/{instanceId}`
- `GET /api/workflow/files/business/{sourceSystem}/{businessType}/{businessId}`
- `DELETE /api/workflow/files/relations/{relationId}`

## Validation

- signed URLs reject wrong actions/files and expired timestamps
- persisted category checks enforce minimum attachment quantities
- Workflow Service CI runs `mvn -B -pl workflow-service -am test`

## Production boundary

This PR includes a local development provider. MinIO/OSS/COS/S3 support should be added as additional `WorkflowStorageProvider` implementations. Production must replace the signing secret, use HTTPS, and integrate malware scanning before marking files clean.