### PR TITLE
feat: add idempotent asynchronous voucher draft writes

### DIFF
--- a/.github/workflows/openapi-ci.yml
+++ b/.github/workflows/openapi-ci.yml
@@ -14,12 +14,13 @@ on:
       - '.github/workflows/openapi-ci.yml'
   push:
     branches:
-      - agent/openapi-governance-v2-dev
+      - 'agent/openapi-*'
     paths:
       - 'openapi-service/**'
       - 'fi-service/**'
       - 'gateway/**'
       - 'common/**'
+      - 'sql/matrix_open_api_*.sql'
       - 'pom.xml'
       - '.github/workflows/openapi-ci.yml'
 

--- a/common/src/main/java/single/cjj/openapi/contract/OpenVoucherDraftCreateCommand.java
+++ b/common/src/main/java/single/cjj/openapi/contract/OpenVoucherDraftCreateCommand.java
@@ -1,0 +1,23 @@
+package single.cjj.openapi.contract;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class OpenVoucherDraftCreateCommand {
+
+    private String sourceRequestId;
+    private String tenantId;
+    private String organizationId;
+    private String bookId;
+    private LocalDate voucherDate;
+    private String summary;
+    private String createdBy;
+    private List<OpenVoucherDraftLineCommand> lines;
+}

--- a/common/src/main/java/single/cjj/openapi/contract/OpenVoucherDraftCreateResult.java
+++ b/common/src/main/java/single/cjj/openapi/contract/OpenVoucherDraftCreateResult.java
@@ -1,0 +1,15 @@
+package single.cjj.openapi.contract;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class OpenVoucherDraftCreateResult {
+
+    private Long voucherId;
+    private String voucherNumber;
+    private String status;
+}

--- a/common/src/main/java/single/cjj/openapi/contract/OpenVoucherDraftLineCommand.java
+++ b/common/src/main/java/single/cjj/openapi/contract/OpenVoucherDraftLineCommand.java
@@ -1,0 +1,23 @@
+package single.cjj.openapi.contract;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class OpenVoucherDraftLineCommand {
+
+    private Integer lineNo;
+    private String accountCode;
+    private String summary;
+    private BigDecimal debitAmount;
+    private BigDecimal creditAmount;
+    private String currency;
+    private BigDecimal rate;
+    private BigDecimal originalAmount;
+    private String cashflowItem;
+}

--- a/docs/bus/platform/openapi/manifest.json
+++ b/docs/bus/platform/openapi/manifest.json
@@ -4,13 +4,14 @@
   "bizCode": "openapi",
   "bizName": "开放平台",
   "status": "development",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "busDocs": [
     "business.md",
     "rules.md",
     "api.md",
     "deployment.md",
-    "governance-v2.md"
+    "governance-v2.md",
+    "voucher-write-v3.md"
   ],
   "promptDocs": [
     "docs/prompt/platform/openapi/backend.md",

--- a/docs/bus/platform/openapi/voucher-write-v3.md
+++ b/docs/bus/platform/openapi/voucher-write-v3.md
@@ -1,0 +1,232 @@
+# OpenAPI V3：凭证草稿异步写入
+
+## 1. 目标与边界
+
+V3A 允许获得 `fi.voucher.write` 授权的外部应用可靠创建 Matrix 凭证草稿。
+
+本期只开放草稿创建，不开放：
+
+- 凭证提交
+- 凭证审核
+- 凭证过账
+- 凭证冲销
+- 凭证删除
+- 外部回调与每日对账（V3B）
+
+## 2. 外部接口
+
+### 2.1 受理写入请求
+
+```http
+POST /api/open-api/v1/fi/voucher-requests
+```
+
+请求示例：
+
+```json
+{
+  "externalBizNo": "EXPENSE-20260722-0001",
+  "idempotencyKey": "expense:EXPENSE-20260722-0001",
+  "organizationId": "ORG-001",
+  "bookId": "BOOK-001",
+  "voucherDate": "2026-07-22",
+  "summary": "员工差旅报销",
+  "lines": [
+    {
+      "lineNo": 1,
+      "accountCode": "660201",
+      "summary": "差旅费",
+      "debitAmount": 1200.00,
+      "creditAmount": 0
+    },
+    {
+      "lineNo": 2,
+      "accountCode": "224101",
+      "summary": "应付员工款",
+      "debitAmount": 0,
+      "creditAmount": 1200.00
+    }
+  ]
+}
+```
+
+成功受理返回 HTTP 202，任务初始状态为 `ACCEPTED`。
+
+### 2.2 按请求 ID 查询
+
+```http
+GET /api/open-api/v1/fi/voucher-requests/{requestId}
+```
+
+### 2.3 按外部业务单号查询
+
+```http
+GET /api/open-api/v1/fi/voucher-requests/by-external-no/{externalBizNo}
+```
+
+## 3. POST 签名
+
+POST 与 GET 使用同一 HMAC-SHA256 规则，但 POST 的 Canonical Request 必须包含原始 HTTP 请求体字节的 SHA-256：
+
+```text
+HTTP_METHOD
+REQUEST_PATH
+CANONICAL_QUERY
+SHA256_HEX(RAW_REQUEST_BODY)
+TIMESTAMP
+NONCE
+```
+
+注意：
+
+- 签名必须使用实际发送的 JSON 原始字节，不能先解析后重新序列化。
+- `Content-Type` 建议固定为 `application/json; charset=UTF-8`。
+- 请求体默认上限为 1 MiB，可通过 `OPENAPI_MAX_REQUEST_BODY_BYTES` 调整。
+- 网关部署前缀 `/api` 不参与稳定外部路径签名，签名路径为 `/open-api/...`。
+
+## 4. 幂等规则
+
+数据库唯一键：
+
+```text
+app_id + idempotency_key
+app_id + external_biz_no
+```
+
+处理规则：
+
+| 场景 | 结果 |
+|---|---|
+| 首次请求 | 创建写入任务、分录和 Outbox |
+| 相同幂等键且请求体 SHA-256 相同 | 返回原任务 |
+| 相同幂等键但请求体不同 | `OPENAPI_VOUCHER_40901` |
+| 外部业务单号已存在 | `OPENAPI_VOUCHER_40902` |
+| RabbitMQ 重复消费 | `tenant_id + source_request_id` 返回原凭证 |
+
+## 5. 事务与消息链路
+
+```text
+外部 POST
+  -> 校验应用、签名、Nonce、授权和额度
+  -> 同一数据库事务写入：
+       matrix_open_api_write_request
+       matrix_open_api_write_request_line
+       matrix_open_api_write_status_log
+       matrix_open_api_outbox_event
+  -> Outbox 调度器 CAS 抢占事件
+  -> RabbitMQ
+  -> 消费者 CAS 抢占写入任务
+  -> Feign 调用 fi-service 内部草稿创建接口
+  -> fi-service 通过 source_request_id 二次幂等
+  -> 写回 SUCCEEDED 或进入重试
+```
+
+Outbox 状态：
+
+```text
+PENDING -> SENDING -> SENT
+                  \-> FAILED -> SENDING
+                  \-> DEAD
+```
+
+写入任务状态：
+
+```text
+ACCEPTED -> PROCESSING -> SUCCEEDED
+                       \-> RETRYING -> PROCESSING
+                       \-> MANUAL_REQUIRED
+```
+
+处理超过配置时间仍为 `PROCESSING` 时，恢复任务会将其切回 `RETRYING` 并产生新 Outbox。
+
+## 6. 写入授权
+
+示例：
+
+```json
+{
+  "organizationIds": ["ORG-001"],
+  "bookIds": ["BOOK-001"],
+  "maxLinesPerVoucher": 200,
+  "dailyWriteQuota": 10000
+}
+```
+
+约束：
+
+- 租户由应用固定，调用方不能提交租户。
+- 组织和账簿必须在授权范围内。
+- 单张凭证分录至少 2 行，最多 500 行。
+- 每行必须且只能填写借方或贷方金额。
+- 借贷合计必须相等。
+- 写权限与只读权限分开授权。
+
+## 7. 管理接口
+
+```http
+GET  /api/openapi/admin/write-requests
+GET  /api/openapi/admin/write-requests/{requestId}
+POST /api/openapi/admin/write-requests/{requestId}/retry
+```
+
+人工重试仅允许 `PROCESSING_FAILED` 或 `MANUAL_REQUIRED` 状态。
+
+前端入口：
+
+```text
+/openapi -> 写入任务
+```
+
+## 8. 部署配置
+
+必须先执行：
+
+```bash
+mysql < sql/matrix_open_api_v3.sql
+```
+
+RabbitMQ 变量：
+
+```text
+RABBITMQ_HOST
+RABBITMQ_PORT
+RABBITMQ_USERNAME
+RABBITMQ_PASSWORD
+RABBITMQ_VHOST
+OPENAPI_WRITE_EXCHANGE
+OPENAPI_WRITE_QUEUE
+OPENAPI_WRITE_ROUTING_KEY
+OPENAPI_WRITE_CONSUMERS
+OPENAPI_WRITE_MAX_CONSUMERS
+```
+
+调度变量：
+
+```text
+OPENAPI_OUTBOX_POLL_MS
+OPENAPI_WRITE_RECOVERY_POLL_MS
+OPENAPI_STALE_PROCESSING_MINUTES
+OPENAPI_MAX_REQUEST_BODY_BYTES
+```
+
+`openapi-service` 与 `fi-service` 仍需配置相同的 `MATRIX_INTERNAL_OPENAPI_TOKEN`。
+
+## 9. 监控建议
+
+至少监控：
+
+- `ACCEPTED` 长时间未进入 `PROCESSING`
+- `PROCESSING` 超时数量
+- `RETRYING` 和 `MANUAL_REQUIRED` 数量
+- Outbox `FAILED`、`DEAD` 数量
+- RabbitMQ 队列堆积
+- 凭证创建成功率与平均耗时
+
+## 10. V3B 后续
+
+后续阶段补充：
+
+- 回调签名、回调任务与指数退避
+- 每日对账与异常补偿
+- API SDK 和完整接入样例
+- 错误类型分级，区分业务不可重试与基础设施可重试

--- a/fi-service/src/main/java/single/cjj/fi/gl/controller/BizfiFiVoucherOpenApiController.java
+++ b/fi-service/src/main/java/single/cjj/fi/gl/controller/BizfiFiVoucherOpenApiController.java
@@ -3,9 +3,13 @@ package single.cjj.fi.gl.controller;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -16,9 +20,13 @@ import single.cjj.fi.gl.entity.BizfiFiVoucher;
 import single.cjj.fi.gl.entity.BizfiFiVoucherLine;
 import single.cjj.fi.gl.service.BizfiFiVoucherService;
 import single.cjj.openapi.contract.OpenApiPageResponse;
+import single.cjj.openapi.contract.OpenVoucherDraftCreateCommand;
+import single.cjj.openapi.contract.OpenVoucherDraftCreateResult;
+import single.cjj.openapi.contract.OpenVoucherDraftLineCommand;
 import single.cjj.openapi.contract.OpenVoucherLineResponse;
 import single.cjj.openapi.contract.OpenVoucherResponse;
 
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -27,8 +35,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * 仅供 openapi-service 调用的凭证只读适配器。
- * 所有租户、组织、账簿和状态权限均在 SQL 条件中执行。
+ * 仅供 openapi-service 调用的凭证适配器。
+ * 查询按租户、组织、账簿和状态在 SQL 中过滤；写入仅创建草稿。
  */
 @RestController
 @RequestMapping("/internal/openapi/v1/vouchers")
@@ -45,6 +53,48 @@ public class BizfiFiVoucherOpenApiController {
 
     public BizfiFiVoucherOpenApiController(BizfiFiVoucherService voucherService) {
         this.voucherService = voucherService;
+    }
+
+    @PostMapping("/drafts")
+    @Transactional(rollbackFor = Exception.class)
+    public ApiResponse<OpenVoucherDraftCreateResult> createDraft(
+            @RequestBody OpenVoucherDraftCreateCommand command) {
+        validateDraftCommand(command);
+        BizfiFiVoucher existing = findBySourceRequest(command.getTenantId(), command.getSourceRequestId());
+        if (existing != null) {
+            return ApiResponse.success(toDraftResult(existing));
+        }
+
+        BizfiFiVoucher voucher = new BizfiFiVoucher();
+        voucher.setTenantId(command.getTenantId().trim());
+        voucher.setOrganizationId(command.getOrganizationId().trim());
+        voucher.setBookId(command.getBookId().trim());
+        voucher.setSourceRequestId(command.getSourceRequestId().trim());
+        voucher.setFdate(command.getVoucherDate());
+        voucher.setFsummary(command.getSummary().trim());
+        voucher.setFamount(command.getLines().stream()
+                .map(OpenVoucherDraftLineCommand::getDebitAmount)
+                .map(this::amount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add));
+        voucher.setFcreatedBy(StringUtils.hasText(command.getCreatedBy())
+                ? command.getCreatedBy().trim() : "openapi");
+
+        BizfiFiVoucher saved;
+        try {
+            saved = voucherService.saveDraft(voucher);
+        } catch (DuplicateKeyException e) {
+            BizfiFiVoucher concurrent = findBySourceRequest(command.getTenantId(), command.getSourceRequestId());
+            if (concurrent != null) {
+                return ApiResponse.success(toDraftResult(concurrent));
+            }
+            throw e;
+        }
+
+        List<BizfiFiVoucherLine> lines = command.getLines().stream()
+                .map(this::toVoucherLine)
+                .collect(Collectors.toList());
+        voucherService.saveLines(saved.getFid(), lines);
+        return ApiResponse.success(toDraftResult(voucherService.get(saved.getFid())));
     }
 
     @GetMapping
@@ -141,6 +191,71 @@ public class BizfiFiVoucherOpenApiController {
             return ApiResponse.success(Collections.emptyList());
         }
         return ApiResponse.success(lines.stream().map(this::toOpenLine).collect(Collectors.toList()));
+    }
+
+    private void validateDraftCommand(OpenVoucherDraftCreateCommand command) {
+        if (command == null
+                || !StringUtils.hasText(command.getSourceRequestId())
+                || !StringUtils.hasText(command.getTenantId())
+                || !StringUtils.hasText(command.getOrganizationId())
+                || !StringUtils.hasText(command.getBookId())
+                || command.getVoucherDate() == null
+                || !StringUtils.hasText(command.getSummary())) {
+            throw new BizException("凭证草稿写入参数不完整");
+        }
+        if (command.getLines() == null || command.getLines().size() < 2) {
+            throw new BizException("凭证至少需要2条分录");
+        }
+        BigDecimal debit = BigDecimal.ZERO;
+        BigDecimal credit = BigDecimal.ZERO;
+        int index = 1;
+        for (OpenVoucherDraftLineCommand line : command.getLines()) {
+            if (line == null || !StringUtils.hasText(line.getAccountCode())) {
+                throw new BizException("第" + index + "行科目不能为空");
+            }
+            BigDecimal lineDebit = amount(line.getDebitAmount());
+            BigDecimal lineCredit = amount(line.getCreditAmount());
+            if (lineDebit.signum() < 0 || lineCredit.signum() < 0
+                    || (lineDebit.signum() == 0) == (lineCredit.signum() == 0)) {
+                throw new BizException("第" + index + "行借贷金额不合法");
+            }
+            debit = debit.add(lineDebit);
+            credit = credit.add(lineCredit);
+            index++;
+        }
+        if (debit.compareTo(credit) != 0) {
+            throw new BizException("凭证借贷金额不平衡");
+        }
+    }
+
+    private BizfiFiVoucher findBySourceRequest(String tenantId, String sourceRequestId) {
+        return voucherService.getOne(new LambdaQueryWrapper<BizfiFiVoucher>()
+                .eq(BizfiFiVoucher::getTenantId, tenantId.trim())
+                .eq(BizfiFiVoucher::getSourceRequestId, sourceRequestId.trim()), false);
+    }
+
+    private BizfiFiVoucherLine toVoucherLine(OpenVoucherDraftLineCommand source) {
+        BizfiFiVoucherLine line = new BizfiFiVoucherLine();
+        line.setFlineNo(source.getLineNo());
+        line.setFaccountCode(source.getAccountCode());
+        line.setFsummary(source.getSummary());
+        line.setFdebitAmount(source.getDebitAmount());
+        line.setFcreditAmount(source.getCreditAmount());
+        line.setFcurrency(source.getCurrency());
+        line.setFrate(source.getRate());
+        line.setForiginalAmount(source.getOriginalAmount());
+        line.setFcashflowItem(source.getCashflowItem());
+        return line;
+    }
+
+    private OpenVoucherDraftCreateResult toDraftResult(BizfiFiVoucher voucher) {
+        return new OpenVoucherDraftCreateResult(
+                voucher.getFid(), voucher.getFnumber(), voucher.getFstatus()
+        );
+    }
+
+    private BigDecimal amount(BigDecimal value) {
+        return value == null ? BigDecimal.ZERO : value;
     }
 
     private BizfiFiVoucher requireAllowedVoucher(Long voucherId,

--- a/fi-service/src/main/java/single/cjj/fi/gl/entity/BizfiFiVoucher.java
+++ b/fi-service/src/main/java/single/cjj/fi/gl/entity/BizfiFiVoucher.java
@@ -38,6 +38,10 @@ public class BizfiFiVoucher implements Serializable {
     @TableField("book_id")
     private String bookId;
 
+    /** OpenAPI写入来源请求，用于消费幂等 */
+    @TableField("source_request_id")
+    private String sourceRequestId;
+
     /** 凭证编号 */
     private String fnumber;
 

--- a/openapi-service/pom.xml
+++ b/openapi-service/pom.xml
@@ -29,6 +29,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-amqp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>

--- a/openapi-service/src/main/java/single/cjj/openapi/OpenApiApplication.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/OpenApiApplication.java
@@ -4,7 +4,9 @@ import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableFeignClients
 @MapperScan("single.cjj.openapi.mapper")
 @SpringBootApplication

--- a/openapi-service/src/main/java/single/cjj/openapi/client/FiVoucherWriteClient.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/client/FiVoucherWriteClient.java
@@ -1,0 +1,22 @@
+package single.cjj.openapi.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import single.cjj.bizfi.entity.ApiResponse;
+import single.cjj.openapi.contract.OpenVoucherDraftCreateCommand;
+import single.cjj.openapi.contract.OpenVoucherDraftCreateResult;
+
+@FeignClient(
+        name = "fi-service",
+        contextId = "fiVoucherWriteClient",
+        path = "/api/internal/openapi/v1/vouchers",
+        configuration = FiOpenApiClientConfig.class
+)
+public interface FiVoucherWriteClient {
+
+    @PostMapping("/drafts")
+    ApiResponse<OpenVoucherDraftCreateResult> createDraft(
+            @RequestBody OpenVoucherDraftCreateCommand command
+    );
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/config/OpenApiWriteMessagingConfig.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/config/OpenApiWriteMessagingConfig.java
@@ -1,0 +1,44 @@
+package single.cjj.openapi.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiWriteMessagingConfig {
+
+    private final String exchangeName;
+    private final String queueName;
+    private final String routingKey;
+
+    public OpenApiWriteMessagingConfig(
+            @Value("${matrix.openapi.write.exchange:matrix.openapi.write.exchange}") String exchangeName,
+            @Value("${matrix.openapi.write.queue:matrix.openapi.voucher.write.queue}") String queueName,
+            @Value("${matrix.openapi.write.routing-key:matrix.openapi.voucher.write}") String routingKey) {
+        this.exchangeName = exchangeName;
+        this.queueName = queueName;
+        this.routingKey = routingKey;
+    }
+
+    @Bean
+    public DirectExchange openApiWriteExchange() {
+        return new DirectExchange(exchangeName, true, false);
+    }
+
+    @Bean
+    public Queue openApiVoucherWriteQueue() {
+        return new Queue(queueName, true);
+    }
+
+    @Bean
+    public Binding openApiVoucherWriteBinding(Queue openApiVoucherWriteQueue,
+                                               DirectExchange openApiWriteExchange) {
+        return BindingBuilder.bind(openApiVoucherWriteQueue)
+                .to(openApiWriteExchange)
+                .with(routingKey);
+    }
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/controller/OpenApiWriteAdminController.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/controller/OpenApiWriteAdminController.java
@@ -1,0 +1,98 @@
+package single.cjj.openapi.controller;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import single.cjj.bizfi.entity.ApiResponse;
+import single.cjj.openapi.contract.OpenApiPageResponse;
+import single.cjj.openapi.dto.VoucherWriteDetailResponse;
+import single.cjj.openapi.dto.VoucherWriteStatusResponse;
+import single.cjj.openapi.entity.OpenApiWriteRequest;
+import single.cjj.openapi.mapper.OpenApiWriteRequestMapper;
+import single.cjj.openapi.service.OpenApiVoucherWriteService;
+import single.cjj.openapi.service.OpenApiWriteStateService;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RestController
+@RequestMapping("/openapi/admin/write-requests")
+public class OpenApiWriteAdminController {
+
+    private final OpenApiWriteRequestMapper requestMapper;
+    private final OpenApiVoucherWriteService writeService;
+    private final OpenApiWriteStateService stateService;
+
+    public OpenApiWriteAdminController(OpenApiWriteRequestMapper requestMapper,
+                                       OpenApiVoucherWriteService writeService,
+                                       OpenApiWriteStateService stateService) {
+        this.requestMapper = requestMapper;
+        this.writeService = writeService;
+        this.stateService = stateService;
+    }
+
+    @GetMapping
+    public ApiResponse<OpenApiPageResponse<VoucherWriteStatusResponse>> list(
+            @RequestParam(value = "pageNo", defaultValue = "1") int pageNo,
+            @RequestParam(value = "pageSize", defaultValue = "20") int pageSize,
+            @RequestParam(value = "requestId", required = false) String requestId,
+            @RequestParam(value = "appId", required = false) String appId,
+            @RequestParam(value = "externalBizNo", required = false) String externalBizNo,
+            @RequestParam(value = "status", required = false) String status,
+            @RequestParam(value = "startTime", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startTime,
+            @RequestParam(value = "endTime", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endTime) {
+        LambdaQueryWrapper<OpenApiWriteRequest> wrapper = new LambdaQueryWrapper<>();
+        if (StringUtils.hasText(requestId)) {
+            wrapper.like(OpenApiWriteRequest::getRequestId, requestId.trim());
+        }
+        if (StringUtils.hasText(appId)) {
+            wrapper.eq(OpenApiWriteRequest::getAppExternalId, appId.trim());
+        }
+        if (StringUtils.hasText(externalBizNo)) {
+            wrapper.like(OpenApiWriteRequest::getExternalBizNo, externalBizNo.trim());
+        }
+        if (StringUtils.hasText(status)) {
+            wrapper.eq(OpenApiWriteRequest::getStatus, status.trim().toUpperCase());
+        }
+        if (startTime != null) {
+            wrapper.ge(OpenApiWriteRequest::getCreatedAt, startTime);
+        }
+        if (endTime != null) {
+            wrapper.le(OpenApiWriteRequest::getCreatedAt, endTime);
+        }
+        wrapper.orderByDesc(OpenApiWriteRequest::getId);
+
+        int safePageNo = Math.max(1, pageNo);
+        int safePageSize = Math.max(1, Math.min(pageSize, 200));
+        IPage<OpenApiWriteRequest> page = requestMapper.selectPage(
+                new Page<>(safePageNo, safePageSize), wrapper
+        );
+        List<VoucherWriteStatusResponse> items = page.getRecords().stream()
+                .map(VoucherWriteStatusResponse::from)
+                .toList();
+        return ApiResponse.success(OpenApiPageResponse.of(
+                page.getTotal(), safePageNo, safePageSize, items
+        ));
+    }
+
+    @GetMapping("/{requestId}")
+    public ApiResponse<VoucherWriteDetailResponse> detail(
+            @PathVariable("requestId") String requestId) {
+        return ApiResponse.success(writeService.detail(requestId));
+    }
+
+    @PostMapping("/{requestId}/retry")
+    public ApiResponse<Boolean> retry(@PathVariable("requestId") String requestId) {
+        return ApiResponse.success(stateService.manualRetry(requestId));
+    }
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/controller/VoucherWriteOpenApiController.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/controller/VoucherWriteOpenApiController.java
@@ -1,0 +1,73 @@
+package single.cjj.openapi.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import single.cjj.openapi.dto.OpenApiEnvelope;
+import single.cjj.openapi.dto.VoucherWriteCreateRequest;
+import single.cjj.openapi.dto.VoucherWriteStatusResponse;
+import single.cjj.openapi.exception.OpenApiCallException;
+import single.cjj.openapi.security.OpenApiContext;
+import single.cjj.openapi.service.OpenApiVoucherWriteService;
+
+@RestController
+@RequestMapping("/open-api/v1/fi/voucher-requests")
+public class VoucherWriteOpenApiController {
+
+    private final OpenApiVoucherWriteService writeService;
+
+    public VoucherWriteOpenApiController(OpenApiVoucherWriteService writeService) {
+        this.writeService = writeService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public OpenApiEnvelope<VoucherWriteStatusResponse> create(
+            @RequestBody VoucherWriteCreateRequest input,
+            HttpServletRequest request) {
+        OpenApiContext context = context(request);
+        Object bodyHash = request.getAttribute(OpenApiContext.REQUEST_BODY_HASH_ATTRIBUTE);
+        VoucherWriteStatusResponse result = writeService.accept(
+                context,
+                input,
+                bodyHash == null ? null : String.valueOf(bodyHash)
+        );
+        return OpenApiEnvelope.success(context.getRequestId(), result);
+    }
+
+    @GetMapping("/{requestId}")
+    public OpenApiEnvelope<VoucherWriteStatusResponse> status(
+            @PathVariable("requestId") String requestId,
+            HttpServletRequest request) {
+        OpenApiContext context = context(request);
+        VoucherWriteStatusResponse result = writeService.statusForApp(
+                context.getApp().getId(), requestId
+        );
+        return OpenApiEnvelope.success(context.getRequestId(), result);
+    }
+
+    @GetMapping("/by-external-no/{externalBizNo}")
+    public OpenApiEnvelope<VoucherWriteStatusResponse> statusByExternalNo(
+            @PathVariable("externalBizNo") String externalBizNo,
+            HttpServletRequest request) {
+        OpenApiContext context = context(request);
+        VoucherWriteStatusResponse result = writeService.statusForAppByExternalNo(
+                context.getApp().getId(), externalBizNo
+        );
+        return OpenApiEnvelope.success(context.getRequestId(), result);
+    }
+
+    private OpenApiContext context(HttpServletRequest request) {
+        Object value = request.getAttribute(OpenApiContext.REQUEST_ATTRIBUTE);
+        if (!(value instanceof OpenApiContext context)) {
+            throw new OpenApiCallException("OPENAPI_50001", "OpenAPI认证上下文缺失", 500);
+        }
+        return context;
+    }
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/dto/VoucherWriteCreateRequest.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/dto/VoucherWriteCreateRequest.java
@@ -1,0 +1,18 @@
+package single.cjj.openapi.dto;
+
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+public class VoucherWriteCreateRequest {
+
+    private String externalBizNo;
+    private String idempotencyKey;
+    private String organizationId;
+    private String bookId;
+    private LocalDate voucherDate;
+    private String summary;
+    private List<VoucherWriteLineRequest> lines;
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/dto/VoucherWriteDetailResponse.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/dto/VoucherWriteDetailResponse.java
@@ -1,0 +1,19 @@
+package single.cjj.openapi.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import single.cjj.openapi.entity.OpenApiWriteRequestLine;
+import single.cjj.openapi.entity.OpenApiWriteStatusLog;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class VoucherWriteDetailResponse {
+
+    private VoucherWriteStatusResponse request;
+    private List<OpenApiWriteRequestLine> lines;
+    private List<OpenApiWriteStatusLog> logs;
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/dto/VoucherWriteLineRequest.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/dto/VoucherWriteLineRequest.java
@@ -1,0 +1,19 @@
+package single.cjj.openapi.dto;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+@Data
+public class VoucherWriteLineRequest {
+
+    private Integer lineNo;
+    private String accountCode;
+    private String summary;
+    private BigDecimal debitAmount;
+    private BigDecimal creditAmount;
+    private String currency;
+    private BigDecimal rate;
+    private BigDecimal originalAmount;
+    private String cashflowItem;
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/dto/VoucherWriteStatusResponse.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/dto/VoucherWriteStatusResponse.java
@@ -1,0 +1,53 @@
+package single.cjj.openapi.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import single.cjj.openapi.entity.OpenApiWriteRequest;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class VoucherWriteStatusResponse {
+
+    private String requestId;
+    private String externalBizNo;
+    private String status;
+    private String tenantId;
+    private String organizationId;
+    private String bookId;
+    private LocalDate voucherDate;
+    private String summary;
+    private Long voucherId;
+    private String voucherNumber;
+    private String errorCode;
+    private String errorMessage;
+    private Integer retryCount;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime finishedAt;
+
+    public static VoucherWriteStatusResponse from(OpenApiWriteRequest request) {
+        return new VoucherWriteStatusResponse(
+                request.getRequestId(),
+                request.getExternalBizNo(),
+                request.getStatus(),
+                request.getTenantId(),
+                request.getOrganizationId(),
+                request.getBookId(),
+                request.getVoucherDate(),
+                request.getSummary(),
+                request.getVoucherId(),
+                request.getVoucherNumber(),
+                request.getErrorCode(),
+                request.getErrorMessage(),
+                request.getRetryCount(),
+                request.getCreatedAt(),
+                request.getUpdatedAt(),
+                request.getFinishedAt()
+        );
+    }
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/entity/OpenApiOutboxEvent.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/entity/OpenApiOutboxEvent.java
@@ -1,0 +1,29 @@
+package single.cjj.openapi.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@TableName("matrix_open_api_outbox_event")
+public class OpenApiOutboxEvent {
+
+    @TableId(type = IdType.AUTO)
+    private Long id;
+    private String eventId;
+    private String aggregateType;
+    private Long aggregateId;
+    private String eventType;
+    private String payloadJson;
+    private String status;
+    private Integer retryCount;
+    private Integer maxRetry;
+    private LocalDateTime nextAttemptAt;
+    private LocalDateTime sentAt;
+    private String errorMessage;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/entity/OpenApiWriteRequest.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/entity/OpenApiWriteRequest.java
@@ -1,0 +1,39 @@
+package single.cjj.openapi.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Data
+@TableName("matrix_open_api_write_request")
+public class OpenApiWriteRequest {
+
+    @TableId(type = IdType.AUTO)
+    private Long id;
+    private String requestId;
+    private Long appId;
+    private String appExternalId;
+    private String tenantId;
+    private String externalBizNo;
+    private String idempotencyKey;
+    private String requestBodyHash;
+    private String organizationId;
+    private String bookId;
+    private LocalDate voucherDate;
+    private String summary;
+    private String status;
+    private Long voucherId;
+    private String voucherNumber;
+    private String errorCode;
+    private String errorMessage;
+    private Integer retryCount;
+    private Integer maxRetry;
+    private LocalDateTime nextRetryAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime finishedAt;
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/entity/OpenApiWriteRequestLine.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/entity/OpenApiWriteRequestLine.java
@@ -1,0 +1,26 @@
+package single.cjj.openapi.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+@Data
+@TableName("matrix_open_api_write_request_line")
+public class OpenApiWriteRequestLine {
+
+    @TableId(type = IdType.AUTO)
+    private Long id;
+    private Long writeRequestId;
+    private Integer lineNo;
+    private String accountCode;
+    private String summary;
+    private BigDecimal debitAmount;
+    private BigDecimal creditAmount;
+    private String currency;
+    private BigDecimal rate;
+    private BigDecimal originalAmount;
+    private String cashflowItem;
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/entity/OpenApiWriteStatusLog.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/entity/OpenApiWriteStatusLog.java
@@ -1,0 +1,22 @@
+package single.cjj.openapi.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@TableName("matrix_open_api_write_status_log")
+public class OpenApiWriteStatusLog {
+
+    @TableId(type = IdType.AUTO)
+    private Long id;
+    private Long writeRequestId;
+    private String fromStatus;
+    private String toStatus;
+    private String errorCode;
+    private String message;
+    private LocalDateTime createdAt;
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/mapper/OpenApiOutboxEventMapper.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/mapper/OpenApiOutboxEventMapper.java
@@ -1,0 +1,7 @@
+package single.cjj.openapi.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import single.cjj.openapi.entity.OpenApiOutboxEvent;
+
+public interface OpenApiOutboxEventMapper extends BaseMapper<OpenApiOutboxEvent> {
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/mapper/OpenApiWriteRequestLineMapper.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/mapper/OpenApiWriteRequestLineMapper.java
@@ -1,0 +1,7 @@
+package single.cjj.openapi.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import single.cjj.openapi.entity.OpenApiWriteRequestLine;
+
+public interface OpenApiWriteRequestLineMapper extends BaseMapper<OpenApiWriteRequestLine> {
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/mapper/OpenApiWriteRequestMapper.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/mapper/OpenApiWriteRequestMapper.java
@@ -1,0 +1,7 @@
+package single.cjj.openapi.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import single.cjj.openapi.entity.OpenApiWriteRequest;
+
+public interface OpenApiWriteRequestMapper extends BaseMapper<OpenApiWriteRequest> {
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/mapper/OpenApiWriteStatusLogMapper.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/mapper/OpenApiWriteStatusLogMapper.java
@@ -1,0 +1,7 @@
+package single.cjj.openapi.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import single.cjj.openapi.entity.OpenApiWriteStatusLog;
+
+public interface OpenApiWriteStatusLogMapper extends BaseMapper<OpenApiWriteStatusLog> {
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/security/CachedBodyHttpServletRequest.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/security/CachedBodyHttpServletRequest.java
@@ -1,0 +1,57 @@
+package single.cjj.openapi.security;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+
+public class CachedBodyHttpServletRequest extends HttpServletRequestWrapper {
+
+    private final byte[] body;
+
+    public CachedBodyHttpServletRequest(HttpServletRequest request) throws IOException {
+        super(request);
+        this.body = request.getInputStream().readAllBytes();
+    }
+
+    public byte[] getCachedBody() {
+        return body.clone();
+    }
+
+    @Override
+    public ServletInputStream getInputStream() {
+        ByteArrayInputStream input = new ByteArrayInputStream(body);
+        return new ServletInputStream() {
+            @Override
+            public boolean isFinished() {
+                return input.available() == 0;
+            }
+
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public void setReadListener(ReadListener readListener) {
+                // Synchronous MVC request body; asynchronous callbacks are not used.
+            }
+
+            @Override
+            public int read() {
+                return input.read();
+            }
+        };
+    }
+
+    @Override
+    public BufferedReader getReader() {
+        return new BufferedReader(new InputStreamReader(getInputStream(), StandardCharsets.UTF_8));
+    }
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/security/OpenApiAuthenticationFilter.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/security/OpenApiAuthenticationFilter.java
@@ -32,6 +32,7 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 @Slf4j
@@ -43,6 +44,7 @@ public class OpenApiAuthenticationFilter extends OncePerRequestFilter {
     private static final String NONCE_HEADER = "X-Matrix-Nonce";
     private static final String SIGNATURE_HEADER = "X-Matrix-Signature";
     private static final String REQUEST_ID_HEADER = "X-Matrix-Request-Id";
+    private static final Set<String> ALLOWED_METHODS = Set.of("GET", "POST");
 
     private final OpenApiAppMapper appMapper;
     private final OpenApiDefinitionMapper definitionMapper;
@@ -54,6 +56,7 @@ public class OpenApiAuthenticationFilter extends OncePerRequestFilter {
     private final ObjectMapper objectMapper;
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
     private final long replayWindowSeconds;
+    private final int maxRequestBodyBytes;
 
     public OpenApiAuthenticationFilter(OpenApiAppMapper appMapper,
                                        OpenApiDefinitionMapper definitionMapper,
@@ -63,7 +66,8 @@ public class OpenApiAuthenticationFilter extends OncePerRequestFilter {
                                        OpenApiSignatureService signatureService,
                                        StringRedisTemplate redisTemplate,
                                        ObjectMapper objectMapper,
-                                       @Value("${matrix.openapi.replay-window-seconds:300}") long replayWindowSeconds) {
+                                       @Value("${matrix.openapi.replay-window-seconds:300}") long replayWindowSeconds,
+                                       @Value("${matrix.openapi.max-request-body-bytes:1048576}") int maxRequestBodyBytes) {
         this.appMapper = appMapper;
         this.definitionMapper = definitionMapper;
         this.grantMapper = grantMapper;
@@ -73,6 +77,7 @@ public class OpenApiAuthenticationFilter extends OncePerRequestFilter {
         this.redisTemplate = redisTemplate;
         this.objectMapper = objectMapper;
         this.replayWindowSeconds = Math.max(60, replayWindowSeconds);
+        this.maxRequestBodyBytes = Math.max(1024, maxRequestBodyBytes);
     }
 
     @Override
@@ -91,34 +96,46 @@ public class OpenApiAuthenticationFilter extends OncePerRequestFilter {
         String errorMessage = null;
         OpenApiApp app = null;
         OpenApiDefinition definition = null;
+        HttpServletRequest effectiveRequest = request;
 
         response.setHeader(REQUEST_ID_HEADER, requestId);
 
         try {
-            if (!"GET".equalsIgnoreCase(request.getMethod())) {
-                throw new OpenApiAuthException("OPENAPI_40001", "第一阶段只支持GET请求", 405);
+            String method = request.getMethod().toUpperCase();
+            if (!ALLOWED_METHODS.contains(method)) {
+                throw new OpenApiAuthException("OPENAPI_40001", "开放平台当前只支持GET和POST请求", 405);
             }
 
-            String appKey = requiredHeader(request, APP_KEY_HEADER, "OPENAPI_40101", "AppKey缺失");
-            String timestamp = requiredHeader(request, TIMESTAMP_HEADER, "OPENAPI_40103", "时间戳缺失");
-            String nonce = requiredHeader(request, NONCE_HEADER, "OPENAPI_40104", "Nonce缺失");
-            String signature = requiredHeader(request, SIGNATURE_HEADER, "OPENAPI_40102", "签名缺失");
+            byte[] requestBody = new byte[0];
+            if ("POST".equals(method)) {
+                CachedBodyHttpServletRequest cachedRequest = new CachedBodyHttpServletRequest(request);
+                requestBody = cachedRequest.getCachedBody();
+                if (requestBody.length > maxRequestBodyBytes) {
+                    throw new OpenApiAuthException("OPENAPI_41301", "请求体超过开放平台大小限制", 413);
+                }
+                effectiveRequest = cachedRequest;
+            }
+
+            String appKey = requiredHeader(effectiveRequest, APP_KEY_HEADER, "OPENAPI_40101", "AppKey缺失");
+            String timestamp = requiredHeader(effectiveRequest, TIMESTAMP_HEADER, "OPENAPI_40103", "时间戳缺失");
+            String nonce = requiredHeader(effectiveRequest, NONCE_HEADER, "OPENAPI_40104", "Nonce缺失");
+            String signature = requiredHeader(effectiveRequest, SIGNATURE_HEADER, "OPENAPI_40102", "签名缺失");
 
             validateTimestamp(timestamp);
             app = findApp(appKey);
             validateApp(app);
 
-            String path = relativePath(request);
-            definition = findDefinition(request.getMethod(), path);
+            String path = relativePath(effectiveRequest);
+            definition = findDefinition(method, path);
             OpenApiGrant grant = findGrant(app.getId(), definition.getId());
             validateGrant(grant);
-            validateIp(app, clientIp(request));
+            validateIp(app, clientIp(effectiveRequest));
 
             String canonicalRequest = signatureService.canonicalRequest(
-                    request.getMethod(),
+                    method,
                     path,
-                    request.getParameterMap(),
-                    new byte[0],
+                    effectiveRequest.getParameterMap(),
+                    requestBody,
                     timestamp,
                     nonce
             );
@@ -133,11 +150,15 @@ public class OpenApiAuthenticationFilter extends OncePerRequestFilter {
             validateNonce(app.getAppKey(), nonce);
             validateRateLimit(app, definition);
 
-            request.setAttribute(
+            effectiveRequest.setAttribute(
                     OpenApiContext.REQUEST_ATTRIBUTE,
                     new OpenApiContext(requestId, app, definition, grant)
             );
-            filterChain.doFilter(request, response);
+            effectiveRequest.setAttribute(
+                    OpenApiContext.REQUEST_BODY_HASH_ATTRIBUTE,
+                    signatureService.sha256Hex(requestBody)
+            );
+            filterChain.doFilter(effectiveRequest, response);
         } catch (OpenApiAuthException e) {
             errorCode = e.getCode();
             errorMessage = e.getMessage();
@@ -151,7 +172,7 @@ public class OpenApiAuthenticationFilter extends OncePerRequestFilter {
             }
         } finally {
             writeRequestLog(
-                    request,
+                    effectiveRequest,
                     response,
                     requestId,
                     requestTime,

--- a/openapi-service/src/main/java/single/cjj/openapi/security/OpenApiContext.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/security/OpenApiContext.java
@@ -11,6 +11,7 @@ import single.cjj.openapi.entity.OpenApiGrant;
 public class OpenApiContext {
 
     public static final String REQUEST_ATTRIBUTE = OpenApiContext.class.getName();
+    public static final String REQUEST_BODY_HASH_ATTRIBUTE = OpenApiContext.class.getName() + ".bodySha256";
 
     private final String requestId;
     private final OpenApiApp app;

--- a/openapi-service/src/main/java/single/cjj/openapi/service/OpenApiOutboxDispatcher.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/service/OpenApiOutboxDispatcher.java
@@ -3,6 +3,7 @@ package single.cjj.openapi.service;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -13,6 +14,7 @@ import single.cjj.openapi.mapper.OpenApiOutboxEventMapper;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Component
@@ -25,17 +27,20 @@ public class OpenApiOutboxDispatcher {
     private final OpenApiWriteStateService stateService;
     private final String exchangeName;
     private final String routingKey;
+    private final long confirmTimeoutMs;
 
     public OpenApiOutboxDispatcher(OpenApiOutboxEventMapper outboxMapper,
                                    RabbitTemplate rabbitTemplate,
                                    OpenApiWriteStateService stateService,
                                    @Value("${matrix.openapi.write.exchange:matrix.openapi.write.exchange}") String exchangeName,
-                                   @Value("${matrix.openapi.write.routing-key:matrix.openapi.voucher.write}") String routingKey) {
+                                   @Value("${matrix.openapi.write.routing-key:matrix.openapi.voucher.write}") String routingKey,
+                                   @Value("${matrix.openapi.write.publisher-confirm-timeout-ms:5000}") long confirmTimeoutMs) {
         this.outboxMapper = outboxMapper;
         this.rabbitTemplate = rabbitTemplate;
         this.stateService = stateService;
         this.exchangeName = exchangeName;
         this.routingKey = routingKey;
+        this.confirmTimeoutMs = Math.max(1000L, confirmTimeoutMs);
     }
 
     @Scheduled(fixedDelayString = "${matrix.openapi.write.outbox-poll-ms:2000}")
@@ -73,9 +78,23 @@ public class OpenApiOutboxDispatcher {
         }
 
         try {
-            rabbitTemplate.convertAndSend(exchangeName, routingKey, String.valueOf(event.getAggregateId()));
+            CorrelationData correlationData = new CorrelationData(event.getEventId());
+            rabbitTemplate.convertAndSend(
+                    exchangeName,
+                    routingKey,
+                    String.valueOf(event.getAggregateId()),
+                    correlationData
+            );
+            CorrelationData.Confirm confirm = correlationData.getFuture()
+                    .get(confirmTimeoutMs, TimeUnit.MILLISECONDS);
+            if (!confirm.isAck()) {
+                throw new IllegalStateException(
+                        "RabbitMQ broker rejected message: " + confirm.getReason()
+                );
+            }
             outboxMapper.update(null, new LambdaUpdateWrapper<OpenApiOutboxEvent>()
                     .eq(OpenApiOutboxEvent::getId, event.getId())
+                    .eq(OpenApiOutboxEvent::getStatus, "SENDING")
                     .set(OpenApiOutboxEvent::getStatus, "SENT")
                     .set(OpenApiOutboxEvent::getSentAt, LocalDateTime.now())
                     .set(OpenApiOutboxEvent::getErrorMessage, null)
@@ -86,6 +105,7 @@ public class OpenApiOutboxDispatcher {
             boolean exhausted = retryCount >= maxRetry;
             outboxMapper.update(null, new LambdaUpdateWrapper<OpenApiOutboxEvent>()
                     .eq(OpenApiOutboxEvent::getId, event.getId())
+                    .eq(OpenApiOutboxEvent::getStatus, "SENDING")
                     .set(OpenApiOutboxEvent::getStatus, exhausted ? "DEAD" : "FAILED")
                     .set(OpenApiOutboxEvent::getRetryCount, retryCount)
                     .set(OpenApiOutboxEvent::getNextAttemptAt,

--- a/openapi-service/src/main/java/single/cjj/openapi/service/OpenApiOutboxDispatcher.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/service/OpenApiOutboxDispatcher.java
@@ -1,0 +1,110 @@
+package single.cjj.openapi.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import single.cjj.openapi.entity.OpenApiOutboxEvent;
+import single.cjj.openapi.mapper.OpenApiOutboxEventMapper;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+@Slf4j
+@Component
+public class OpenApiOutboxDispatcher {
+
+    private static final Set<String> DISPATCHABLE = Set.of("PENDING", "FAILED");
+
+    private final OpenApiOutboxEventMapper outboxMapper;
+    private final RabbitTemplate rabbitTemplate;
+    private final OpenApiWriteStateService stateService;
+    private final String exchangeName;
+    private final String routingKey;
+
+    public OpenApiOutboxDispatcher(OpenApiOutboxEventMapper outboxMapper,
+                                   RabbitTemplate rabbitTemplate,
+                                   OpenApiWriteStateService stateService,
+                                   @Value("${matrix.openapi.write.exchange:matrix.openapi.write.exchange}") String exchangeName,
+                                   @Value("${matrix.openapi.write.routing-key:matrix.openapi.voucher.write}") String routingKey) {
+        this.outboxMapper = outboxMapper;
+        this.rabbitTemplate = rabbitTemplate;
+        this.stateService = stateService;
+        this.exchangeName = exchangeName;
+        this.routingKey = routingKey;
+    }
+
+    @Scheduled(fixedDelayString = "${matrix.openapi.write.outbox-poll-ms:2000}")
+    public void dispatch() {
+        LocalDateTime now = LocalDateTime.now();
+        List<OpenApiOutboxEvent> events = outboxMapper.selectList(
+                new LambdaQueryWrapper<OpenApiOutboxEvent>()
+                        .in(OpenApiOutboxEvent::getStatus, DISPATCHABLE)
+                        .le(OpenApiOutboxEvent::getNextAttemptAt, now)
+                        .orderByAsc(OpenApiOutboxEvent::getId)
+                        .last("LIMIT 50")
+        );
+        for (OpenApiOutboxEvent event : events) {
+            dispatchOne(event);
+        }
+    }
+
+    @Scheduled(fixedDelayString = "${matrix.openapi.write.recovery-poll-ms:60000}")
+    public void recoverStaleProcessing() {
+        int recovered = stateService.recoverStaleProcessing();
+        if (recovered > 0) {
+            log.warn("recovered {} stale OpenAPI voucher write requests", recovered);
+        }
+    }
+
+    private void dispatchOne(OpenApiOutboxEvent event) {
+        LocalDateTime now = LocalDateTime.now();
+        int claimed = outboxMapper.update(null, new LambdaUpdateWrapper<OpenApiOutboxEvent>()
+                .eq(OpenApiOutboxEvent::getId, event.getId())
+                .in(OpenApiOutboxEvent::getStatus, DISPATCHABLE)
+                .set(OpenApiOutboxEvent::getStatus, "SENDING")
+                .set(OpenApiOutboxEvent::getUpdatedAt, now));
+        if (claimed == 0) {
+            return;
+        }
+
+        try {
+            rabbitTemplate.convertAndSend(exchangeName, routingKey, String.valueOf(event.getAggregateId()));
+            outboxMapper.update(null, new LambdaUpdateWrapper<OpenApiOutboxEvent>()
+                    .eq(OpenApiOutboxEvent::getId, event.getId())
+                    .set(OpenApiOutboxEvent::getStatus, "SENT")
+                    .set(OpenApiOutboxEvent::getSentAt, LocalDateTime.now())
+                    .set(OpenApiOutboxEvent::getErrorMessage, null)
+                    .set(OpenApiOutboxEvent::getUpdatedAt, LocalDateTime.now()));
+        } catch (Exception e) {
+            int retryCount = (event.getRetryCount() == null ? 0 : event.getRetryCount()) + 1;
+            int maxRetry = event.getMaxRetry() == null ? 10 : event.getMaxRetry();
+            boolean exhausted = retryCount >= maxRetry;
+            outboxMapper.update(null, new LambdaUpdateWrapper<OpenApiOutboxEvent>()
+                    .eq(OpenApiOutboxEvent::getId, event.getId())
+                    .set(OpenApiOutboxEvent::getStatus, exhausted ? "DEAD" : "FAILED")
+                    .set(OpenApiOutboxEvent::getRetryCount, retryCount)
+                    .set(OpenApiOutboxEvent::getNextAttemptAt,
+                            exhausted ? null : LocalDateTime.now().plusSeconds(retryDelaySeconds(retryCount)))
+                    .set(OpenApiOutboxEvent::getErrorMessage, truncate(e.getMessage(), 1000))
+                    .set(OpenApiOutboxEvent::getUpdatedAt, LocalDateTime.now()));
+            log.warn("dispatch OpenAPI outbox failed, eventId={}, retry={}, message={}",
+                    event.getEventId(), retryCount, e.getMessage());
+        }
+    }
+
+    private long retryDelaySeconds(int retryCount) {
+        return Math.min(300L, 5L * (1L << Math.min(retryCount, 6)));
+    }
+
+    private String truncate(String value, int maxLength) {
+        if (value == null) {
+            return null;
+        }
+        return value.length() <= maxLength ? value : value.substring(0, maxLength);
+    }
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/service/OpenApiPermissionService.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/service/OpenApiPermissionService.java
@@ -17,6 +17,8 @@ public class OpenApiPermissionService {
     private static final Set<String> VOUCHER_API_MAX_STATUSES = Set.of("POSTED");
     private static final Set<String> WILDCARD_SCOPE = Set.of("*");
     private static final int DEFAULT_HISTORY_MONTHS = 24;
+    private static final int DEFAULT_MAX_LINES = 200;
+    private static final int DEFAULT_DAILY_WRITE_QUOTA = 10000;
 
     private final ObjectMapper objectMapper;
 
@@ -25,52 +27,87 @@ public class OpenApiPermissionService {
     }
 
     public VoucherPermission resolveVoucherPermission(OpenApiApp app, OpenApiGrant grant) {
-        if (app == null || !StringUtils.hasText(app.getTenantId())) {
-            throw new OpenApiCallException("OPENAPI_50001", "应用租户配置缺失", 500);
-        }
-
+        String tenantId = requireTenant(app);
         Set<String> statuses = new LinkedHashSet<>(VOUCHER_API_MAX_STATUSES);
         Set<String> organizationIds = new LinkedHashSet<>(WILDCARD_SCOPE);
         Set<String> bookIds = new LinkedHashSet<>(WILDCARD_SCOPE);
         int maxHistoryMonths = DEFAULT_HISTORY_MONTHS;
 
         if (grant != null && StringUtils.hasText(grant.getDataPermissionJson())) {
-            try {
-                JsonNode root = objectMapper.readTree(grant.getDataPermissionJson());
-                JsonNode statusNode = root.path("allowedStatuses");
-                if (statusNode.isArray()) {
-                    Set<String> requested = new LinkedHashSet<>();
-                    statusNode.forEach(item -> {
-                        if (item.isTextual() && StringUtils.hasText(item.asText())) {
-                            requested.add(item.asText().trim().toUpperCase());
-                        }
-                    });
-                    statuses.retainAll(requested);
-                }
-                organizationIds = parseScope(root.path("organizationIds"));
-                bookIds = parseScope(root.path("bookIds"));
-                int configuredMonths = root.path("maxHistoryMonths").asInt(DEFAULT_HISTORY_MONTHS);
-                maxHistoryMonths = Math.max(1, Math.min(configuredMonths, 120));
-            } catch (OpenApiCallException e) {
-                throw e;
-            } catch (Exception e) {
-                throw new OpenApiCallException("OPENAPI_50001", "应用数据权限配置格式错误", 500);
+            JsonNode root = readPermission(grant);
+            JsonNode statusNode = root.path("allowedStatuses");
+            if (statusNode.isArray()) {
+                Set<String> requested = new LinkedHashSet<>();
+                statusNode.forEach(item -> {
+                    if (item.isTextual() && StringUtils.hasText(item.asText())) {
+                        requested.add(item.asText().trim().toUpperCase());
+                    }
+                });
+                statuses.retainAll(requested);
             }
+            organizationIds = parseScope(root.path("organizationIds"));
+            bookIds = parseScope(root.path("bookIds"));
+            int configuredMonths = root.path("maxHistoryMonths").asInt(DEFAULT_HISTORY_MONTHS);
+            maxHistoryMonths = Math.max(1, Math.min(configuredMonths, 120));
         }
 
         if (statuses.isEmpty()) {
             throw new OpenApiCallException("OPENAPI_40303", "应用没有可查询的凭证状态", 403);
         }
-        if (organizationIds.isEmpty() || bookIds.isEmpty()) {
-            throw new OpenApiCallException("OPENAPI_40303", "应用没有可查询的组织或账簿范围", 403);
+        requireDataScope(organizationIds, bookIds, "查询");
+        return new VoucherPermission(tenantId, statuses, organizationIds, bookIds, maxHistoryMonths);
+    }
+
+    public VoucherWritePermission resolveVoucherWritePermission(OpenApiApp app, OpenApiGrant grant) {
+        String tenantId = requireTenant(app);
+        Set<String> organizationIds = new LinkedHashSet<>(WILDCARD_SCOPE);
+        Set<String> bookIds = new LinkedHashSet<>(WILDCARD_SCOPE);
+        int maxLinesPerVoucher = DEFAULT_MAX_LINES;
+        int dailyWriteQuota = DEFAULT_DAILY_WRITE_QUOTA;
+
+        if (grant != null && StringUtils.hasText(grant.getDataPermissionJson())) {
+            JsonNode root = readPermission(grant);
+            organizationIds = parseScope(root.path("organizationIds"));
+            bookIds = parseScope(root.path("bookIds"));
+            maxLinesPerVoucher = Math.max(2, Math.min(
+                    root.path("maxLinesPerVoucher").asInt(DEFAULT_MAX_LINES), 500
+            ));
+            dailyWriteQuota = Math.max(1, Math.min(
+                    root.path("dailyWriteQuota").asInt(DEFAULT_DAILY_WRITE_QUOTA), 1_000_000
+            ));
         }
-        return new VoucherPermission(
-                app.getTenantId().trim(),
-                statuses,
+
+        requireDataScope(organizationIds, bookIds, "写入");
+        return new VoucherWritePermission(
+                tenantId,
                 organizationIds,
                 bookIds,
-                maxHistoryMonths
+                maxLinesPerVoucher,
+                dailyWriteQuota
         );
+    }
+
+    private String requireTenant(OpenApiApp app) {
+        if (app == null || !StringUtils.hasText(app.getTenantId())) {
+            throw new OpenApiCallException("OPENAPI_50001", "应用租户配置缺失", 500);
+        }
+        return app.getTenantId().trim();
+    }
+
+    private JsonNode readPermission(OpenApiGrant grant) {
+        try {
+            return objectMapper.readTree(grant.getDataPermissionJson());
+        } catch (Exception e) {
+            throw new OpenApiCallException("OPENAPI_50001", "应用数据权限配置格式错误", 500);
+        }
+    }
+
+    private void requireDataScope(Set<String> organizationIds, Set<String> bookIds, String operation) {
+        if (organizationIds.isEmpty() || bookIds.isEmpty()) {
+            throw new OpenApiCallException(
+                    "OPENAPI_40303", "应用没有可" + operation + "的组织或账簿范围", 403
+            );
+        }
     }
 
     private Set<String> parseScope(JsonNode node) {
@@ -95,6 +132,22 @@ public class OpenApiPermissionService {
             Set<String> organizationIds,
             Set<String> bookIds,
             int maxHistoryMonths) {
+
+        public boolean allowsOrganization(String organizationId) {
+            return organizationIds.contains("*") || organizationIds.contains(organizationId);
+        }
+
+        public boolean allowsBook(String bookId) {
+            return bookIds.contains("*") || bookIds.contains(bookId);
+        }
+    }
+
+    public record VoucherWritePermission(
+            String tenantId,
+            Set<String> organizationIds,
+            Set<String> bookIds,
+            int maxLinesPerVoucher,
+            int dailyWriteQuota) {
 
         public boolean allowsOrganization(String organizationId) {
             return organizationIds.contains("*") || organizationIds.contains(organizationId);

--- a/openapi-service/src/main/java/single/cjj/openapi/service/OpenApiVoucherWriteConsumer.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/service/OpenApiVoucherWriteConsumer.java
@@ -1,0 +1,97 @@
+package single.cjj.openapi.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import single.cjj.bizfi.entity.ApiResponse;
+import single.cjj.openapi.client.FiVoucherWriteClient;
+import single.cjj.openapi.contract.OpenVoucherDraftCreateCommand;
+import single.cjj.openapi.contract.OpenVoucherDraftCreateResult;
+import single.cjj.openapi.contract.OpenVoucherDraftLineCommand;
+import single.cjj.openapi.entity.OpenApiWriteRequest;
+import single.cjj.openapi.entity.OpenApiWriteRequestLine;
+import single.cjj.openapi.mapper.OpenApiWriteRequestMapper;
+
+import java.util.List;
+
+@Slf4j
+@Component
+public class OpenApiVoucherWriteConsumer {
+
+    private final OpenApiWriteRequestMapper requestMapper;
+    private final OpenApiVoucherWriteService writeService;
+    private final OpenApiWriteStateService stateService;
+    private final FiVoucherWriteClient voucherWriteClient;
+
+    public OpenApiVoucherWriteConsumer(OpenApiWriteRequestMapper requestMapper,
+                                       OpenApiVoucherWriteService writeService,
+                                       OpenApiWriteStateService stateService,
+                                       FiVoucherWriteClient voucherWriteClient) {
+        this.requestMapper = requestMapper;
+        this.writeService = writeService;
+        this.stateService = stateService;
+        this.voucherWriteClient = voucherWriteClient;
+    }
+
+    @RabbitListener(queues = "${matrix.openapi.write.queue:matrix.openapi.voucher.write.queue}")
+    public void consume(String writeRequestIdText) {
+        Long writeRequestId;
+        try {
+            writeRequestId = Long.valueOf(writeRequestIdText);
+        } catch (Exception e) {
+            log.error("invalid OpenAPI voucher write message: {}", writeRequestIdText);
+            return;
+        }
+
+        if (!stateService.claimForProcessing(writeRequestId)) {
+            return;
+        }
+        try {
+            OpenApiWriteRequest request = requestMapper.selectById(writeRequestId);
+            if (request == null) {
+                return;
+            }
+            List<OpenApiWriteRequestLine> lines = writeService.lines(writeRequestId);
+            OpenVoucherDraftCreateCommand command = new OpenVoucherDraftCreateCommand(
+                    request.getRequestId(),
+                    request.getTenantId(),
+                    request.getOrganizationId(),
+                    request.getBookId(),
+                    request.getVoucherDate(),
+                    request.getSummary(),
+                    "openapi:" + request.getAppExternalId(),
+                    lines.stream().map(this::toCommand).toList()
+            );
+            ApiResponse<OpenVoucherDraftCreateResult> response = voucherWriteClient.createDraft(command);
+            if (response == null || response.getCode() != 200 || response.getData() == null) {
+                String message = response == null || !StringUtils.hasText(response.getMessage())
+                        ? "财务服务创建凭证草稿失败" : response.getMessage();
+                throw new IllegalStateException(message);
+            }
+            stateService.markSucceeded(writeRequestId, response.getData());
+        } catch (Exception e) {
+            log.warn("process OpenAPI voucher write failed, writeRequestId={}, message={}",
+                    writeRequestId, e.getMessage());
+            stateService.markFailed(
+                    writeRequestId,
+                    "OPENAPI_VOUCHER_50001",
+                    StringUtils.hasText(e.getMessage()) ? e.getMessage() : "凭证草稿创建失败"
+            );
+        }
+    }
+
+    private OpenVoucherDraftLineCommand toCommand(OpenApiWriteRequestLine line) {
+        return new OpenVoucherDraftLineCommand(
+                line.getLineNo(),
+                line.getAccountCode(),
+                line.getSummary(),
+                line.getDebitAmount(),
+                line.getCreditAmount(),
+                line.getCurrency(),
+                line.getRate(),
+                line.getOriginalAmount(),
+                line.getCashflowItem()
+        );
+    }
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/service/OpenApiVoucherWriteService.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/service/OpenApiVoucherWriteService.java
@@ -1,0 +1,286 @@
+package single.cjj.openapi.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import single.cjj.openapi.dto.VoucherWriteCreateRequest;
+import single.cjj.openapi.dto.VoucherWriteDetailResponse;
+import single.cjj.openapi.dto.VoucherWriteLineRequest;
+import single.cjj.openapi.dto.VoucherWriteStatusResponse;
+import single.cjj.openapi.entity.OpenApiWriteRequest;
+import single.cjj.openapi.entity.OpenApiWriteRequestLine;
+import single.cjj.openapi.entity.OpenApiWriteStatusLog;
+import single.cjj.openapi.exception.OpenApiCallException;
+import single.cjj.openapi.mapper.OpenApiWriteRequestLineMapper;
+import single.cjj.openapi.mapper.OpenApiWriteRequestMapper;
+import single.cjj.openapi.mapper.OpenApiWriteStatusLogMapper;
+import single.cjj.openapi.security.OpenApiContext;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+public class OpenApiVoucherWriteService {
+
+    private final OpenApiWriteRequestMapper requestMapper;
+    private final OpenApiWriteRequestLineMapper lineMapper;
+    private final OpenApiWriteStatusLogMapper statusLogMapper;
+    private final OpenApiPermissionService permissionService;
+    private final OpenApiWriteStateService stateService;
+
+    public OpenApiVoucherWriteService(OpenApiWriteRequestMapper requestMapper,
+                                      OpenApiWriteRequestLineMapper lineMapper,
+                                      OpenApiWriteStatusLogMapper statusLogMapper,
+                                      OpenApiPermissionService permissionService,
+                                      OpenApiWriteStateService stateService) {
+        this.requestMapper = requestMapper;
+        this.lineMapper = lineMapper;
+        this.statusLogMapper = statusLogMapper;
+        this.permissionService = permissionService;
+        this.stateService = stateService;
+    }
+
+    @Transactional
+    public VoucherWriteStatusResponse accept(OpenApiContext context,
+                                             VoucherWriteCreateRequest input,
+                                             String requestBodyHash) {
+        if (context == null) {
+            throw new OpenApiCallException("OPENAPI_50001", "OpenAPI认证上下文缺失", 500);
+        }
+        if (!StringUtils.hasText(requestBodyHash)) {
+            throw new OpenApiCallException("OPENAPI_50001", "请求体摘要缺失", 500);
+        }
+        OpenApiPermissionService.VoucherWritePermission permission =
+                permissionService.resolveVoucherWritePermission(context.getApp(), context.getGrant());
+        validateInput(input, permission);
+
+        OpenApiWriteRequest existing = findByIdempotency(
+                context.getApp().getId(), input.getIdempotencyKey().trim()
+        );
+        if (existing != null) {
+            return resolveIdempotent(existing, requestBodyHash);
+        }
+        OpenApiWriteRequest externalExisting = findByExternalBizNo(
+                context.getApp().getId(), input.getExternalBizNo().trim()
+        );
+        if (externalExisting != null) {
+            throw new OpenApiCallException(
+                    "OPENAPI_VOUCHER_40902", "外部业务单号已存在，请查询原写入任务", 409
+            );
+        }
+        enforceDailyQuota(context.getApp().getId(), permission.dailyWriteQuota());
+
+        LocalDateTime now = LocalDateTime.now();
+        OpenApiWriteRequest request = new OpenApiWriteRequest();
+        request.setRequestId("vwr_" + UUID.randomUUID().toString().replace("-", ""));
+        request.setAppId(context.getApp().getId());
+        request.setAppExternalId(context.getApp().getAppId());
+        request.setTenantId(permission.tenantId());
+        request.setExternalBizNo(input.getExternalBizNo().trim());
+        request.setIdempotencyKey(input.getIdempotencyKey().trim());
+        request.setRequestBodyHash(requestBodyHash);
+        request.setOrganizationId(input.getOrganizationId().trim());
+        request.setBookId(input.getBookId().trim());
+        request.setVoucherDate(input.getVoucherDate());
+        request.setSummary(input.getSummary().trim());
+        request.setStatus(OpenApiWriteStateService.ACCEPTED);
+        request.setRetryCount(0);
+        request.setMaxRetry(5);
+        request.setCreatedAt(now);
+        request.setUpdatedAt(now);
+
+        try {
+            requestMapper.insert(request);
+        } catch (DuplicateKeyException e) {
+            OpenApiWriteRequest concurrent = findByIdempotency(
+                    context.getApp().getId(), input.getIdempotencyKey().trim()
+            );
+            if (concurrent != null) {
+                return resolveIdempotent(concurrent, requestBodyHash);
+            }
+            throw new OpenApiCallException(
+                    "OPENAPI_VOUCHER_40902", "外部业务单号或幂等键已存在", 409
+            );
+        }
+
+        int lineNo = 1;
+        for (VoucherWriteLineRequest source : input.getLines()) {
+            OpenApiWriteRequestLine line = new OpenApiWriteRequestLine();
+            line.setWriteRequestId(request.getId());
+            line.setLineNo(source.getLineNo() == null ? lineNo : source.getLineNo());
+            line.setAccountCode(source.getAccountCode().trim());
+            line.setSummary(StringUtils.hasText(source.getSummary())
+                    ? source.getSummary().trim() : input.getSummary().trim());
+            line.setDebitAmount(amount(source.getDebitAmount()));
+            line.setCreditAmount(amount(source.getCreditAmount()));
+            line.setCurrency(trimToNull(source.getCurrency()));
+            line.setRate(source.getRate());
+            line.setOriginalAmount(source.getOriginalAmount());
+            line.setCashflowItem(trimToNull(source.getCashflowItem()));
+            lineMapper.insert(line);
+            lineNo++;
+        }
+        stateService.initialize(request);
+        return VoucherWriteStatusResponse.from(request);
+    }
+
+    public VoucherWriteStatusResponse statusForApp(Long appId, String requestId) {
+        OpenApiWriteRequest request = requestMapper.selectOne(new LambdaQueryWrapper<OpenApiWriteRequest>()
+                .eq(OpenApiWriteRequest::getAppId, appId)
+                .eq(OpenApiWriteRequest::getRequestId, requestId));
+        return VoucherWriteStatusResponse.from(require(request));
+    }
+
+    public VoucherWriteStatusResponse statusForAppByExternalNo(Long appId, String externalBizNo) {
+        OpenApiWriteRequest request = requestMapper.selectOne(new LambdaQueryWrapper<OpenApiWriteRequest>()
+                .eq(OpenApiWriteRequest::getAppId, appId)
+                .eq(OpenApiWriteRequest::getExternalBizNo, externalBizNo));
+        return VoucherWriteStatusResponse.from(require(request));
+    }
+
+    public VoucherWriteDetailResponse detail(String requestId) {
+        OpenApiWriteRequest request = requestMapper.selectOne(new LambdaQueryWrapper<OpenApiWriteRequest>()
+                .eq(OpenApiWriteRequest::getRequestId, requestId));
+        require(request);
+        List<OpenApiWriteRequestLine> lines = lineMapper.selectList(
+                new LambdaQueryWrapper<OpenApiWriteRequestLine>()
+                        .eq(OpenApiWriteRequestLine::getWriteRequestId, request.getId())
+                        .orderByAsc(OpenApiWriteRequestLine::getLineNo)
+                        .orderByAsc(OpenApiWriteRequestLine::getId)
+        );
+        List<OpenApiWriteStatusLog> logs = statusLogMapper.selectList(
+                new LambdaQueryWrapper<OpenApiWriteStatusLog>()
+                        .eq(OpenApiWriteStatusLog::getWriteRequestId, request.getId())
+                        .orderByAsc(OpenApiWriteStatusLog::getId)
+        );
+        return new VoucherWriteDetailResponse(VoucherWriteStatusResponse.from(request), lines, logs);
+    }
+
+    public List<OpenApiWriteRequestLine> lines(Long writeRequestId) {
+        return lineMapper.selectList(new LambdaQueryWrapper<OpenApiWriteRequestLine>()
+                .eq(OpenApiWriteRequestLine::getWriteRequestId, writeRequestId)
+                .orderByAsc(OpenApiWriteRequestLine::getLineNo)
+                .orderByAsc(OpenApiWriteRequestLine::getId));
+    }
+
+    private void validateInput(VoucherWriteCreateRequest input,
+                               OpenApiPermissionService.VoucherWritePermission permission) {
+        if (input == null) {
+            throw new OpenApiCallException("OPENAPI_VOUCHER_40001", "请求体不能为空", 400);
+        }
+        requireText(input.getExternalBizNo(), "外部业务单号", 128);
+        requireText(input.getIdempotencyKey(), "幂等键", 128);
+        requireText(input.getOrganizationId(), "组织", 64);
+        requireText(input.getBookId(), "账簿", 64);
+        requireText(input.getSummary(), "凭证摘要", 500);
+        if (input.getVoucherDate() == null) {
+            throw new OpenApiCallException("OPENAPI_VOUCHER_40001", "凭证日期不能为空", 400);
+        }
+        if (!permission.allowsOrganization(input.getOrganizationId().trim())) {
+            throw new OpenApiCallException("OPENAPI_VOUCHER_40301", "组织不在写入授权范围", 403);
+        }
+        if (!permission.allowsBook(input.getBookId().trim())) {
+            throw new OpenApiCallException("OPENAPI_VOUCHER_40302", "账簿不在写入授权范围", 403);
+        }
+        if (input.getLines() == null || input.getLines().size() < 2) {
+            throw new OpenApiCallException("OPENAPI_VOUCHER_40001", "凭证至少需要两行分录", 400);
+        }
+        if (input.getLines().size() > permission.maxLinesPerVoucher()) {
+            throw new OpenApiCallException("OPENAPI_VOUCHER_40004", "凭证分录数量超过授权上限", 400);
+        }
+
+        BigDecimal debitTotal = BigDecimal.ZERO;
+        BigDecimal creditTotal = BigDecimal.ZERO;
+        Set<Integer> lineNumbers = new HashSet<>();
+        int index = 1;
+        for (VoucherWriteLineRequest line : input.getLines()) {
+            if (line == null || !StringUtils.hasText(line.getAccountCode())) {
+                throw new OpenApiCallException("OPENAPI_VOUCHER_40002", "第" + index + "行科目不能为空", 400);
+            }
+            BigDecimal debit = amount(line.getDebitAmount());
+            BigDecimal credit = amount(line.getCreditAmount());
+            if (debit.signum() < 0 || credit.signum() < 0) {
+                throw new OpenApiCallException("OPENAPI_VOUCHER_40001", "第" + index + "行金额不能小于0", 400);
+            }
+            if ((debit.signum() == 0) == (credit.signum() == 0)) {
+                throw new OpenApiCallException(
+                        "OPENAPI_VOUCHER_40001", "第" + index + "行必须且只能填写借方或贷方金额", 400
+                );
+            }
+            int lineNo = line.getLineNo() == null ? index : line.getLineNo();
+            if (lineNo <= 0 || !lineNumbers.add(lineNo)) {
+                throw new OpenApiCallException("OPENAPI_VOUCHER_40001", "凭证分录行号必须为正数且不能重复", 400);
+            }
+            debitTotal = debitTotal.add(debit);
+            creditTotal = creditTotal.add(credit);
+            index++;
+        }
+        if (debitTotal.compareTo(creditTotal) != 0) {
+            throw new OpenApiCallException("OPENAPI_VOUCHER_40001", "凭证借贷金额不平衡", 400);
+        }
+    }
+
+    private void enforceDailyQuota(Long appId, int quota) {
+        LocalDateTime start = LocalDateTime.now().toLocalDate().atStartOfDay();
+        LocalDateTime end = LocalDateTime.now().toLocalDate().atTime(LocalTime.MAX);
+        Long count = requestMapper.selectCount(new LambdaQueryWrapper<OpenApiWriteRequest>()
+                .eq(OpenApiWriteRequest::getAppId, appId)
+                .ge(OpenApiWriteRequest::getCreatedAt, start)
+                .le(OpenApiWriteRequest::getCreatedAt, end));
+        if (count != null && count >= quota) {
+            throw new OpenApiCallException("OPENAPI_42902", "应用当日凭证写入额度已用完", 429);
+        }
+    }
+
+    private VoucherWriteStatusResponse resolveIdempotent(OpenApiWriteRequest existing, String bodyHash) {
+        if (!bodyHash.equalsIgnoreCase(existing.getRequestBodyHash())) {
+            throw new OpenApiCallException(
+                    "OPENAPI_VOUCHER_40901", "相同幂等键对应的请求内容不一致", 409
+            );
+        }
+        return VoucherWriteStatusResponse.from(existing);
+    }
+
+    private OpenApiWriteRequest findByIdempotency(Long appId, String idempotencyKey) {
+        return requestMapper.selectOne(new LambdaQueryWrapper<OpenApiWriteRequest>()
+                .eq(OpenApiWriteRequest::getAppId, appId)
+                .eq(OpenApiWriteRequest::getIdempotencyKey, idempotencyKey));
+    }
+
+    private OpenApiWriteRequest findByExternalBizNo(Long appId, String externalBizNo) {
+        return requestMapper.selectOne(new LambdaQueryWrapper<OpenApiWriteRequest>()
+                .eq(OpenApiWriteRequest::getAppId, appId)
+                .eq(OpenApiWriteRequest::getExternalBizNo, externalBizNo));
+    }
+
+    private OpenApiWriteRequest require(OpenApiWriteRequest request) {
+        if (request == null) {
+            throw new OpenApiCallException("OPENAPI_40401", "写入任务不存在", 404);
+        }
+        return request;
+    }
+
+    private void requireText(String value, String label, int maxLength) {
+        if (!StringUtils.hasText(value)) {
+            throw new OpenApiCallException("OPENAPI_VOUCHER_40001", label + "不能为空", 400);
+        }
+        if (value.trim().length() > maxLength) {
+            throw new OpenApiCallException("OPENAPI_VOUCHER_40001", label + "长度超过限制", 400);
+        }
+    }
+
+    private BigDecimal amount(BigDecimal value) {
+        return value == null ? BigDecimal.ZERO : value;
+    }
+
+    private String trimToNull(String value) {
+        return StringUtils.hasText(value) ? value.trim() : null;
+    }
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/service/OpenApiWriteStateService.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/service/OpenApiWriteStateService.java
@@ -30,6 +30,7 @@ public class OpenApiWriteStateService {
     public static final String MANUAL_REQUIRED = "MANUAL_REQUIRED";
 
     private static final Set<String> CLAIMABLE = Set.of(ACCEPTED, RETRYING, PROCESSING_FAILED);
+    private static final Set<String> MANUALLY_RETRYABLE = Set.of(MANUAL_REQUIRED, PROCESSING_FAILED);
 
     private final OpenApiWriteRequestMapper requestMapper;
     private final OpenApiOutboxEventMapper outboxMapper;
@@ -128,17 +129,27 @@ public class OpenApiWriteStateService {
         if (current == null) {
             throw new OpenApiCallException("OPENAPI_40401", "写入任务不存在", 404);
         }
-        if (SUCCEEDED.equals(current.getStatus())) {
-            return false;
+        if (!MANUALLY_RETRYABLE.contains(current.getStatus())) {
+            throw new OpenApiCallException(
+                    "OPENAPI_VOUCHER_40903",
+                    "只有处理失败或需要人工处理的任务可以手动重试",
+                    409
+            );
         }
         LocalDateTime now = LocalDateTime.now();
-        requestMapper.update(null, new LambdaUpdateWrapper<OpenApiWriteRequest>()
+        int updated = requestMapper.update(null, new LambdaUpdateWrapper<OpenApiWriteRequest>()
                 .eq(OpenApiWriteRequest::getId, current.getId())
+                .in(OpenApiWriteRequest::getStatus, MANUALLY_RETRYABLE)
                 .set(OpenApiWriteRequest::getStatus, RETRYING)
                 .set(OpenApiWriteRequest::getErrorCode, null)
                 .set(OpenApiWriteRequest::getErrorMessage, null)
                 .set(OpenApiWriteRequest::getNextRetryAt, now)
                 .set(OpenApiWriteRequest::getUpdatedAt, now));
+        if (updated == 0) {
+            throw new OpenApiCallException(
+                    "OPENAPI_VOUCHER_40903", "任务状态已发生变化，请刷新后重试", 409
+            );
+        }
         appendLog(current.getId(), current.getStatus(), RETRYING, null, "管理员触发重新执行");
         createOutbox(current, now);
         return true;

--- a/openapi-service/src/main/java/single/cjj/openapi/service/OpenApiWriteStateService.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/service/OpenApiWriteStateService.java
@@ -1,0 +1,229 @@
+package single.cjj.openapi.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import single.cjj.openapi.contract.OpenVoucherDraftCreateResult;
+import single.cjj.openapi.entity.OpenApiOutboxEvent;
+import single.cjj.openapi.entity.OpenApiWriteRequest;
+import single.cjj.openapi.entity.OpenApiWriteStatusLog;
+import single.cjj.openapi.exception.OpenApiCallException;
+import single.cjj.openapi.mapper.OpenApiOutboxEventMapper;
+import single.cjj.openapi.mapper.OpenApiWriteRequestMapper;
+import single.cjj.openapi.mapper.OpenApiWriteStatusLogMapper;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+public class OpenApiWriteStateService {
+
+    public static final String ACCEPTED = "ACCEPTED";
+    public static final String PROCESSING = "PROCESSING";
+    public static final String RETRYING = "RETRYING";
+    public static final String PROCESSING_FAILED = "PROCESSING_FAILED";
+    public static final String SUCCEEDED = "SUCCEEDED";
+    public static final String MANUAL_REQUIRED = "MANUAL_REQUIRED";
+
+    private static final Set<String> CLAIMABLE = Set.of(ACCEPTED, RETRYING, PROCESSING_FAILED);
+
+    private final OpenApiWriteRequestMapper requestMapper;
+    private final OpenApiOutboxEventMapper outboxMapper;
+    private final OpenApiWriteStatusLogMapper statusLogMapper;
+    private final int staleProcessingMinutes;
+
+    public OpenApiWriteStateService(OpenApiWriteRequestMapper requestMapper,
+                                    OpenApiOutboxEventMapper outboxMapper,
+                                    OpenApiWriteStatusLogMapper statusLogMapper,
+                                    @Value("${matrix.openapi.write.stale-processing-minutes:5}") int staleProcessingMinutes) {
+        this.requestMapper = requestMapper;
+        this.outboxMapper = outboxMapper;
+        this.statusLogMapper = statusLogMapper;
+        this.staleProcessingMinutes = Math.max(1, staleProcessingMinutes);
+    }
+
+    @Transactional
+    public void initialize(OpenApiWriteRequest request) {
+        createOutbox(request, LocalDateTime.now());
+        appendLog(request.getId(), null, ACCEPTED, null, "写入请求已受理");
+    }
+
+    @Transactional
+    public boolean claimForProcessing(Long writeRequestId) {
+        OpenApiWriteRequest current = requestMapper.selectById(writeRequestId);
+        if (current == null || SUCCEEDED.equals(current.getStatus())) {
+            return false;
+        }
+        LocalDateTime now = LocalDateTime.now();
+        int updated = requestMapper.update(null, new LambdaUpdateWrapper<OpenApiWriteRequest>()
+                .eq(OpenApiWriteRequest::getId, writeRequestId)
+                .in(OpenApiWriteRequest::getStatus, CLAIMABLE)
+                .set(OpenApiWriteRequest::getStatus, PROCESSING)
+                .set(OpenApiWriteRequest::getErrorCode, null)
+                .set(OpenApiWriteRequest::getErrorMessage, null)
+                .set(OpenApiWriteRequest::getUpdatedAt, now));
+        if (updated > 0) {
+            appendLog(writeRequestId, current.getStatus(), PROCESSING, null, "开始创建凭证草稿");
+            return true;
+        }
+        return false;
+    }
+
+    @Transactional
+    public void markSucceeded(Long writeRequestId, OpenVoucherDraftCreateResult result) {
+        OpenApiWriteRequest current = require(writeRequestId);
+        LocalDateTime now = LocalDateTime.now();
+        int updated = requestMapper.update(null, new LambdaUpdateWrapper<OpenApiWriteRequest>()
+                .eq(OpenApiWriteRequest::getId, writeRequestId)
+                .ne(OpenApiWriteRequest::getStatus, SUCCEEDED)
+                .set(OpenApiWriteRequest::getStatus, SUCCEEDED)
+                .set(OpenApiWriteRequest::getVoucherId, result.getVoucherId())
+                .set(OpenApiWriteRequest::getVoucherNumber, result.getVoucherNumber())
+                .set(OpenApiWriteRequest::getErrorCode, null)
+                .set(OpenApiWriteRequest::getErrorMessage, null)
+                .set(OpenApiWriteRequest::getNextRetryAt, null)
+                .set(OpenApiWriteRequest::getUpdatedAt, now)
+                .set(OpenApiWriteRequest::getFinishedAt, now));
+        if (updated > 0) {
+            appendLog(writeRequestId, current.getStatus(), SUCCEEDED, null, "凭证草稿创建成功");
+        }
+    }
+
+    @Transactional
+    public void markFailed(Long writeRequestId, String errorCode, String errorMessage) {
+        OpenApiWriteRequest current = require(writeRequestId);
+        if (SUCCEEDED.equals(current.getStatus())) {
+            return;
+        }
+        int nextRetryCount = (current.getRetryCount() == null ? 0 : current.getRetryCount()) + 1;
+        int maxRetry = current.getMaxRetry() == null ? 5 : current.getMaxRetry();
+        boolean retryable = nextRetryCount < maxRetry;
+        String nextStatus = retryable ? RETRYING : MANUAL_REQUIRED;
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime nextRetryAt = retryable ? now.plusMinutes(retryDelayMinutes(nextRetryCount)) : null;
+
+        requestMapper.update(null, new LambdaUpdateWrapper<OpenApiWriteRequest>()
+                .eq(OpenApiWriteRequest::getId, writeRequestId)
+                .set(OpenApiWriteRequest::getStatus, nextStatus)
+                .set(OpenApiWriteRequest::getRetryCount, nextRetryCount)
+                .set(OpenApiWriteRequest::getErrorCode, errorCode)
+                .set(OpenApiWriteRequest::getErrorMessage, truncate(errorMessage, 1000))
+                .set(OpenApiWriteRequest::getNextRetryAt, nextRetryAt)
+                .set(OpenApiWriteRequest::getUpdatedAt, now));
+        appendLog(writeRequestId, current.getStatus(), nextStatus, errorCode, truncate(errorMessage, 1000));
+        if (retryable) {
+            OpenApiWriteRequest latest = requestMapper.selectById(writeRequestId);
+            createOutbox(latest, nextRetryAt);
+        }
+    }
+
+    @Transactional
+    public boolean manualRetry(String requestId) {
+        OpenApiWriteRequest current = requestMapper.selectOne(new LambdaQueryWrapper<OpenApiWriteRequest>()
+                .eq(OpenApiWriteRequest::getRequestId, requestId));
+        if (current == null) {
+            throw new OpenApiCallException("OPENAPI_40401", "写入任务不存在", 404);
+        }
+        if (SUCCEEDED.equals(current.getStatus())) {
+            return false;
+        }
+        LocalDateTime now = LocalDateTime.now();
+        requestMapper.update(null, new LambdaUpdateWrapper<OpenApiWriteRequest>()
+                .eq(OpenApiWriteRequest::getId, current.getId())
+                .set(OpenApiWriteRequest::getStatus, RETRYING)
+                .set(OpenApiWriteRequest::getErrorCode, null)
+                .set(OpenApiWriteRequest::getErrorMessage, null)
+                .set(OpenApiWriteRequest::getNextRetryAt, now)
+                .set(OpenApiWriteRequest::getUpdatedAt, now));
+        appendLog(current.getId(), current.getStatus(), RETRYING, null, "管理员触发重新执行");
+        createOutbox(current, now);
+        return true;
+    }
+
+    @Transactional
+    public int recoverStaleProcessing() {
+        LocalDateTime cutoff = LocalDateTime.now().minusMinutes(staleProcessingMinutes);
+        List<OpenApiWriteRequest> stale = requestMapper.selectList(new LambdaQueryWrapper<OpenApiWriteRequest>()
+                .eq(OpenApiWriteRequest::getStatus, PROCESSING)
+                .lt(OpenApiWriteRequest::getUpdatedAt, cutoff)
+                .orderByAsc(OpenApiWriteRequest::getId)
+                .last("LIMIT 100"));
+        int recovered = 0;
+        for (OpenApiWriteRequest request : stale) {
+            LocalDateTime now = LocalDateTime.now();
+            int updated = requestMapper.update(null, new LambdaUpdateWrapper<OpenApiWriteRequest>()
+                    .eq(OpenApiWriteRequest::getId, request.getId())
+                    .eq(OpenApiWriteRequest::getStatus, PROCESSING)
+                    .set(OpenApiWriteRequest::getStatus, RETRYING)
+                    .set(OpenApiWriteRequest::getNextRetryAt, now)
+                    .set(OpenApiWriteRequest::getUpdatedAt, now));
+            if (updated > 0) {
+                appendLog(request.getId(), PROCESSING, RETRYING, "OPENAPI_VOUCHER_50002", "处理超时，系统自动恢复");
+                createOutbox(request, now);
+                recovered++;
+            }
+        }
+        return recovered;
+    }
+
+    private OpenApiWriteRequest require(Long id) {
+        OpenApiWriteRequest request = requestMapper.selectById(id);
+        if (request == null) {
+            throw new OpenApiCallException("OPENAPI_40401", "写入任务不存在", 404);
+        }
+        return request;
+    }
+
+    private void createOutbox(OpenApiWriteRequest request, LocalDateTime nextAttemptAt) {
+        LocalDateTime now = LocalDateTime.now();
+        OpenApiOutboxEvent event = new OpenApiOutboxEvent();
+        event.setEventId("evt_" + UUID.randomUUID().toString().replace("-", ""));
+        event.setAggregateType("VOUCHER_WRITE_REQUEST");
+        event.setAggregateId(request.getId());
+        event.setEventType("VOUCHER_DRAFT_CREATE");
+        event.setPayloadJson("{\"requestId\":\"" + request.getRequestId() + "\"}");
+        event.setStatus("PENDING");
+        event.setRetryCount(0);
+        event.setMaxRetry(10);
+        event.setNextAttemptAt(nextAttemptAt == null ? now : nextAttemptAt);
+        event.setCreatedAt(now);
+        event.setUpdatedAt(now);
+        outboxMapper.insert(event);
+    }
+
+    private void appendLog(Long writeRequestId,
+                           String fromStatus,
+                           String toStatus,
+                           String errorCode,
+                           String message) {
+        OpenApiWriteStatusLog log = new OpenApiWriteStatusLog();
+        log.setWriteRequestId(writeRequestId);
+        log.setFromStatus(fromStatus);
+        log.setToStatus(toStatus);
+        log.setErrorCode(errorCode);
+        log.setMessage(truncate(message, 1000));
+        log.setCreatedAt(LocalDateTime.now());
+        statusLogMapper.insert(log);
+    }
+
+    private long retryDelayMinutes(int retryCount) {
+        return switch (retryCount) {
+            case 1 -> 1;
+            case 2 -> 5;
+            case 3 -> 15;
+            case 4 -> 60;
+            default -> 180;
+        };
+    }
+
+    private String truncate(String value, int maxLength) {
+        if (value == null) {
+            return null;
+        }
+        return value.length() <= maxLength ? value : value.substring(0, maxLength);
+    }
+}

--- a/openapi-service/src/main/resources/application.yml
+++ b/openapi-service/src/main/resources/application.yml
@@ -55,6 +55,7 @@ matrix:
       outbox-poll-ms: ${OPENAPI_OUTBOX_POLL_MS:2000}
       recovery-poll-ms: ${OPENAPI_WRITE_RECOVERY_POLL_MS:60000}
       stale-processing-minutes: ${OPENAPI_STALE_PROCESSING_MINUTES:5}
+      publisher-confirm-timeout-ms: ${OPENAPI_PUBLISHER_CONFIRM_TIMEOUT_MS:5000}
 
 management:
   endpoints:

--- a/openapi-service/src/main/resources/application.yml
+++ b/openapi-service/src/main/resources/application.yml
@@ -10,6 +10,19 @@ spring:
     active: ${SPRING_PROFILES_ACTIVE:dev}
   config:
     import: "nacos:${spring.application.name}"
+  rabbitmq:
+    host: ${RABBITMQ_HOST:localhost}
+    port: ${RABBITMQ_PORT:5672}
+    username: ${RABBITMQ_USERNAME:guest}
+    password: ${RABBITMQ_PASSWORD:guest}
+    virtual-host: ${RABBITMQ_VHOST:/}
+    publisher-confirm-type: correlated
+    listener:
+      simple:
+        acknowledge-mode: auto
+        default-requeue-rejected: false
+        concurrency: ${OPENAPI_WRITE_CONSUMERS:2}
+        max-concurrency: ${OPENAPI_WRITE_MAX_CONSUMERS:8}
   cloud:
     nacos:
       discovery:
@@ -26,7 +39,7 @@ spring:
         config:
           fi-service:
             connect-timeout: 3000
-            read-timeout: 5000
+            read-timeout: 10000
 
 matrix:
   openapi:
@@ -34,6 +47,14 @@ matrix:
     internal-token: ${MATRIX_INTERNAL_OPENAPI_TOKEN:}
     replay-window-seconds: ${OPENAPI_REPLAY_WINDOW_SECONDS:300}
     system-max-page-size: ${OPENAPI_SYSTEM_MAX_PAGE_SIZE:500}
+    max-request-body-bytes: ${OPENAPI_MAX_REQUEST_BODY_BYTES:1048576}
+    write:
+      exchange: ${OPENAPI_WRITE_EXCHANGE:matrix.openapi.write.exchange}
+      queue: ${OPENAPI_WRITE_QUEUE:matrix.openapi.voucher.write.queue}
+      routing-key: ${OPENAPI_WRITE_ROUTING_KEY:matrix.openapi.voucher.write}
+      outbox-poll-ms: ${OPENAPI_OUTBOX_POLL_MS:2000}
+      recovery-poll-ms: ${OPENAPI_WRITE_RECOVERY_POLL_MS:60000}
+      stale-processing-minutes: ${OPENAPI_STALE_PROCESSING_MINUTES:5}
 
 management:
   endpoints:

--- a/openapi-service/src/test/java/single/cjj/openapi/service/OpenApiPermissionServiceTest.java
+++ b/openapi-service/src/test/java/single/cjj/openapi/service/OpenApiPermissionServiceTest.java
@@ -41,6 +41,52 @@ class OpenApiPermissionServiceTest {
     }
 
     @Test
+    void shouldResolveVoucherWriteLimits() {
+        OpenApiApp app = new OpenApiApp();
+        app.setTenantId("tenant-write");
+        OpenApiGrant grant = new OpenApiGrant();
+        grant.setDataPermissionJson("""
+                {
+                  "organizationIds": ["ORG-W"],
+                  "bookIds": ["BOOK-W"],
+                  "maxLinesPerVoucher": 80,
+                  "dailyWriteQuota": 1200
+                }
+                """);
+
+        OpenApiPermissionService.VoucherWritePermission permission =
+                service.resolveVoucherWritePermission(app, grant);
+
+        assertEquals("tenant-write", permission.tenantId());
+        assertEquals(80, permission.maxLinesPerVoucher());
+        assertEquals(1200, permission.dailyWriteQuota());
+        assertTrue(permission.allowsOrganization("ORG-W"));
+        assertFalse(permission.allowsOrganization("ORG-X"));
+        assertTrue(permission.allowsBook("BOOK-W"));
+    }
+
+    @Test
+    void shouldClampVoucherWriteLimits() {
+        OpenApiApp app = new OpenApiApp();
+        app.setTenantId("default");
+        OpenApiGrant grant = new OpenApiGrant();
+        grant.setDataPermissionJson("""
+                {
+                  "maxLinesPerVoucher": 5000,
+                  "dailyWriteQuota": 5000000
+                }
+                """);
+
+        OpenApiPermissionService.VoucherWritePermission permission =
+                service.resolveVoucherWritePermission(app, grant);
+
+        assertEquals(500, permission.maxLinesPerVoucher());
+        assertEquals(1000000, permission.dailyWriteQuota());
+        assertTrue(permission.allowsOrganization("ANY-ORG"));
+        assertTrue(permission.allowsBook("ANY-BOOK"));
+    }
+
+    @Test
     void shouldTreatMissingOrganizationAndBookScopesAsTenantWildcard() {
         OpenApiApp app = new OpenApiApp();
         app.setTenantId("default");

--- a/openapi-service/src/test/java/single/cjj/openapi/service/OpenApiSignatureServiceTest.java
+++ b/openapi-service/src/test/java/single/cjj/openapi/service/OpenApiSignatureServiceTest.java
@@ -2,6 +2,7 @@ package single.cjj.openapi.service;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -42,5 +43,32 @@ class OpenApiSignatureServiceTest {
                 service.sign("secret", canonical)
         );
         assertTrue(service.verify(service.sign("secret", canonical), service.sign("secret", canonical)));
+    }
+
+    @Test
+    void shouldIncludePostBodyHashInSignature() {
+        byte[] body = "{\"externalBizNo\":\"EXP-001\",\"idempotencyKey\":\"expense:EXP-001\"}"
+                .getBytes(StandardCharsets.UTF_8);
+        String canonical = service.canonicalRequest(
+                "POST",
+                "/open-api/v1/fi/voucher-requests",
+                Map.of(),
+                body,
+                "1784710000000",
+                "nonce-write-1"
+        );
+
+        assertEquals(
+                "POST\n" +
+                        "/open-api/v1/fi/voucher-requests\n\n" +
+                        "1de3b15095f7f6ad6f901a82eac829870bf182f0f4ae1a1de891847d3fe5db0b\n" +
+                        "1784710000000\n" +
+                        "nonce-write-1",
+                canonical
+        );
+        assertEquals(
+                "3f270d30a8f6820d725a23d89de0e94d30ae3b024d14a304855c8274e4925cac",
+                service.sign("secret", canonical)
+        );
     }
 }

--- a/openapi-service/src/test/java/single/cjj/openapi/service/OpenApiVoucherWriteServiceTest.java
+++ b/openapi-service/src/test/java/single/cjj/openapi/service/OpenApiVoucherWriteServiceTest.java
@@ -1,0 +1,131 @@
+package single.cjj.openapi.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import single.cjj.openapi.dto.VoucherWriteCreateRequest;
+import single.cjj.openapi.dto.VoucherWriteLineRequest;
+import single.cjj.openapi.dto.VoucherWriteStatusResponse;
+import single.cjj.openapi.entity.OpenApiApp;
+import single.cjj.openapi.entity.OpenApiDefinition;
+import single.cjj.openapi.entity.OpenApiGrant;
+import single.cjj.openapi.entity.OpenApiWriteRequest;
+import single.cjj.openapi.exception.OpenApiCallException;
+import single.cjj.openapi.mapper.OpenApiWriteRequestLineMapper;
+import single.cjj.openapi.mapper.OpenApiWriteRequestMapper;
+import single.cjj.openapi.mapper.OpenApiWriteStatusLogMapper;
+import single.cjj.openapi.security.OpenApiContext;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class OpenApiVoucherWriteServiceTest {
+
+    private OpenApiWriteRequestMapper requestMapper;
+    private OpenApiPermissionService permissionService;
+    private OpenApiVoucherWriteService service;
+    private OpenApiContext context;
+
+    @BeforeEach
+    void setUp() {
+        requestMapper = Mockito.mock(OpenApiWriteRequestMapper.class);
+        OpenApiWriteRequestLineMapper lineMapper = Mockito.mock(OpenApiWriteRequestLineMapper.class);
+        OpenApiWriteStatusLogMapper logMapper = Mockito.mock(OpenApiWriteStatusLogMapper.class);
+        permissionService = Mockito.mock(OpenApiPermissionService.class);
+        OpenApiWriteStateService stateService = Mockito.mock(OpenApiWriteStateService.class);
+        service = new OpenApiVoucherWriteService(
+                requestMapper, lineMapper, logMapper, permissionService, stateService
+        );
+
+        OpenApiApp app = new OpenApiApp();
+        app.setId(10L);
+        app.setAppId("app-test");
+        app.setTenantId("tenant-a");
+        OpenApiGrant grant = new OpenApiGrant();
+        context = new OpenApiContext("req-test", app, new OpenApiDefinition(), grant);
+        when(permissionService.resolveVoucherWritePermission(app, grant)).thenReturn(
+                new OpenApiPermissionService.VoucherWritePermission(
+                        "tenant-a", Set.of("ORG-1"), Set.of("BOOK-1"), 200, 10000
+                )
+        );
+    }
+
+    @Test
+    void shouldReturnExistingRequestForSameIdempotencyBody() {
+        OpenApiWriteRequest existing = new OpenApiWriteRequest();
+        existing.setRequestId("vwr-existing");
+        existing.setRequestBodyHash("abc123");
+        existing.setStatus(OpenApiWriteStateService.ACCEPTED);
+        existing.setCreatedAt(LocalDateTime.now());
+        existing.setUpdatedAt(LocalDateTime.now());
+        when(requestMapper.selectOne(any())).thenReturn(existing);
+
+        VoucherWriteStatusResponse response = service.accept(context, validRequest(), "abc123");
+
+        assertEquals("vwr-existing", response.getRequestId());
+        assertEquals(OpenApiWriteStateService.ACCEPTED, response.getStatus());
+    }
+
+    @Test
+    void shouldRejectReusedIdempotencyKeyWithDifferentBody() {
+        OpenApiWriteRequest existing = new OpenApiWriteRequest();
+        existing.setRequestId("vwr-existing");
+        existing.setRequestBodyHash("first-body");
+        existing.setStatus(OpenApiWriteStateService.ACCEPTED);
+        when(requestMapper.selectOne(any())).thenReturn(existing);
+
+        OpenApiCallException exception = assertThrows(
+                OpenApiCallException.class,
+                () -> service.accept(context, validRequest(), "different-body")
+        );
+
+        assertEquals("OPENAPI_VOUCHER_40901", exception.getCode());
+    }
+
+    @Test
+    void shouldRejectUnbalancedVoucher() {
+        VoucherWriteCreateRequest request = validRequest();
+        request.getLines().get(1).setCreditAmount(new BigDecimal("90.00"));
+
+        OpenApiCallException exception = assertThrows(
+                OpenApiCallException.class,
+                () -> service.accept(context, request, "body-hash")
+        );
+
+        assertEquals("OPENAPI_VOUCHER_40001", exception.getCode());
+    }
+
+    private VoucherWriteCreateRequest validRequest() {
+        VoucherWriteLineRequest debit = new VoucherWriteLineRequest();
+        debit.setLineNo(1);
+        debit.setAccountCode("660201");
+        debit.setSummary("差旅费");
+        debit.setDebitAmount(new BigDecimal("100.00"));
+        debit.setCreditAmount(BigDecimal.ZERO);
+
+        VoucherWriteLineRequest credit = new VoucherWriteLineRequest();
+        credit.setLineNo(2);
+        credit.setAccountCode("224101");
+        credit.setSummary("应付员工款");
+        credit.setDebitAmount(BigDecimal.ZERO);
+        credit.setCreditAmount(new BigDecimal("100.00"));
+
+        VoucherWriteCreateRequest request = new VoucherWriteCreateRequest();
+        request.setExternalBizNo("EXP-001");
+        request.setIdempotencyKey("expense:EXP-001");
+        request.setOrganizationId("ORG-1");
+        request.setBookId("BOOK-1");
+        request.setVoucherDate(LocalDate.of(2026, 7, 22));
+        request.setSummary("员工差旅报销");
+        request.setLines(List.of(debit, credit));
+        return request;
+    }
+}

--- a/sql/matrix_open_api_v3.sql
+++ b/sql/matrix_open_api_v3.sql
@@ -1,0 +1,113 @@
+-- Matrix OpenAPI V3
+-- 第三阶段A：凭证草稿异步写入、幂等、Outbox与状态跟踪
+-- 前置：matrix_open_api_v1.sql、matrix_open_api_v2.sql
+
+ALTER TABLE bizfi_fi_voucher
+    ADD COLUMN source_request_id VARCHAR(64) NULL COMMENT 'OpenAPI写入来源请求' AFTER book_id,
+    ADD UNIQUE KEY uk_voucher_openapi_source (tenant_id, source_request_id);
+
+CREATE TABLE matrix_open_api_write_request (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    request_id VARCHAR(64) NOT NULL COMMENT '对外写入请求ID',
+    app_id BIGINT NOT NULL COMMENT 'matrix_open_api_app.id',
+    app_external_id VARCHAR(64) NOT NULL COMMENT '对外应用ID快照',
+    tenant_id VARCHAR(64) NOT NULL,
+    external_biz_no VARCHAR(128) NOT NULL,
+    idempotency_key VARCHAR(128) NOT NULL,
+    request_body_hash CHAR(64) NOT NULL,
+    organization_id VARCHAR(64) NOT NULL,
+    book_id VARCHAR(64) NOT NULL,
+    voucher_date DATE NOT NULL,
+    summary VARCHAR(500) NOT NULL,
+    status VARCHAR(32) NOT NULL COMMENT 'ACCEPTED/PROCESSING/RETRYING/SUCCEEDED/MANUAL_REQUIRED',
+    voucher_id BIGINT NULL,
+    voucher_number VARCHAR(100) NULL,
+    error_code VARCHAR(64) NULL,
+    error_message VARCHAR(1000) NULL,
+    retry_count INT NOT NULL DEFAULT 0,
+    max_retry INT NOT NULL DEFAULT 5,
+    next_retry_at DATETIME NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    finished_at DATETIME NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_open_api_write_request_id (request_id),
+    UNIQUE KEY uk_open_api_write_idempotency (app_id, idempotency_key),
+    UNIQUE KEY uk_open_api_write_external_biz (app_id, external_biz_no),
+    KEY idx_open_api_write_status_time (status, updated_at),
+    KEY idx_open_api_write_app_time (app_external_id, created_at),
+    KEY idx_open_api_write_voucher (voucher_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='OpenAPI凭证写入任务';
+
+CREATE TABLE matrix_open_api_write_request_line (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    write_request_id BIGINT NOT NULL,
+    line_no INT NOT NULL,
+    account_code VARCHAR(100) NOT NULL,
+    summary VARCHAR(500) NULL,
+    debit_amount DECIMAL(18,2) NOT NULL DEFAULT 0,
+    credit_amount DECIMAL(18,2) NOT NULL DEFAULT 0,
+    currency VARCHAR(20) NULL,
+    rate DECIMAL(18,6) NULL,
+    original_amount DECIMAL(18,2) NULL,
+    cashflow_item VARCHAR(100) NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_open_api_write_line_no (write_request_id, line_no),
+    KEY idx_open_api_write_line_request (write_request_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='OpenAPI凭证写入分录';
+
+CREATE TABLE matrix_open_api_outbox_event (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    event_id VARCHAR(64) NOT NULL,
+    aggregate_type VARCHAR(64) NOT NULL,
+    aggregate_id BIGINT NOT NULL,
+    event_type VARCHAR(64) NOT NULL,
+    payload_json JSON NULL,
+    status VARCHAR(20) NOT NULL COMMENT 'PENDING/SENDING/SENT/FAILED/DEAD',
+    retry_count INT NOT NULL DEFAULT 0,
+    max_retry INT NOT NULL DEFAULT 10,
+    next_attempt_at DATETIME NOT NULL,
+    sent_at DATETIME NULL,
+    error_message VARCHAR(1000) NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_open_api_outbox_event_id (event_id),
+    KEY idx_open_api_outbox_dispatch (status, next_attempt_at, id),
+    KEY idx_open_api_outbox_aggregate (aggregate_type, aggregate_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='OpenAPI事务Outbox';
+
+CREATE TABLE matrix_open_api_write_status_log (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    write_request_id BIGINT NOT NULL,
+    from_status VARCHAR(32) NULL,
+    to_status VARCHAR(32) NOT NULL,
+    error_code VARCHAR(64) NULL,
+    message VARCHAR(1000) NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    KEY idx_open_api_write_log_request (write_request_id, id),
+    KEY idx_open_api_write_log_status (to_status, created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='OpenAPI凭证写入状态轨迹';
+
+INSERT INTO matrix_open_api_definition
+(api_code, api_name, api_version, http_method, external_path, scope_code, status, max_page_size, sensitivity_level, description)
+VALUES
+('fi.voucher.write.request', '凭证草稿写入受理', 'v1', 'POST', '/open-api/v1/fi/voucher-requests', 'fi.voucher.write', 'PUBLISHED', NULL, 'FINANCIAL_WRITE', '幂等受理凭证草稿异步写入请求'),
+('fi.voucher.write.status', '凭证写入状态查询', 'v1', 'GET', '/open-api/v1/fi/voucher-requests/{requestId}', 'fi.voucher.write.status.read', 'PUBLISHED', NULL, 'FINANCIAL', '按请求ID查询凭证写入状态'),
+('fi.voucher.write.status.external', '凭证写入外部单号查询', 'v1', 'GET', '/open-api/v1/fi/voucher-requests/by-external-no/{externalBizNo}', 'fi.voucher.write.status.read', 'PUBLISHED', NULL, 'FINANCIAL', '按外部业务单号查询凭证写入状态')
+ON DUPLICATE KEY UPDATE
+api_name = VALUES(api_name),
+http_method = VALUES(http_method),
+external_path = VALUES(external_path),
+scope_code = VALUES(scope_code),
+status = VALUES(status),
+description = VALUES(description);
+
+-- 写入授权示例：
+-- {
+--   "organizationIds": ["ORG-001"],
+--   "bookIds": ["BOOK-001"],
+--   "maxLinesPerVoucher": 200,
+--   "dailyWriteQuota": 10000
+-- }


### PR DESCRIPTION
OpenAPI CI and all related module checks passed on head `67dd269918c3b9e0b53a3388ffad4a16e578a294`. This draft is replaced by a non-draft PR from the same verified branch so GitHub recalculates against the current `dev` baseline.