### PR TITLE
feat: integrate expense reimbursement with workflow service

### DIFF
--- a/.github/workflows/fi-workflow-integration-ci.yml
+++ b/.github/workflows/fi-workflow-integration-ci.yml
@@ -1,0 +1,35 @@
+name: Finance Workflow Integration CI
+
+on:
+  pull_request:
+    paths:
+      - 'fi-service/**'
+      - 'workflow-service/**'
+      - 'common/**'
+      - 'pom.xml'
+      - '.github/workflows/fi-workflow-integration-ci.yml'
+  push:
+    branches:
+      - agent/fi-expense-workflow-integration
+    paths:
+      - 'fi-service/**'
+      - 'workflow-service/**'
+      - 'common/**'
+      - 'pom.xml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+
+      - name: Test finance and workflow services
+        run: mvn -B -pl fi-service,workflow-service -am test

--- a/docs/business/workflow/fi-expense-workflow-integration.md
+++ b/docs/business/workflow/fi-expense-workflow-integration.md
@@ -1,0 +1,150 @@
+# FI Expense Workflow Integration
+
+## Scope
+
+This phase introduces the first real finance document that uses `workflow-service` as its approval engine.
+
+The business document remains owned by `fi-service`. Workflow definitions, instances, tasks and approval history remain owned by `workflow-service`.
+
+## Business lifecycle
+
+```text
+DRAFT
+  -> APPROVING
+  -> RETURNED -> APPROVING
+  -> APPROVED | REJECTED | CANCELLED
+```
+
+`fi-service` never changes a document to `APPROVED` directly. Terminal states are applied from signed workflow callback events.
+
+## Submit flow
+
+```text
+POST /api/fi/expense-reimbursements/{expenseId}/submit
+  -> validate applicant and status
+  -> update expense to APPROVING
+  -> upsert fi_workflow_binding
+  -> insert fi_event_outbox
+  -> commit local transaction
+```
+
+The scheduled Outbox dispatcher calls workflow APIs after the business transaction commits.
+
+- First submission: `POST /api/workflow/instances`
+- Submission after return: `POST /api/workflow/instances/{instanceId}/resubmit`
+
+Remote failures do not roll back the submitted business transaction. The Outbox row moves to `FAILED` and is retried with exponential backoff.
+
+## Public APIs
+
+### Create expense
+
+```http
+POST /api/fi/expense-reimbursements
+```
+
+```json
+{
+  "tenantId": "default",
+  "applicantId": "10001",
+  "departmentCode": "D001",
+  "amount": 1280.50,
+  "currency": "CNY",
+  "description": "Customer visit travel reimbursement"
+}
+```
+
+### Submit expense
+
+```http
+POST /api/fi/expense-reimbursements/{expenseId}/submit
+X-Request-Id: expense-submit-20260722-001
+```
+
+```json
+{
+  "operatorId": "10001",
+  "definitionKey": "expense-reimbursement",
+  "comment": "Submit for approval"
+}
+```
+
+### Query expense
+
+```http
+GET /api/fi/expense-reimbursements/{expenseId}
+```
+
+### Workflow callback
+
+```http
+POST /api/fi/expense/workflow/events
+X-Workflow-Event-Id: <eventId>
+X-Workflow-Timestamp: <epochSeconds>
+X-Workflow-Signature: sha256=<hmac>
+```
+
+The signature input is:
+
+```text
+timestamp + "." + rawRequestBody
+```
+
+Both services must use the same `WORKFLOW_CALLBACK_SECRET`.
+
+## Callback mapping
+
+| Workflow event | Expense status | Binding status |
+| --- | --- | --- |
+| `INSTANCE_RETURNED` | `RETURNED` | `WAITING_RESUBMIT` |
+| `INSTANCE_RESUBMITTED` | `APPROVING` | `RUNNING` |
+| `INSTANCE_COMPLETED` | `APPROVED` | `COMPLETED` |
+| `INSTANCE_REJECTED` | `REJECTED` | `REJECTED` |
+| `INSTANCE_CANCELLED` | `CANCELLED` | `CANCELLED` |
+
+`fi_workflow_event_log.event_id` is the callback idempotency key.
+
+## Database migration
+
+Run:
+
+```text
+fi-service/src/main/resources/sql/fi_workflow_expense_v1.sql
+```
+
+It creates:
+
+- `fi_expense_reimbursement`
+- `fi_workflow_binding`
+- `fi_event_outbox`
+- `fi_workflow_event_log`
+
+## Configuration
+
+`fi-service`:
+
+```text
+FI_WORKFLOW_BASE_URL
+FI_WORKFLOW_CALLBACK_URL
+WORKFLOW_CALLBACK_SECRET
+WORKFLOW_CALLBACK_MAX_SKEW_SECONDS
+FI_WORKFLOW_OUTBOX_BATCH_SIZE
+FI_WORKFLOW_OUTBOX_DISPATCH_DELAY_MS
+```
+
+`workflow-service`:
+
+```text
+WORKFLOW_CALLBACK_SECRET
+```
+
+Production environments must use HTTPS and a non-default callback secret.
+
+## Deferred
+
+- attachment pre-check in the submit endpoint
+- expense edit API after return
+- user-facing approval detail aggregation
+- cancellation API from `fi-service`
+- reconciliation scheduler and manual recovery UI
+- role membership resolution through Auth Service

--- a/fi-service/src/main/java/single/cjj/fi/FinanceApplication.java
+++ b/fi-service/src/main/java/single/cjj/fi/FinanceApplication.java
@@ -3,7 +3,9 @@ package single.cjj.fi;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication(scanBasePackages = "single.cjj.fi")
 @MapperScan(basePackages = "single.cjj.fi.**.mapper")
 public class FinanceApplication {

--- a/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowCallbackController.java
+++ b/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowCallbackController.java
@@ -1,0 +1,56 @@
+package single.cjj.fi.expense.workflow;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import single.cjj.bizfi.entity.ApiResponse;
+import single.cjj.bizfi.exception.BizException;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/fi/expense/workflow")
+public class ExpenseWorkflowCallbackController {
+
+    private final ExpenseWorkflowCallbackSigner signer;
+    private final ExpenseWorkflowCallbackService callbackService;
+    private final ObjectMapper objectMapper;
+
+    public ExpenseWorkflowCallbackController(
+            ExpenseWorkflowCallbackSigner signer,
+            ExpenseWorkflowCallbackService callbackService,
+            ObjectMapper objectMapper) {
+        this.signer = signer;
+        this.callbackService = callbackService;
+        this.objectMapper = objectMapper;
+    }
+
+    @PostMapping("/events")
+    public ApiResponse<Map<String, Object>> receive(
+            @RequestHeader("X-Workflow-Event-Id") String eventId,
+            @RequestHeader("X-Workflow-Timestamp") String timestamp,
+            @RequestHeader("X-Workflow-Signature") String signature,
+            @RequestBody String body) {
+        signer.verify(timestamp, signature, body);
+        try {
+            ExpenseWorkflowContracts.WorkflowEventRequest event = objectMapper.readValue(
+                    body, ExpenseWorkflowContracts.WorkflowEventRequest.class);
+            if (!eventId.equals(event.eventId())) {
+                throw new BizException("工作流事件 ID 与请求头不一致");
+            }
+            boolean processed = callbackService.process(event);
+            return ApiResponse.success(Map.of(
+                    "eventId", event.eventId(),
+                    "processed", processed,
+                    "duplicate", !processed
+            ));
+        } catch (BizException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new BizException("工作流回调内容无法解析: " + ex.getMessage());
+        }
+    }
+}

--- a/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowCallbackService.java
+++ b/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowCallbackService.java
@@ -1,0 +1,60 @@
+package single.cjj.fi.expense.workflow;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import single.cjj.bizfi.exception.BizException;
+
+import java.time.LocalDateTime;
+
+@Service
+public class ExpenseWorkflowCallbackService {
+
+    private final ExpenseWorkflowRepository repository;
+
+    public ExpenseWorkflowCallbackService(ExpenseWorkflowRepository repository) {
+        this.repository = repository;
+    }
+
+    @Transactional
+    public boolean process(ExpenseWorkflowContracts.WorkflowEventRequest event) {
+        if (!ExpenseWorkflowService.SOURCE_SYSTEM.equals(event.sourceSystem())) {
+            throw new BizException("工作流事件来源系统不匹配");
+        }
+        if (!ExpenseWorkflowService.BUSINESS_TYPE.equals(event.businessType())) {
+            throw new BizException("工作流事件业务类型不匹配");
+        }
+
+        int inserted = repository.insertWorkflowEventIfAbsent(
+                new ExpenseWorkflowRepository.WorkflowEventRow(
+                        event.eventId(), event.eventType(), event.instanceId(),
+                        event.businessType(), event.businessId(), LocalDateTime.now()
+                ));
+        if (inserted == 0) {
+            return false;
+        }
+
+        StatusMapping mapping = map(event.eventType());
+        int affected = repository.applyWorkflowEvent(
+                event.tenantId(), event.businessId(), event.instanceId(),
+                mapping.businessStatus(), mapping.workflowStatus(), mapping.terminal());
+        if (affected != 1) {
+            throw new BizException("工作流事件对应的报销单不存在或流程实例不匹配");
+        }
+        repository.markWorkflowEventProcessed(event.eventId());
+        return true;
+    }
+
+    private StatusMapping map(String eventType) {
+        return switch (eventType) {
+            case "INSTANCE_RETURNED" -> new StatusMapping("RETURNED", "WAITING_RESUBMIT", false);
+            case "INSTANCE_RESUBMITTED" -> new StatusMapping("APPROVING", "RUNNING", false);
+            case "INSTANCE_COMPLETED" -> new StatusMapping("APPROVED", "COMPLETED", true);
+            case "INSTANCE_REJECTED" -> new StatusMapping("REJECTED", "REJECTED", true);
+            case "INSTANCE_CANCELLED" -> new StatusMapping("CANCELLED", "CANCELLED", true);
+            default -> throw new BizException("不支持的工作流事件类型: " + eventType);
+        };
+    }
+
+    private record StatusMapping(String businessStatus, String workflowStatus, boolean terminal) {
+    }
+}

--- a/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowCallbackSigner.java
+++ b/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowCallbackSigner.java
@@ -1,0 +1,55 @@
+package single.cjj.fi.expense.workflow;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import single.cjj.bizfi.exception.BizException;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Instant;
+import java.util.HexFormat;
+
+@Component
+public class ExpenseWorkflowCallbackSigner {
+
+    private final byte[] secret;
+    private final long maximumSkewSeconds;
+
+    public ExpenseWorkflowCallbackSigner(
+            @Value("${fi.workflow.callback-secret:change-me-in-production}") String secret,
+            @Value("${fi.workflow.callback-max-skew-seconds:300}") long maximumSkewSeconds) {
+        this.secret = secret.getBytes(StandardCharsets.UTF_8);
+        this.maximumSkewSeconds = maximumSkewSeconds;
+    }
+
+    public void verify(String timestampValue, String signatureValue, String body) {
+        long timestamp;
+        try {
+            timestamp = Long.parseLong(timestampValue);
+        } catch (Exception ex) {
+            throw new BizException("工作流回调时间戳无效");
+        }
+        if (Math.abs(Instant.now().getEpochSecond() - timestamp) > maximumSkewSeconds) {
+            throw new BizException("工作流回调已过期");
+        }
+        String expected = "sha256=" + hmac(timestamp + "." + body);
+        byte[] expectedBytes = expected.getBytes(StandardCharsets.UTF_8);
+        byte[] suppliedBytes = signatureValue == null
+                ? new byte[0] : signatureValue.getBytes(StandardCharsets.UTF_8);
+        if (!MessageDigest.isEqual(expectedBytes, suppliedBytes)) {
+            throw new BizException("工作流回调签名校验失败");
+        }
+    }
+
+    private String hmac(String value) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(secret, "HmacSHA256"));
+            return HexFormat.of().formatHex(mac.doFinal(value.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception ex) {
+            throw new IllegalStateException("无法计算工作流回调签名", ex);
+        }
+    }
+}

--- a/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowContracts.java
+++ b/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowContracts.java
@@ -1,0 +1,94 @@
+package single.cjj.fi.expense.workflow;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public final class ExpenseWorkflowContracts {
+
+    private ExpenseWorkflowContracts() {
+    }
+
+    public record CreateExpenseRequest(
+            @NotBlank String tenantId,
+            @NotBlank String applicantId,
+            @NotBlank String departmentCode,
+            @NotNull @DecimalMin(value = "0.01") BigDecimal amount,
+            String currency,
+            @NotBlank String description
+    ) {
+        public String safeCurrency() {
+            return currency == null || currency.isBlank() ? "CNY" : currency.trim().toUpperCase();
+        }
+    }
+
+    public record SubmitExpenseRequest(
+            @NotBlank String operatorId,
+            String definitionKey,
+            String comment
+    ) {
+        public String safeDefinitionKey() {
+            return definitionKey == null || definitionKey.isBlank()
+                    ? "expense-reimbursement" : definitionKey.trim();
+        }
+    }
+
+    public record ExpenseResponse(
+            String id,
+            String tenantId,
+            String documentNumber,
+            String applicantId,
+            String departmentCode,
+            BigDecimal amount,
+            String currency,
+            String description,
+            String status,
+            String workflowInstanceId,
+            int version,
+            LocalDateTime createdAt,
+            LocalDateTime submittedAt,
+            LocalDateTime completedAt
+    ) {
+    }
+
+    public record WorkflowEventRequest(
+            @NotBlank String eventId,
+            @NotBlank String eventType,
+            @NotBlank String instanceId,
+            @NotBlank String tenantId,
+            @NotBlank String sourceSystem,
+            @NotBlank String businessType,
+            @NotBlank String businessId,
+            String status,
+            Map<String, Object> variables,
+            String occurredAt
+    ) {
+        public Map<String, Object> safeVariables() {
+            return variables == null ? new LinkedHashMap<>() : new LinkedHashMap<>(variables);
+        }
+    }
+
+    public record WorkflowStartPayload(
+            String tenantId,
+            String definitionKey,
+            String sourceSystem,
+            String businessType,
+            String businessId,
+            String initiatorId,
+            Map<String, Object> variables,
+            String callbackUrl
+    ) {
+    }
+
+    public record WorkflowResubmitPayload(
+            String operatorId,
+            String comment,
+            Map<String, Object> variables
+    ) {
+    }
+}

--- a/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowController.java
+++ b/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowController.java
@@ -1,0 +1,42 @@
+package single.cjj.fi.expense.workflow;
+
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import single.cjj.bizfi.entity.ApiResponse;
+
+@RestController
+@RequestMapping("/fi/expense-reimbursements")
+public class ExpenseWorkflowController {
+
+    private final ExpenseWorkflowService service;
+
+    public ExpenseWorkflowController(ExpenseWorkflowService service) {
+        this.service = service;
+    }
+
+    @PostMapping
+    public ApiResponse<ExpenseWorkflowContracts.ExpenseResponse> create(
+            @Valid @RequestBody ExpenseWorkflowContracts.CreateExpenseRequest request) {
+        return ApiResponse.success(service.create(request));
+    }
+
+    @GetMapping("/{expenseId}")
+    public ApiResponse<ExpenseWorkflowContracts.ExpenseResponse> get(
+            @PathVariable("expenseId") String expenseId) {
+        return ApiResponse.success(service.get(expenseId));
+    }
+
+    @PostMapping("/{expenseId}/submit")
+    public ApiResponse<ExpenseWorkflowContracts.ExpenseResponse> submit(
+            @PathVariable("expenseId") String expenseId,
+            @RequestHeader(value = "X-Request-Id", required = false) String requestId,
+            @Valid @RequestBody ExpenseWorkflowContracts.SubmitExpenseRequest request) {
+        return ApiResponse.success(service.submit(expenseId, request, requestId));
+    }
+}

--- a/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowGateway.java
+++ b/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowGateway.java
@@ -1,0 +1,68 @@
+package single.cjj.fi.expense.workflow;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import single.cjj.bizfi.exception.BizException;
+
+@Component
+public class ExpenseWorkflowGateway {
+
+    private final RestClient restClient;
+    private final ObjectMapper objectMapper;
+
+    public ExpenseWorkflowGateway(
+            ObjectMapper objectMapper,
+            @Value("${fi.workflow.base-url:http://localhost:10006/api}") String baseUrl) {
+        this.objectMapper = objectMapper;
+        this.restClient = RestClient.builder().baseUrl(baseUrl.replaceAll("/+$", "")).build();
+    }
+
+    public WorkflowResult start(String payloadJson, String idempotencyKey) {
+        String response = restClient.post()
+                .uri("/workflow/instances")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Idempotency-Key", idempotencyKey)
+                .body(payloadJson)
+                .retrieve()
+                .body(String.class);
+        return parseResult(response);
+    }
+
+    public WorkflowResult resubmit(String instanceId, String payloadJson, String requestId) {
+        String response = restClient.post()
+                .uri("/workflow/instances/{instanceId}/resubmit", instanceId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("X-Request-Id", requestId)
+                .body(payloadJson)
+                .retrieve()
+                .body(String.class);
+        return parseResult(response);
+    }
+
+    private WorkflowResult parseResult(String response) {
+        try {
+            JsonNode root = objectMapper.readTree(response);
+            if (root == null || root.path("code").asInt() != 200) {
+                throw new BizException("工作流服务调用失败: "
+                        + (root == null ? "空响应" : root.path("message").asText("未知错误")));
+            }
+            JsonNode data = root.path("data");
+            String instanceId = data.path("instanceId").asText();
+            if (instanceId.isBlank()) {
+                throw new BizException("工作流服务响应缺少 instanceId");
+            }
+            return new WorkflowResult(instanceId, data.path("status").asText("RUNNING"));
+        } catch (BizException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new BizException("工作流服务响应无法解析: " + ex.getMessage());
+        }
+    }
+
+    public record WorkflowResult(String instanceId, String status) {
+    }
+}

--- a/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowOutboxDispatcher.java
+++ b/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowOutboxDispatcher.java
@@ -1,0 +1,73 @@
+package single.cjj.fi.expense.workflow;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+public class ExpenseWorkflowOutboxDispatcher {
+
+    private final ExpenseWorkflowRepository repository;
+    private final ExpenseWorkflowGateway gateway;
+    private final int batchSize;
+
+    public ExpenseWorkflowOutboxDispatcher(
+            ExpenseWorkflowRepository repository,
+            ExpenseWorkflowGateway gateway,
+            @Value("${fi.workflow.outbox.batch-size:20}") int batchSize) {
+        this.repository = repository;
+        this.gateway = gateway;
+        this.batchSize = Math.max(1, batchSize);
+    }
+
+    @Scheduled(fixedDelayString = "${fi.workflow.outbox.dispatch-delay-ms:5000}")
+    public void dispatch() {
+        List<ExpenseWorkflowRepository.OutboxRow> rows = repository.findDispatchable(batchSize);
+        for (ExpenseWorkflowRepository.OutboxRow row : rows) {
+            if (!repository.claimOutbox(row.id())) {
+                continue;
+            }
+            dispatchOne(row);
+        }
+    }
+
+    private void dispatchOne(ExpenseWorkflowRepository.OutboxRow row) {
+        try {
+            ExpenseWorkflowRepository.ExpenseRow expense = repository.findExpense(row.aggregateId())
+                    .orElseThrow(() -> new IllegalStateException("报销单不存在: " + row.aggregateId()));
+            ExpenseWorkflowRepository.BindingRow binding = repository
+                    .findBinding(expense.tenantId(), ExpenseWorkflowService.BUSINESS_TYPE, expense.id())
+                    .orElseThrow(() -> new IllegalStateException("报销单缺少流程绑定"));
+
+            ExpenseWorkflowGateway.WorkflowResult result;
+            if (ExpenseWorkflowService.EVENT_START.equals(row.eventType())) {
+                result = gateway.start(row.payloadJson(), row.idempotencyKey());
+            } else if (ExpenseWorkflowService.EVENT_RESUBMIT.equals(row.eventType())) {
+                if (!StringUtils.hasText(binding.workflowInstanceId())) {
+                    throw new IllegalStateException("重新提交缺少 workflowInstanceId");
+                }
+                result = gateway.resubmit(
+                        binding.workflowInstanceId(), row.payloadJson(), row.idempotencyKey());
+            } else {
+                throw new IllegalStateException("不支持的业务 Outbox 事件: " + row.eventType());
+            }
+
+            repository.bindWorkflowInstance(
+                    expense.tenantId(), ExpenseWorkflowService.BUSINESS_TYPE,
+                    expense.id(), result.instanceId(), result.status());
+            repository.markOutboxSent(row.id());
+        } catch (Exception ex) {
+            long delaySeconds = Math.min(3600L, 5L * (1L << Math.min(row.retryCount(), 9)));
+            LocalDateTime nextRetry = LocalDateTime.now().plusSeconds(delaySeconds);
+            repository.markOutboxFailed(row.id(), nextRetry, ex.getMessage());
+            log.warn("expense workflow outbox failed, eventId={}, nextRetry={}",
+                    row.eventId(), nextRetry, ex);
+        }
+    }
+}

--- a/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowRepository.java
+++ b/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowRepository.java
@@ -1,0 +1,259 @@
+package single.cjj.fi.expense.workflow;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class ExpenseWorkflowRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public ExpenseWorkflowRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public void insertExpense(ExpenseRow row) {
+        jdbcTemplate.update("""
+                INSERT INTO fi_expense_reimbursement
+                    (id, tenant_id, document_number, applicant_id, department_code,
+                     amount, currency_code, description_text, status, version, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'DRAFT', 0, ?)
+                """, row.id(), row.tenantId(), row.documentNumber(), row.applicantId(),
+                row.departmentCode(), row.amount(), row.currency(), row.description(), row.createdAt());
+    }
+
+    public Optional<ExpenseRow> findExpense(String expenseId) {
+        return first(jdbcTemplate.query(
+                "SELECT * FROM fi_expense_reimbursement WHERE id = ?",
+                this::mapExpense,
+                expenseId
+        ));
+    }
+
+    public int markApproving(String expenseId, int expectedVersion, String workflowInstanceId) {
+        return jdbcTemplate.update("""
+                UPDATE fi_expense_reimbursement
+                SET status = 'APPROVING', workflow_instance_id = COALESCE(?, workflow_instance_id),
+                    submitted_at = COALESCE(submitted_at, NOW()), version = version + 1,
+                    updated_at = NOW()
+                WHERE id = ? AND version = ? AND status IN ('DRAFT', 'RETURNED')
+                """, workflowInstanceId, expenseId, expectedVersion);
+    }
+
+    public void upsertBinding(BindingRow row) {
+        jdbcTemplate.update("""
+                INSERT INTO fi_workflow_binding
+                    (id, tenant_id, business_type, business_id, workflow_instance_id,
+                     workflow_definition_key, workflow_status, business_status,
+                     submit_request_id, callback_url, submitted_by, submitted_at, version)
+                VALUES (?, ?, ?, ?, ?, ?, ?, 'APPROVING', ?, ?, ?, NOW(), 0)
+                ON DUPLICATE KEY UPDATE
+                    workflow_instance_id = COALESCE(VALUES(workflow_instance_id), workflow_instance_id),
+                    workflow_definition_key = VALUES(workflow_definition_key),
+                    workflow_status = VALUES(workflow_status),
+                    business_status = 'APPROVING',
+                    submit_request_id = VALUES(submit_request_id),
+                    callback_url = VALUES(callback_url),
+                    submitted_by = VALUES(submitted_by),
+                    submitted_at = NOW(),
+                    version = version + 1
+                """, row.id(), row.tenantId(), row.businessType(), row.businessId(),
+                row.workflowInstanceId(), row.workflowDefinitionKey(), row.workflowStatus(),
+                row.submitRequestId(), row.callbackUrl(), row.submittedBy());
+    }
+
+    public Optional<BindingRow> findBinding(String tenantId, String businessType, String businessId) {
+        return first(jdbcTemplate.query("""
+                SELECT * FROM fi_workflow_binding
+                WHERE tenant_id = ? AND business_type = ? AND business_id = ?
+                LIMIT 1
+                """, this::mapBinding, tenantId, businessType, businessId));
+    }
+
+    public void insertOutbox(OutboxRow row) {
+        jdbcTemplate.update("""
+                INSERT INTO fi_event_outbox
+                    (id, event_id, aggregate_type, aggregate_id, event_type,
+                     payload_json, idempotency_key, status, retry_count, created_at)
+                VALUES (?, ?, ?, ?, ?, CAST(? AS JSON), ?, 'PENDING', 0, ?)
+                """, row.id(), row.eventId(), row.aggregateType(), row.aggregateId(),
+                row.eventType(), row.payloadJson(), row.idempotencyKey(), row.createdAt());
+    }
+
+    public List<OutboxRow> findDispatchable(int limit) {
+        return jdbcTemplate.query("""
+                SELECT * FROM fi_event_outbox
+                WHERE status IN ('PENDING', 'FAILED')
+                  AND (next_retry_time IS NULL OR next_retry_time <= NOW())
+                ORDER BY created_at
+                LIMIT ?
+                """, this::mapOutbox, limit);
+    }
+
+    public boolean claimOutbox(String id) {
+        return jdbcTemplate.update("""
+                UPDATE fi_event_outbox
+                SET status = 'SENDING'
+                WHERE id = ? AND status IN ('PENDING', 'FAILED')
+                """, id) == 1;
+    }
+
+    public void markOutboxSent(String id) {
+        jdbcTemplate.update("""
+                UPDATE fi_event_outbox
+                SET status = 'SUCCESS', sent_at = NOW(), last_error = NULL
+                WHERE id = ? AND status = 'SENDING'
+                """, id);
+    }
+
+    public void markOutboxFailed(String id, LocalDateTime nextRetryTime, String error) {
+        jdbcTemplate.update("""
+                UPDATE fi_event_outbox
+                SET status = 'FAILED', retry_count = retry_count + 1,
+                    next_retry_time = ?, last_error = ?
+                WHERE id = ? AND status = 'SENDING'
+                """, nextRetryTime, abbreviate(error, 1000), id);
+    }
+
+    public void bindWorkflowInstance(String tenantId,
+                                     String businessType,
+                                     String businessId,
+                                     String workflowInstanceId,
+                                     String workflowStatus) {
+        jdbcTemplate.update("""
+                UPDATE fi_workflow_binding
+                SET workflow_instance_id = ?, workflow_status = ?, version = version + 1
+                WHERE tenant_id = ? AND business_type = ? AND business_id = ?
+                """, workflowInstanceId, workflowStatus, tenantId, businessType, businessId);
+        jdbcTemplate.update("""
+                UPDATE fi_expense_reimbursement
+                SET workflow_instance_id = ?, updated_at = NOW()
+                WHERE id = ? AND tenant_id = ?
+                """, workflowInstanceId, businessId, tenantId);
+    }
+
+    public int insertWorkflowEventIfAbsent(WorkflowEventRow row) {
+        return jdbcTemplate.update("""
+                INSERT IGNORE INTO fi_workflow_event_log
+                    (event_id, event_type, workflow_instance_id, business_type,
+                     business_id, processed_status, created_at)
+                VALUES (?, ?, ?, ?, ?, 'PROCESSING', ?)
+                """, row.eventId(), row.eventType(), row.workflowInstanceId(),
+                row.businessType(), row.businessId(), row.createdAt());
+    }
+
+    public int applyWorkflowEvent(String tenantId,
+                                  String businessId,
+                                  String workflowInstanceId,
+                                  String businessStatus,
+                                  String workflowStatus,
+                                  boolean terminal) {
+        int affected = jdbcTemplate.update("""
+                UPDATE fi_expense_reimbursement
+                SET status = ?, workflow_instance_id = ?,
+                    completed_at = CASE WHEN ? THEN NOW() ELSE completed_at END,
+                    version = version + 1, updated_at = NOW()
+                WHERE id = ? AND tenant_id = ?
+                  AND (workflow_instance_id IS NULL OR workflow_instance_id = ?)
+                """, businessStatus, workflowInstanceId, terminal,
+                businessId, tenantId, workflowInstanceId);
+        jdbcTemplate.update("""
+                UPDATE fi_workflow_binding
+                SET workflow_instance_id = ?, workflow_status = ?, business_status = ?,
+                    completed_at = CASE WHEN ? THEN NOW() ELSE completed_at END,
+                    version = version + 1
+                WHERE tenant_id = ? AND business_type = 'EXPENSE_REIMBURSEMENT'
+                  AND business_id = ?
+                  AND (workflow_instance_id IS NULL OR workflow_instance_id = ?)
+                """, workflowInstanceId, workflowStatus, businessStatus, terminal,
+                tenantId, businessId, workflowInstanceId);
+        return affected;
+    }
+
+    public void markWorkflowEventProcessed(String eventId) {
+        jdbcTemplate.update("""
+                UPDATE fi_workflow_event_log
+                SET processed_status = 'SUCCESS', processed_at = NOW(), error_message = NULL
+                WHERE event_id = ?
+                """, eventId);
+    }
+
+    private ExpenseRow mapExpense(ResultSet rs, int rowNum) throws SQLException {
+        return new ExpenseRow(
+                rs.getString("id"), rs.getString("tenant_id"), rs.getString("document_number"),
+                rs.getString("applicant_id"), rs.getString("department_code"),
+                rs.getBigDecimal("amount"), rs.getString("currency_code"),
+                rs.getString("description_text"), rs.getString("status"),
+                rs.getString("workflow_instance_id"), rs.getInt("version"),
+                rs.getObject("created_at", LocalDateTime.class),
+                rs.getObject("submitted_at", LocalDateTime.class),
+                rs.getObject("completed_at", LocalDateTime.class)
+        );
+    }
+
+    private BindingRow mapBinding(ResultSet rs, int rowNum) throws SQLException {
+        return new BindingRow(
+                rs.getString("id"), rs.getString("tenant_id"), rs.getString("business_type"),
+                rs.getString("business_id"), rs.getString("workflow_instance_id"),
+                rs.getString("workflow_definition_key"), rs.getString("workflow_status"),
+                rs.getString("business_status"), rs.getString("submit_request_id"),
+                rs.getString("callback_url"), rs.getString("submitted_by")
+        );
+    }
+
+    private OutboxRow mapOutbox(ResultSet rs, int rowNum) throws SQLException {
+        return new OutboxRow(
+                rs.getString("id"), rs.getString("event_id"), rs.getString("aggregate_type"),
+                rs.getString("aggregate_id"), rs.getString("event_type"),
+                rs.getString("payload_json"), rs.getString("idempotency_key"),
+                rs.getString("status"), rs.getInt("retry_count"),
+                rs.getObject("created_at", LocalDateTime.class)
+        );
+    }
+
+    private <T> Optional<T> first(List<T> rows) {
+        return rows.isEmpty() ? Optional.empty() : Optional.of(rows.get(0));
+    }
+
+    private String abbreviate(String value, int maximumLength) {
+        if (value == null || value.length() <= maximumLength) {
+            return value;
+        }
+        return value.substring(0, maximumLength);
+    }
+
+    public record ExpenseRow(
+            String id, String tenantId, String documentNumber, String applicantId,
+            String departmentCode, BigDecimal amount, String currency, String description,
+            String status, String workflowInstanceId, int version, LocalDateTime createdAt,
+            LocalDateTime submittedAt, LocalDateTime completedAt
+    ) {
+    }
+
+    public record BindingRow(
+            String id, String tenantId, String businessType, String businessId,
+            String workflowInstanceId, String workflowDefinitionKey, String workflowStatus,
+            String businessStatus, String submitRequestId, String callbackUrl, String submittedBy
+    ) {
+    }
+
+    public record OutboxRow(
+            String id, String eventId, String aggregateType, String aggregateId,
+            String eventType, String payloadJson, String idempotencyKey,
+            String status, int retryCount, LocalDateTime createdAt
+    ) {
+    }
+
+    public record WorkflowEventRow(
+            String eventId, String eventType, String workflowInstanceId,
+            String businessType, String businessId, LocalDateTime createdAt
+    ) {
+    }
+}

--- a/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowService.java
+++ b/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowService.java
@@ -1,0 +1,169 @@
+package single.cjj.fi.expense.workflow;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import single.cjj.bizfi.exception.BizException;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+public class ExpenseWorkflowService {
+
+    public static final String BUSINESS_TYPE = "EXPENSE_REIMBURSEMENT";
+    public static final String SOURCE_SYSTEM = "fi-service";
+    public static final String EVENT_START = "WORKFLOW_START_REQUESTED";
+    public static final String EVENT_RESUBMIT = "WORKFLOW_RESUBMIT_REQUESTED";
+
+    private final ExpenseWorkflowRepository repository;
+    private final ObjectMapper objectMapper;
+    private final String callbackUrl;
+
+    public ExpenseWorkflowService(
+            ExpenseWorkflowRepository repository,
+            ObjectMapper objectMapper,
+            @Value("${fi.workflow.callback-url:http://localhost:10003/api/fi/expense/workflow/events}")
+            String callbackUrl) {
+        this.repository = repository;
+        this.objectMapper = objectMapper;
+        this.callbackUrl = callbackUrl;
+    }
+
+    @Transactional
+    public ExpenseWorkflowContracts.ExpenseResponse create(
+            ExpenseWorkflowContracts.CreateExpenseRequest request) {
+        String expenseId = newId();
+        LocalDateTime now = LocalDateTime.now();
+        ExpenseWorkflowRepository.ExpenseRow row = new ExpenseWorkflowRepository.ExpenseRow(
+                expenseId,
+                request.tenantId(),
+                "ER-" + now.format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"))
+                        + "-" + expenseId.substring(0, 6).toUpperCase(),
+                request.applicantId(),
+                request.departmentCode(),
+                request.amount(),
+                request.safeCurrency(),
+                request.description(),
+                "DRAFT",
+                null,
+                0,
+                now,
+                null,
+                null
+        );
+        repository.insertExpense(row);
+        return toResponse(row);
+    }
+
+    public ExpenseWorkflowContracts.ExpenseResponse get(String expenseId) {
+        return toResponse(requireExpense(expenseId));
+    }
+
+    @Transactional
+    public ExpenseWorkflowContracts.ExpenseResponse submit(
+            String expenseId,
+            ExpenseWorkflowContracts.SubmitExpenseRequest request,
+            String requestId) {
+        ExpenseWorkflowRepository.ExpenseRow expense = requireExpense(expenseId);
+        if (!expense.applicantId().equals(request.operatorId())) {
+            throw new BizException("只有报销单申请人可以提交审批");
+        }
+        if (!("DRAFT".equals(expense.status()) || "RETURNED".equals(expense.status()))) {
+            throw new BizException("只有草稿或已退回的报销单可以提交");
+        }
+
+        String effectiveRequestId = StringUtils.hasText(requestId) ? requestId.trim() : newId();
+        ExpenseWorkflowRepository.BindingRow binding = repository
+                .findBinding(expense.tenantId(), BUSINESS_TYPE, expense.id())
+                .orElse(null);
+        boolean resubmit = "RETURNED".equals(expense.status())
+                && binding != null
+                && StringUtils.hasText(binding.workflowInstanceId());
+
+        int updated = repository.markApproving(
+                expense.id(), expense.version(), binding == null ? null : binding.workflowInstanceId());
+        if (updated != 1) {
+            throw new BizException("报销单状态已变化，请刷新后重试");
+        }
+
+        String definitionKey = request.safeDefinitionKey();
+        String bindingId = binding == null ? newId() : binding.id();
+        String workflowStatus = resubmit ? "RESUBMIT_REQUESTED" : "START_REQUESTED";
+        repository.upsertBinding(new ExpenseWorkflowRepository.BindingRow(
+                bindingId,
+                expense.tenantId(),
+                BUSINESS_TYPE,
+                expense.id(),
+                binding == null ? null : binding.workflowInstanceId(),
+                definitionKey,
+                workflowStatus,
+                "APPROVING",
+                effectiveRequestId,
+                callbackUrl,
+                request.operatorId()
+        ));
+
+        String eventId = newId();
+        String eventType = resubmit ? EVENT_RESUBMIT : EVENT_START;
+        String idempotencyKey = resubmit
+                ? "expense-resubmit:" + expense.id() + ":" + effectiveRequestId
+                : "expense-start:" + expense.id();
+        Map<String, Object> variables = buildVariables(expense);
+        Object payload = resubmit
+                ? new ExpenseWorkflowContracts.WorkflowResubmitPayload(
+                        request.operatorId(), request.comment(), variables)
+                : new ExpenseWorkflowContracts.WorkflowStartPayload(
+                        expense.tenantId(), definitionKey, SOURCE_SYSTEM, BUSINESS_TYPE,
+                        expense.id(), request.operatorId(), variables, callbackUrl);
+        repository.insertOutbox(new ExpenseWorkflowRepository.OutboxRow(
+                newId(), eventId, BUSINESS_TYPE, expense.id(), eventType,
+                writeJson(payload), idempotencyKey, "PENDING", 0, LocalDateTime.now()
+        ));
+        return toResponse(requireExpense(expense.id()));
+    }
+
+    private Map<String, Object> buildVariables(ExpenseWorkflowRepository.ExpenseRow expense) {
+        Map<String, Object> variables = new LinkedHashMap<>();
+        variables.put("documentNumber", expense.documentNumber());
+        variables.put("applicantId", expense.applicantId());
+        variables.put("departmentCode", expense.departmentCode());
+        variables.put("amount", expense.amount());
+        variables.put("currency", expense.currency());
+        variables.put("description", expense.description());
+        return variables;
+    }
+
+    private ExpenseWorkflowRepository.ExpenseRow requireExpense(String expenseId) {
+        return repository.findExpense(expenseId)
+                .orElseThrow(() -> new BizException("报销单不存在"));
+    }
+
+    private ExpenseWorkflowContracts.ExpenseResponse toResponse(
+            ExpenseWorkflowRepository.ExpenseRow row) {
+        return new ExpenseWorkflowContracts.ExpenseResponse(
+                row.id(), row.tenantId(), row.documentNumber(), row.applicantId(),
+                row.departmentCode(), row.amount(), row.currency(), row.description(),
+                row.status(), row.workflowInstanceId(), row.version(), row.createdAt(),
+                row.submittedAt(), row.completedAt()
+        );
+    }
+
+    private String writeJson(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException ex) {
+            throw new BizException("报销工作流事件无法序列化: " + ex.getOriginalMessage());
+        }
+    }
+
+    private String newId() {
+        return UUID.randomUUID().toString().replace("-", "");
+    }
+}

--- a/fi-service/src/main/resources/application.yml
+++ b/fi-service/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     active: ${SPRING_PROFILES_ACTIVE:dev}
 
   config:
-    import: "nacos:${spring.application.name}"
+    import: "optional:nacos:${spring.application.name}"
 
   cloud:
     nacos:
@@ -34,3 +34,13 @@ matrix:
       max-concurrency: ${FI_SCHEDULER_MAX_CONCURRENCY:8}
       heartbeat-interval-ms: 30000
       initialize-schema: true
+
+fi:
+  workflow:
+    base-url: ${FI_WORKFLOW_BASE_URL:http://localhost:10006/api}
+    callback-url: ${FI_WORKFLOW_CALLBACK_URL:http://localhost:10003/api/fi/expense/workflow/events}
+    callback-secret: ${WORKFLOW_CALLBACK_SECRET:change-me-in-production}
+    callback-max-skew-seconds: ${WORKFLOW_CALLBACK_MAX_SKEW_SECONDS:300}
+    outbox:
+      batch-size: ${FI_WORKFLOW_OUTBOX_BATCH_SIZE:20}
+      dispatch-delay-ms: ${FI_WORKFLOW_OUTBOX_DISPATCH_DELAY_MS:5000}

--- a/fi-service/src/main/resources/sql/fi_workflow_expense_v1.sql
+++ b/fi-service/src/main/resources/sql/fi_workflow_expense_v1.sql
@@ -1,0 +1,72 @@
+CREATE TABLE IF NOT EXISTS fi_expense_reimbursement (
+    id VARCHAR(40) PRIMARY KEY,
+    tenant_id VARCHAR(64) NOT NULL,
+    document_number VARCHAR(80) NOT NULL,
+    applicant_id VARCHAR(64) NOT NULL,
+    department_code VARCHAR(64) NOT NULL,
+    amount DECIMAL(19, 4) NOT NULL,
+    currency_code VARCHAR(16) NOT NULL DEFAULT 'CNY',
+    description_text VARCHAR(1000) NOT NULL,
+    status VARCHAR(32) NOT NULL DEFAULT 'DRAFT',
+    workflow_instance_id VARCHAR(40) NULL,
+    version INT NOT NULL DEFAULT 0,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    submitted_at DATETIME NULL,
+    completed_at DATETIME NULL,
+    UNIQUE KEY uk_fi_expense_number (tenant_id, document_number),
+    KEY idx_fi_expense_status (tenant_id, status, created_at),
+    KEY idx_fi_expense_workflow (workflow_instance_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS fi_workflow_binding (
+    id VARCHAR(40) PRIMARY KEY,
+    tenant_id VARCHAR(64) NOT NULL,
+    business_type VARCHAR(100) NOT NULL,
+    business_id VARCHAR(128) NOT NULL,
+    workflow_instance_id VARCHAR(40) NULL,
+    workflow_definition_key VARCHAR(100) NOT NULL,
+    workflow_status VARCHAR(32) NOT NULL,
+    business_status VARCHAR(32) NOT NULL,
+    submit_request_id VARCHAR(160) NOT NULL,
+    callback_url VARCHAR(500) NOT NULL,
+    submitted_by VARCHAR(64) NOT NULL,
+    submitted_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at DATETIME NULL,
+    version INT NOT NULL DEFAULT 0,
+    UNIQUE KEY uk_fi_workflow_business (tenant_id, business_type, business_id),
+    KEY idx_fi_workflow_instance (workflow_instance_id),
+    KEY idx_fi_workflow_status (tenant_id, workflow_status, submitted_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS fi_event_outbox (
+    id VARCHAR(40) PRIMARY KEY,
+    event_id VARCHAR(40) NOT NULL,
+    aggregate_type VARCHAR(100) NOT NULL,
+    aggregate_id VARCHAR(128) NOT NULL,
+    event_type VARCHAR(64) NOT NULL,
+    payload_json JSON NOT NULL,
+    idempotency_key VARCHAR(200) NOT NULL,
+    status VARCHAR(32) NOT NULL DEFAULT 'PENDING',
+    retry_count INT NOT NULL DEFAULT 0,
+    next_retry_time DATETIME NULL,
+    last_error VARCHAR(1000) NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    sent_at DATETIME NULL,
+    UNIQUE KEY uk_fi_outbox_event (event_id),
+    UNIQUE KEY uk_fi_outbox_idempotency (idempotency_key),
+    KEY idx_fi_outbox_dispatch (status, next_retry_time, created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS fi_workflow_event_log (
+    event_id VARCHAR(40) PRIMARY KEY,
+    event_type VARCHAR(64) NOT NULL,
+    workflow_instance_id VARCHAR(40) NOT NULL,
+    business_type VARCHAR(100) NOT NULL,
+    business_id VARCHAR(128) NOT NULL,
+    processed_status VARCHAR(32) NOT NULL,
+    error_message VARCHAR(1000) NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    processed_at DATETIME NULL,
+    KEY idx_fi_workflow_event_business (business_type, business_id, created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/fi-service/src/test/java/single/cjj/fi/expense/workflow/ExpenseWorkflowCallbackServiceTest.java
+++ b/fi-service/src/test/java/single/cjj/fi/expense/workflow/ExpenseWorkflowCallbackServiceTest.java
@@ -1,0 +1,47 @@
+package single.cjj.fi.expense.workflow;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ExpenseWorkflowCallbackServiceTest {
+
+    @Mock
+    private ExpenseWorkflowRepository repository;
+
+    @Test
+    void completedEventApprovesExpense() {
+        when(repository.insertWorkflowEventIfAbsent(org.mockito.ArgumentMatchers.any())).thenReturn(1);
+        when(repository.applyWorkflowEvent(
+                "tenant", "exp1", "wf1", "APPROVED", "COMPLETED", true)).thenReturn(1);
+
+        ExpenseWorkflowCallbackService service = new ExpenseWorkflowCallbackService(repository);
+        boolean processed = service.process(event("evt1", "INSTANCE_COMPLETED"));
+
+        assertTrue(processed);
+        verify(repository).markWorkflowEventProcessed("evt1");
+    }
+
+    @Test
+    void duplicateEventIsIgnored() {
+        when(repository.insertWorkflowEventIfAbsent(org.mockito.ArgumentMatchers.any())).thenReturn(0);
+
+        ExpenseWorkflowCallbackService service = new ExpenseWorkflowCallbackService(repository);
+        assertFalse(service.process(event("evt1", "INSTANCE_RETURNED")));
+    }
+
+    private ExpenseWorkflowContracts.WorkflowEventRequest event(String eventId, String eventType) {
+        return new ExpenseWorkflowContracts.WorkflowEventRequest(
+                eventId, eventType, "wf1", "tenant", ExpenseWorkflowService.SOURCE_SYSTEM,
+                ExpenseWorkflowService.BUSINESS_TYPE, "exp1", "COMPLETED", Map.of(), null);
+    }
+}

--- a/fi-service/src/test/java/single/cjj/fi/expense/workflow/ExpenseWorkflowServiceTest.java
+++ b/fi-service/src/test/java/single/cjj/fi/expense/workflow/ExpenseWorkflowServiceTest.java
@@ -1,0 +1,80 @@
+package single.cjj.fi.expense.workflow;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ExpenseWorkflowServiceTest {
+
+    @Mock
+    private ExpenseWorkflowRepository repository;
+
+    @Test
+    void draftSubmissionCreatesWorkflowStartOutbox() {
+        ExpenseWorkflowRepository.ExpenseRow draft = expense("DRAFT", null, 0);
+        ExpenseWorkflowRepository.ExpenseRow approving = expense("APPROVING", null, 1);
+        when(repository.findExpense("exp1"))
+                .thenReturn(Optional.of(draft))
+                .thenReturn(Optional.of(approving));
+        when(repository.findBinding("tenant", ExpenseWorkflowService.BUSINESS_TYPE, "exp1"))
+                .thenReturn(Optional.empty());
+        when(repository.markApproving("exp1", 0, null)).thenReturn(1);
+
+        ExpenseWorkflowService service = new ExpenseWorkflowService(
+                repository, new ObjectMapper(), "http://fi/api/fi/expense/workflow/events");
+        service.submit("exp1", new ExpenseWorkflowContracts.SubmitExpenseRequest(
+                "user1", "expense-reimbursement", "submit"), "req1");
+
+        ArgumentCaptor<ExpenseWorkflowRepository.OutboxRow> captor =
+                ArgumentCaptor.forClass(ExpenseWorkflowRepository.OutboxRow.class);
+        verify(repository).insertOutbox(captor.capture());
+        assertEquals(ExpenseWorkflowService.EVENT_START, captor.getValue().eventType());
+        assertEquals("expense-start:exp1", captor.getValue().idempotencyKey());
+    }
+
+    @Test
+    void returnedSubmissionCreatesResubmitOutbox() {
+        ExpenseWorkflowRepository.ExpenseRow returned = expense("RETURNED", "wf1", 3);
+        ExpenseWorkflowRepository.ExpenseRow approving = expense("APPROVING", "wf1", 4);
+        ExpenseWorkflowRepository.BindingRow binding = new ExpenseWorkflowRepository.BindingRow(
+                "binding1", "tenant", ExpenseWorkflowService.BUSINESS_TYPE, "exp1", "wf1",
+                "expense-reimbursement", "WAITING_RESUBMIT", "RETURNED", "old", "callback", "user1");
+        when(repository.findExpense("exp1"))
+                .thenReturn(Optional.of(returned))
+                .thenReturn(Optional.of(approving));
+        when(repository.findBinding("tenant", ExpenseWorkflowService.BUSINESS_TYPE, "exp1"))
+                .thenReturn(Optional.of(binding));
+        when(repository.markApproving("exp1", 3, "wf1")).thenReturn(1);
+
+        ExpenseWorkflowService service = new ExpenseWorkflowService(
+                repository, new ObjectMapper(), "http://fi/api/fi/expense/workflow/events");
+        service.submit("exp1", new ExpenseWorkflowContracts.SubmitExpenseRequest(
+                "user1", null, "fixed"), "req2");
+
+        ArgumentCaptor<ExpenseWorkflowRepository.OutboxRow> captor =
+                ArgumentCaptor.forClass(ExpenseWorkflowRepository.OutboxRow.class);
+        verify(repository).insertOutbox(captor.capture());
+        assertEquals(ExpenseWorkflowService.EVENT_RESUBMIT, captor.getValue().eventType());
+        assertEquals("expense-resubmit:exp1:req2", captor.getValue().idempotencyKey());
+    }
+
+    private ExpenseWorkflowRepository.ExpenseRow expense(
+            String status, String workflowInstanceId, int version) {
+        return new ExpenseWorkflowRepository.ExpenseRow(
+                "exp1", "tenant", "ER-1", "user1", "D001", new BigDecimal("100.00"),
+                "CNY", "travel", status, workflowInstanceId, version,
+                LocalDateTime.now(), null, null);
+    }
+}

--- a/workflow-service/src/main/java/single/cjj/workflow/integration/WorkflowCallbackSigner.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/integration/WorkflowCallbackSigner.java
@@ -1,0 +1,31 @@
+package single.cjj.workflow.integration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.HexFormat;
+
+@Component
+public class WorkflowCallbackSigner {
+
+    private final byte[] secret;
+
+    public WorkflowCallbackSigner(
+            @Value("${workflow.callback.signing-secret:change-me-in-production}") String secret) {
+        this.secret = secret.getBytes(StandardCharsets.UTF_8);
+    }
+
+    public String sign(long timestamp, String body) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(secret, "HmacSHA256"));
+            byte[] digest = mac.doFinal((timestamp + "." + body).getBytes(StandardCharsets.UTF_8));
+            return "sha256=" + HexFormat.of().formatHex(digest);
+        } catch (Exception ex) {
+            throw new IllegalStateException("无法计算工作流回调签名", ex);
+        }
+    }
+}

--- a/workflow-service/src/main/java/single/cjj/workflow/integration/WorkflowOutboxDispatcher.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/integration/WorkflowOutboxDispatcher.java
@@ -4,12 +4,14 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestClient;
 import single.cjj.workflow.repository.WorkflowOutboxRepository;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -21,15 +23,18 @@ public class WorkflowOutboxDispatcher {
 
     private final WorkflowOutboxRepository outboxRepository;
     private final ObjectMapper objectMapper;
+    private final WorkflowCallbackSigner callbackSigner;
     private final RestClient restClient = RestClient.create();
 
     @Value("${workflow.outbox.batch-size:20}")
     private int batchSize;
 
     public WorkflowOutboxDispatcher(WorkflowOutboxRepository outboxRepository,
-                                    ObjectMapper objectMapper) {
+                                    ObjectMapper objectMapper,
+                                    WorkflowCallbackSigner callbackSigner) {
         this.outboxRepository = outboxRepository;
         this.objectMapper = objectMapper;
+        this.callbackSigner = callbackSigner;
     }
 
     @Scheduled(fixedDelayString = "${workflow.outbox.dispatch-delay-ms:5000}")
@@ -58,11 +63,16 @@ public class WorkflowOutboxDispatcher {
                 return;
             }
 
+            long timestamp = Instant.now().getEpochSecond();
+            String rawBody = row.payloadJson();
             restClient.post()
                     .uri(callbackUrl)
+                    .contentType(MediaType.APPLICATION_JSON)
                     .header("X-Workflow-Event-Id", row.eventId())
                     .header("X-Workflow-Event-Type", row.eventType())
-                    .body(payload)
+                    .header("X-Workflow-Timestamp", String.valueOf(timestamp))
+                    .header("X-Workflow-Signature", callbackSigner.sign(timestamp, rawBody))
+                    .body(rawBody)
                     .retrieve()
                     .toBodilessEntity();
             outboxRepository.markSent(row.id());

--- a/workflow-service/src/main/resources/application.yml
+++ b/workflow-service/src/main/resources/application.yml
@@ -28,6 +28,8 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
 
 workflow:
+  callback:
+    signing-secret: ${WORKFLOW_CALLBACK_SECRET:change-me-in-production}
   attachment:
     base-url: ${WORKFLOW_ATTACHMENT_BASE_URL:http://localhost:10006}
     local-root: ${WORKFLOW_ATTACHMENT_LOCAL_ROOT:./data/workflow-attachments}

--- a/workflow-service/src/test/java/single/cjj/workflow/integration/WorkflowCallbackSignerTest.java
+++ b/workflow-service/src/test/java/single/cjj/workflow/integration/WorkflowCallbackSignerTest.java
@@ -1,0 +1,20 @@
+package single.cjj.workflow.integration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WorkflowCallbackSignerTest {
+
+    @Test
+    void signatureIsStableAndPrefixed() {
+        WorkflowCallbackSigner signer = new WorkflowCallbackSigner("secret");
+        String first = signer.sign(1000L, "{\"eventId\":\"evt1\"}");
+        String second = signer.sign(1000L, "{\"eventId\":\"evt1\"}");
+
+        assertEquals(first, second);
+        assertTrue(first.startsWith("sha256="));
+        assertEquals(71, first.length());
+    }
+}


### PR DESCRIPTION
## Summary

- add a dedicated `fi-service` expense reimbursement business document
- add DRAFT / APPROVING / RETURNED / APPROVED / REJECTED / CANCELLED lifecycle handling
- persist workflow bindings separately from business document data
- add a finance-side transactional Outbox for workflow start and resubmit requests
- add retrying workflow API dispatch with stable idempotency keys
- add signed workflow callbacks using HMAC-SHA256 over the raw request body
- add callback replay protection and event idempotency through `fi_workflow_event_log`
- map workflow terminal and return events back to finance document status
- add database migration, configuration, unit tests, documentation, and a dual-module CI workflow

## Business flow

1. Create an expense reimbursement in `DRAFT`.
2. Submit it locally; the document becomes `APPROVING` and a business Outbox row is committed.
3. The dispatcher starts a workflow instance or resubmits an existing returned instance.
4. Workflow callbacks are signed and delivered through the existing workflow Outbox.
5. `fi-service` verifies the signature, deduplicates `eventId`, and updates the business state.

## API additions

- `POST /api/fi/expense-reimbursements`
- `GET /api/fi/expense-reimbursements/{expenseId}`
- `POST /api/fi/expense-reimbursements/{expenseId}/submit`
- `POST /api/fi/expense/workflow/events`

## Database

Run `fi-service/src/main/resources/sql/fi_workflow_expense_v1.sql` before enabling the feature.

## Validation

- first submission creates `WORKFLOW_START_REQUESTED`
- returned submission creates `WORKFLOW_RESUBMIT_REQUESTED`
- callback events are idempotent
- completed workflow events map the document to `APPROVED`
- callback signatures use the shared `WORKFLOW_CALLBACK_SECRET`
- CI runs `mvn -B -pl fi-service,workflow-service -am test`

## Deferred

- synchronous attachment pre-check before submit
- edit API for returned documents
- approval detail aggregation and timeline UI
- business-side cancel API
- periodic reconciliation and manual recovery tools
