### PR TITLE
feat: complete expense workflow business loop

### DIFF
--- a/docs/business/workflow/fi-expense-workflow-phase2.md
+++ b/docs/business/workflow/fi-expense-workflow-phase2.md
@@ -1,0 +1,47 @@
+# FI 报销工作流业务闭环（二期）
+
+本期在报销工作流接入一期基础上，补齐退回编辑、提交前影像校验、业务撤销、审批详情和状态对账。
+
+## 业务接口
+
+- `PUT /api/fi/expense-reimbursements/{expenseId}`：仅申请人可修改 `DRAFT` 或 `RETURNED` 单据，使用 `version` 乐观锁。
+- `POST /api/fi/expense-reimbursements/{expenseId}/submit`：提交前要求至少一份已确认且扫描状态为 `CLEAN` 的 `INVOICE` 影像。
+- `POST /api/fi/expense-reimbursements/{expenseId}/cancel`：写入 `WORKFLOW_CANCEL_REQUESTED` 业务 Outbox，异步调用工作流撤销接口。
+- `GET /api/fi/expense-reimbursements/{expenseId}/approval-detail`：聚合单据、绑定、流程实例、影像、任务和时间线。
+- `POST /api/fi/expense-reimbursements/admin/reconcile?limit=100`：手动触发状态对账。
+
+## 工作流查询接口
+
+- `GET /api/workflow/instances/{instanceId}/tasks`
+- `GET /api/workflow/instances/{instanceId}/timeline`
+
+时间线来自 `wf_action_log`，并关联任务节点名称。
+
+## 自动对账
+
+`ExpenseWorkflowReconciliationService` 默认每十分钟扫描非终态绑定，通过业务键查询工作流事实状态：
+
+- `RUNNING -> APPROVING`
+- `WAITING_RESUBMIT -> RETURNED`
+- `COMPLETED -> APPROVED`
+- `REJECTED -> REJECTED`
+- `CANCELLED -> CANCELLED`
+
+状态不一致时自动修复，并写入 `fi_workflow_reconciliation_issue`。查询失败记录为 `OPEN`，自动修复记录为 `AUTO_RESOLVED`。
+
+## 数据库
+
+部署前依次执行：
+
+1. `fi_workflow_expense_v1.sql`
+2. `fi_workflow_expense_v2.sql`
+
+## 配置
+
+- `FI_WORKFLOW_RECONCILIATION_DELAY_MS`：自动对账间隔，默认 600000 毫秒。
+- `FI_WORKFLOW_BASE_URL`：工作流服务基础地址。
+- `WORKFLOW_CALLBACK_SECRET`：工作流与财务服务共享回调签名密钥。
+
+## 一致性边界
+
+编辑和提交使用单据 `version` 乐观锁。启动、重提和撤销均通过业务 Outbox 发送；工作流回调使用事件 ID 幂等；定时对账负责修复回调丢失或短暂失败造成的状态差异。

--- a/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowContracts.java
+++ b/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowContracts.java
@@ -1,5 +1,6 @@
 package single.cjj.fi.expense.workflow;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -27,6 +28,19 @@ public final class ExpenseWorkflowContracts {
         }
     }
 
+    public record UpdateExpenseRequest(
+            @NotBlank String operatorId,
+            @NotBlank String departmentCode,
+            @NotNull @DecimalMin(value = "0.01") BigDecimal amount,
+            String currency,
+            @NotBlank String description,
+            @NotNull Integer version
+    ) {
+        public String safeCurrency() {
+            return currency == null || currency.isBlank() ? "CNY" : currency.trim().toUpperCase();
+        }
+    }
+
     public record SubmitExpenseRequest(
             @NotBlank String operatorId,
             String definitionKey,
@@ -36,6 +50,12 @@ public final class ExpenseWorkflowContracts {
             return definitionKey == null || definitionKey.isBlank()
                     ? "expense-reimbursement" : definitionKey.trim();
         }
+    }
+
+    public record CancelExpenseRequest(
+            @NotBlank String operatorId,
+            String reason
+    ) {
     }
 
     public record ExpenseResponse(
@@ -54,6 +74,19 @@ public final class ExpenseWorkflowContracts {
             LocalDateTime submittedAt,
             LocalDateTime completedAt
     ) {
+    }
+
+    public record ApprovalDetailResponse(
+            ExpenseResponse document,
+            Map<String, Object> binding,
+            JsonNode workflow,
+            JsonNode attachments,
+            JsonNode tasks,
+            JsonNode timeline
+    ) {
+    }
+
+    public record ReconciliationResponse(int scanned, int repaired, int failed) {
     }
 
     public record WorkflowEventRequest(
@@ -90,5 +123,8 @@ public final class ExpenseWorkflowContracts {
             String comment,
             Map<String, Object> variables
     ) {
+    }
+
+    public record WorkflowCancelPayload(String operatorId, String reason) {
     }
 }

--- a/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowController.java
+++ b/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowController.java
@@ -4,9 +4,11 @@ import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import single.cjj.bizfi.entity.ApiResponse;
 
@@ -15,9 +17,12 @@ import single.cjj.bizfi.entity.ApiResponse;
 public class ExpenseWorkflowController {
 
     private final ExpenseWorkflowService service;
+    private final ExpenseWorkflowReconciliationService reconciliationService;
 
-    public ExpenseWorkflowController(ExpenseWorkflowService service) {
+    public ExpenseWorkflowController(ExpenseWorkflowService service,
+                                     ExpenseWorkflowReconciliationService reconciliationService) {
         this.service = service;
+        this.reconciliationService = reconciliationService;
     }
 
     @PostMapping
@@ -26,10 +31,23 @@ public class ExpenseWorkflowController {
         return ApiResponse.success(service.create(request));
     }
 
+    @PutMapping("/{expenseId}")
+    public ApiResponse<ExpenseWorkflowContracts.ExpenseResponse> update(
+            @PathVariable("expenseId") String expenseId,
+            @Valid @RequestBody ExpenseWorkflowContracts.UpdateExpenseRequest request) {
+        return ApiResponse.success(service.update(expenseId, request));
+    }
+
     @GetMapping("/{expenseId}")
     public ApiResponse<ExpenseWorkflowContracts.ExpenseResponse> get(
             @PathVariable("expenseId") String expenseId) {
         return ApiResponse.success(service.get(expenseId));
+    }
+
+    @GetMapping("/{expenseId}/approval-detail")
+    public ApiResponse<ExpenseWorkflowContracts.ApprovalDetailResponse> approvalDetail(
+            @PathVariable("expenseId") String expenseId) {
+        return ApiResponse.success(service.approvalDetail(expenseId));
     }
 
     @PostMapping("/{expenseId}/submit")
@@ -38,5 +56,19 @@ public class ExpenseWorkflowController {
             @RequestHeader(value = "X-Request-Id", required = false) String requestId,
             @Valid @RequestBody ExpenseWorkflowContracts.SubmitExpenseRequest request) {
         return ApiResponse.success(service.submit(expenseId, request, requestId));
+    }
+
+    @PostMapping("/{expenseId}/cancel")
+    public ApiResponse<ExpenseWorkflowContracts.ExpenseResponse> cancel(
+            @PathVariable("expenseId") String expenseId,
+            @RequestHeader(value = "X-Request-Id", required = false) String requestId,
+            @Valid @RequestBody ExpenseWorkflowContracts.CancelExpenseRequest request) {
+        return ApiResponse.success(service.cancel(expenseId, request, requestId));
+    }
+
+    @PostMapping("/admin/reconcile")
+    public ApiResponse<ExpenseWorkflowContracts.ReconciliationResponse> reconcile(
+            @RequestParam(value = "limit", defaultValue = "100") int limit) {
+        return ApiResponse.success(reconciliationService.reconcile(limit));
     }
 }

--- a/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowGateway.java
+++ b/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowGateway.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import single.cjj.bizfi.exception.BizException;
 
+import java.util.Locale;
+
 @Component
 public class ExpenseWorkflowGateway {
 
@@ -43,19 +45,83 @@ public class ExpenseWorkflowGateway {
         return parseResult(response);
     }
 
+    public WorkflowResult cancel(String instanceId, String payloadJson, String requestId) {
+        String response = restClient.post()
+                .uri("/workflow/instances/{instanceId}/cancel", instanceId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("X-Request-Id", requestId)
+                .body(payloadJson)
+                .retrieve()
+                .body(String.class);
+        return parseResult(response);
+    }
+
+    public JsonNode getBusinessInstance(String tenantId, String businessId) {
+        return getData("/workflow/business/" + ExpenseWorkflowService.SOURCE_SYSTEM + "/"
+                + ExpenseWorkflowService.BUSINESS_TYPE + "/" + businessId + "?tenantId=" + tenantId);
+    }
+
+    public JsonNode getInstance(String instanceId) {
+        return getData("/workflow/instances/" + instanceId);
+    }
+
+    public JsonNode listTasks(String instanceId) {
+        return getData("/workflow/instances/" + instanceId + "/tasks");
+    }
+
+    public JsonNode listTimeline(String instanceId) {
+        return getData("/workflow/instances/" + instanceId + "/timeline");
+    }
+
+    public JsonNode listAttachments(String tenantId, String businessId) {
+        return getData("/workflow/files/business/" + ExpenseWorkflowService.SOURCE_SYSTEM + "/"
+                + ExpenseWorkflowService.BUSINESS_TYPE + "/" + businessId + "?tenantId=" + tenantId);
+    }
+
+    public void requireUploadedCategory(String tenantId,
+                                        String businessId,
+                                        String categoryCode,
+                                        int minimumCount) {
+        JsonNode attachments = listAttachments(tenantId, businessId);
+        int count = 0;
+        if (attachments != null && attachments.isArray()) {
+            for (JsonNode attachment : attachments) {
+                String category = attachment.path("categoryCode").asText("")
+                        .toUpperCase(Locale.ROOT);
+                if (categoryCode.equalsIgnoreCase(category)
+                        && "UPLOADED".equalsIgnoreCase(attachment.path("uploadStatus").asText())
+                        && "CLEAN".equalsIgnoreCase(attachment.path("scanStatus").asText())) {
+                    count++;
+                }
+            }
+        }
+        if (count < minimumCount) {
+            throw new BizException("提交审批前至少需要 " + minimumCount + " 份 " + categoryCode + " 影像");
+        }
+    }
+
+    private JsonNode getData(String uri) {
+        String response = restClient.get().uri(uri).retrieve().body(String.class);
+        return parseData(response);
+    }
+
     private WorkflowResult parseResult(String response) {
+        JsonNode data = parseData(response);
+        String instanceId = data.path("instanceId").asText();
+        if (instanceId.isBlank()) {
+            throw new BizException("工作流服务响应缺少 instanceId");
+        }
+        return new WorkflowResult(instanceId, data.path("status").asText("RUNNING"));
+    }
+
+    private JsonNode parseData(String response) {
         try {
             JsonNode root = objectMapper.readTree(response);
             if (root == null || root.path("code").asInt() != 200) {
                 throw new BizException("工作流服务调用失败: "
                         + (root == null ? "空响应" : root.path("message").asText("未知错误")));
             }
-            JsonNode data = root.path("data");
-            String instanceId = data.path("instanceId").asText();
-            if (instanceId.isBlank()) {
-                throw new BizException("工作流服务响应缺少 instanceId");
-            }
-            return new WorkflowResult(instanceId, data.path("status").asText("RUNNING"));
+            return root.path("data");
         } catch (BizException ex) {
             throw ex;
         } catch (Exception ex) {

--- a/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowOutboxDispatcher.java
+++ b/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowOutboxDispatcher.java
@@ -54,6 +54,12 @@ public class ExpenseWorkflowOutboxDispatcher {
                 }
                 result = gateway.resubmit(
                         binding.workflowInstanceId(), row.payloadJson(), row.idempotencyKey());
+            } else if (ExpenseWorkflowService.EVENT_CANCEL.equals(row.eventType())) {
+                if (!StringUtils.hasText(binding.workflowInstanceId())) {
+                    throw new IllegalStateException("撤销缺少 workflowInstanceId");
+                }
+                result = gateway.cancel(
+                        binding.workflowInstanceId(), row.payloadJson(), row.idempotencyKey());
             } else {
                 throw new IllegalStateException("不支持的业务 Outbox 事件: " + row.eventType());
             }

--- a/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowReconciliationService.java
+++ b/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowReconciliationService.java
@@ -1,0 +1,87 @@
+package single.cjj.fi.expense.workflow;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+public class ExpenseWorkflowReconciliationService {
+
+    private final ExpenseWorkflowRepository repository;
+    private final ExpenseWorkflowGateway gateway;
+
+    public ExpenseWorkflowReconciliationService(ExpenseWorkflowRepository repository,
+                                                ExpenseWorkflowGateway gateway) {
+        this.repository = repository;
+        this.gateway = gateway;
+    }
+
+    @Scheduled(fixedDelayString = "${fi.workflow.reconciliation.delay-ms:600000}")
+    public void scheduledReconcile() {
+        reconcile(100);
+    }
+
+    public ExpenseWorkflowContracts.ReconciliationResponse reconcile(int requestedLimit) {
+        int limit = Math.min(Math.max(requestedLimit, 1), 500);
+        List<ExpenseWorkflowRepository.BindingRow> rows = repository.findReconciliationCandidates(limit);
+        int repaired = 0;
+        int failed = 0;
+        for (ExpenseWorkflowRepository.BindingRow binding : rows) {
+            try {
+                JsonNode workflow = gateway.getBusinessInstance(binding.tenantId(), binding.businessId());
+                String workflowStatus = workflow.path("status").asText();
+                String businessStatus = mapBusinessStatus(workflowStatus);
+                if (businessStatus == null) {
+                    continue;
+                }
+                if (!workflowStatus.equals(binding.workflowStatus())
+                        || !businessStatus.equals(binding.businessStatus())) {
+                    repository.reconcileStatus(binding.tenantId(), binding.businessId(),
+                            workflow.path("instanceId").asText(binding.workflowInstanceId()),
+                            workflowStatus, businessStatus, isTerminal(workflowStatus));
+                    repository.upsertReconciliationIssue(new ExpenseWorkflowRepository.ReconciliationIssueRow(
+                            newId(), binding.tenantId(), binding.businessType(), binding.businessId(),
+                            binding.workflowInstanceId(), "STATUS_MISMATCH", binding.businessStatus(),
+                            binding.workflowStatus(), businessStatus, workflowStatus,
+                            "AUTO_RESOLVED", null, LocalDateTime.now()));
+                    repaired++;
+                }
+            } catch (Exception ex) {
+                failed++;
+                repository.upsertReconciliationIssue(new ExpenseWorkflowRepository.ReconciliationIssueRow(
+                        newId(), binding.tenantId(), binding.businessType(), binding.businessId(),
+                        binding.workflowInstanceId(), "QUERY_FAILED", binding.businessStatus(),
+                        binding.workflowStatus(), null, null, "OPEN", ex.getMessage(), LocalDateTime.now()));
+                log.warn("expense workflow reconciliation failed, businessId={}", binding.businessId(), ex);
+            }
+        }
+        return new ExpenseWorkflowContracts.ReconciliationResponse(rows.size(), repaired, failed);
+    }
+
+    private String mapBusinessStatus(String workflowStatus) {
+        return switch (workflowStatus) {
+            case "RUNNING" -> "APPROVING";
+            case "WAITING_RESUBMIT" -> "RETURNED";
+            case "COMPLETED" -> "APPROVED";
+            case "REJECTED" -> "REJECTED";
+            case "CANCELLED" -> "CANCELLED";
+            default -> null;
+        };
+    }
+
+    private boolean isTerminal(String workflowStatus) {
+        return "COMPLETED".equals(workflowStatus)
+                || "REJECTED".equals(workflowStatus)
+                || "CANCELLED".equals(workflowStatus);
+    }
+
+    private String newId() {
+        return UUID.randomUUID().toString().replace("-", "");
+    }
+}

--- a/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowRepository.java
+++ b/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowRepository.java
@@ -37,6 +37,23 @@ public class ExpenseWorkflowRepository {
         ));
     }
 
+    public int updateEditable(String expenseId,
+                              String applicantId,
+                              int expectedVersion,
+                              String departmentCode,
+                              BigDecimal amount,
+                              String currency,
+                              String description) {
+        return jdbcTemplate.update("""
+                UPDATE fi_expense_reimbursement
+                SET department_code = ?, amount = ?, currency_code = ?, description_text = ?,
+                    version = version + 1, updated_at = NOW()
+                WHERE id = ? AND applicant_id = ? AND version = ?
+                  AND status IN ('DRAFT', 'RETURNED')
+                """, departmentCode, amount, currency, description,
+                expenseId, applicantId, expectedVersion);
+    }
+
     public int markApproving(String expenseId, int expectedVersion, String workflowInstanceId) {
         return jdbcTemplate.update("""
                 UPDATE fi_expense_reimbursement
@@ -75,6 +92,16 @@ public class ExpenseWorkflowRepository {
                 WHERE tenant_id = ? AND business_type = ? AND business_id = ?
                 LIMIT 1
                 """, this::mapBinding, tenantId, businessType, businessId));
+    }
+
+    public int markCancelRequested(String tenantId, String businessId, String workflowInstanceId) {
+        return jdbcTemplate.update("""
+                UPDATE fi_workflow_binding
+                SET workflow_status = 'CANCEL_REQUESTED', version = version + 1
+                WHERE tenant_id = ? AND business_type = 'EXPENSE_REIMBURSEMENT'
+                  AND business_id = ? AND workflow_instance_id = ?
+                  AND workflow_status <> 'CANCEL_REQUESTED'
+                """, tenantId, businessId, workflowInstanceId);
     }
 
     public void insertOutbox(OutboxRow row) {
@@ -185,6 +212,67 @@ public class ExpenseWorkflowRepository {
                 """, eventId);
     }
 
+    public List<BindingRow> findReconciliationCandidates(int limit) {
+        return jdbcTemplate.query("""
+                SELECT * FROM fi_workflow_binding
+                WHERE business_type = 'EXPENSE_REIMBURSEMENT'
+                  AND workflow_instance_id IS NOT NULL
+                  AND (
+                    business_status IN ('APPROVING', 'RETURNED')
+                    OR workflow_status IN ('START_REQUESTED', 'RESUBMIT_REQUESTED',
+                                           'CANCEL_REQUESTED', 'RUNNING', 'WAITING_RESUBMIT')
+                  )
+                ORDER BY submitted_at
+                LIMIT ?
+                """, this::mapBinding, limit);
+    }
+
+    public void reconcileStatus(String tenantId,
+                                String businessId,
+                                String workflowInstanceId,
+                                String workflowStatus,
+                                String businessStatus,
+                                boolean terminal) {
+        jdbcTemplate.update("""
+                UPDATE fi_expense_reimbursement
+                SET status = ?, workflow_instance_id = ?,
+                    completed_at = CASE WHEN ? THEN NOW() ELSE completed_at END,
+                    version = version + 1, updated_at = NOW()
+                WHERE tenant_id = ? AND id = ?
+                """, businessStatus, workflowInstanceId, terminal, tenantId, businessId);
+        jdbcTemplate.update("""
+                UPDATE fi_workflow_binding
+                SET workflow_instance_id = ?, workflow_status = ?, business_status = ?,
+                    completed_at = CASE WHEN ? THEN NOW() ELSE completed_at END,
+                    version = version + 1
+                WHERE tenant_id = ? AND business_type = 'EXPENSE_REIMBURSEMENT'
+                  AND business_id = ?
+                """, workflowInstanceId, workflowStatus, businessStatus,
+                terminal, tenantId, businessId);
+    }
+
+    public void upsertReconciliationIssue(ReconciliationIssueRow row) {
+        jdbcTemplate.update("""
+                INSERT INTO fi_workflow_reconciliation_issue
+                    (id, tenant_id, business_type, business_id, workflow_instance_id,
+                     issue_type, old_business_status, old_workflow_status,
+                     actual_business_status, actual_workflow_status,
+                     resolve_status, detail_text, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON DUPLICATE KEY UPDATE
+                    workflow_instance_id = VALUES(workflow_instance_id),
+                    old_business_status = VALUES(old_business_status),
+                    old_workflow_status = VALUES(old_workflow_status),
+                    actual_business_status = VALUES(actual_business_status),
+                    actual_workflow_status = VALUES(actual_workflow_status),
+                    detail_text = VALUES(detail_text),
+                    updated_at = VALUES(updated_at)
+                """, row.id(), row.tenantId(), row.businessType(), row.businessId(),
+                row.workflowInstanceId(), row.issueType(), row.oldBusinessStatus(),
+                row.oldWorkflowStatus(), row.actualBusinessStatus(), row.actualWorkflowStatus(),
+                row.resolveStatus(), abbreviate(row.detail(), 1000), row.createdAt(), row.createdAt());
+    }
+
     private ExpenseRow mapExpense(ResultSet rs, int rowNum) throws SQLException {
         return new ExpenseRow(
                 rs.getString("id"), rs.getString("tenant_id"), rs.getString("document_number"),
@@ -254,6 +342,15 @@ public class ExpenseWorkflowRepository {
     public record WorkflowEventRow(
             String eventId, String eventType, String workflowInstanceId,
             String businessType, String businessId, LocalDateTime createdAt
+    ) {
+    }
+
+    public record ReconciliationIssueRow(
+            String id, String tenantId, String businessType, String businessId,
+            String workflowInstanceId, String issueType, String oldBusinessStatus,
+            String oldWorkflowStatus, String actualBusinessStatus,
+            String actualWorkflowStatus, String resolveStatus, String detail,
+            LocalDateTime createdAt
     ) {
     }
 }

--- a/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowService.java
+++ b/fi-service/src/main/java/single/cjj/fi/expense/workflow/ExpenseWorkflowService.java
@@ -1,6 +1,7 @@
 package single.cjj.fi.expense.workflow;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -21,17 +22,21 @@ public class ExpenseWorkflowService {
     public static final String SOURCE_SYSTEM = "fi-service";
     public static final String EVENT_START = "WORKFLOW_START_REQUESTED";
     public static final String EVENT_RESUBMIT = "WORKFLOW_RESUBMIT_REQUESTED";
+    public static final String EVENT_CANCEL = "WORKFLOW_CANCEL_REQUESTED";
 
     private final ExpenseWorkflowRepository repository;
+    private final ExpenseWorkflowGateway gateway;
     private final ObjectMapper objectMapper;
     private final String callbackUrl;
 
     public ExpenseWorkflowService(
             ExpenseWorkflowRepository repository,
+            ExpenseWorkflowGateway gateway,
             ObjectMapper objectMapper,
             @Value("${fi.workflow.callback-url:http://localhost:10003/api/fi/expense/workflow/events}")
             String callbackUrl) {
         this.repository = repository;
+        this.gateway = gateway;
         this.objectMapper = objectMapper;
         this.callbackUrl = callbackUrl;
     }
@@ -62,8 +67,44 @@ public class ExpenseWorkflowService {
         return toResponse(row);
     }
 
+    @Transactional
+    public ExpenseWorkflowContracts.ExpenseResponse update(
+            String expenseId,
+            ExpenseWorkflowContracts.UpdateExpenseRequest request) {
+        ExpenseWorkflowRepository.ExpenseRow expense = requireExpense(expenseId);
+        validateApplicant(expense, request.operatorId());
+        if (!("DRAFT".equals(expense.status()) || "RETURNED".equals(expense.status()))) {
+            throw new BizException("只有草稿或已退回的报销单可以修改");
+        }
+        int updated = repository.updateEditable(
+                expense.id(), request.operatorId(), request.version(), request.departmentCode(),
+                request.amount(), request.safeCurrency(), request.description());
+        if (updated != 1) {
+            throw new BizException("报销单状态或版本已变化，请刷新后重试");
+        }
+        return toResponse(requireExpense(expenseId));
+    }
+
     public ExpenseWorkflowContracts.ExpenseResponse get(String expenseId) {
         return toResponse(requireExpense(expenseId));
+    }
+
+    public ExpenseWorkflowContracts.ApprovalDetailResponse approvalDetail(String expenseId) {
+        ExpenseWorkflowRepository.ExpenseRow expense = requireExpense(expenseId);
+        ExpenseWorkflowRepository.BindingRow binding = repository
+                .findBinding(expense.tenantId(), BUSINESS_TYPE, expense.id())
+                .orElse(null);
+        JsonNode attachments = gateway.listAttachments(expense.tenantId(), expense.id());
+        if (binding == null || !StringUtils.hasText(binding.workflowInstanceId())) {
+            return new ExpenseWorkflowContracts.ApprovalDetailResponse(
+                    toResponse(expense), bindingMap(binding), null,
+                    attachments, objectMapper.createArrayNode(), objectMapper.createArrayNode());
+        }
+        return new ExpenseWorkflowContracts.ApprovalDetailResponse(
+                toResponse(expense), bindingMap(binding),
+                gateway.getInstance(binding.workflowInstanceId()), attachments,
+                gateway.listTasks(binding.workflowInstanceId()),
+                gateway.listTimeline(binding.workflowInstanceId()));
     }
 
     @Transactional
@@ -72,12 +113,12 @@ public class ExpenseWorkflowService {
             ExpenseWorkflowContracts.SubmitExpenseRequest request,
             String requestId) {
         ExpenseWorkflowRepository.ExpenseRow expense = requireExpense(expenseId);
-        if (!expense.applicantId().equals(request.operatorId())) {
-            throw new BizException("只有报销单申请人可以提交审批");
-        }
+        validateApplicant(expense, request.operatorId());
         if (!("DRAFT".equals(expense.status()) || "RETURNED".equals(expense.status()))) {
             throw new BizException("只有草稿或已退回的报销单可以提交");
         }
+
+        gateway.requireUploadedCategory(expense.tenantId(), expense.id(), "INVOICE", 1);
 
         String effectiveRequestId = StringUtils.hasText(requestId) ? requestId.trim() : newId();
         ExpenseWorkflowRepository.BindingRow binding = repository
@@ -129,6 +170,40 @@ public class ExpenseWorkflowService {
         return toResponse(requireExpense(expense.id()));
     }
 
+    @Transactional
+    public ExpenseWorkflowContracts.ExpenseResponse cancel(
+            String expenseId,
+            ExpenseWorkflowContracts.CancelExpenseRequest request,
+            String requestId) {
+        ExpenseWorkflowRepository.ExpenseRow expense = requireExpense(expenseId);
+        validateApplicant(expense, request.operatorId());
+        if (!("APPROVING".equals(expense.status()) || "RETURNED".equals(expense.status()))) {
+            throw new BizException("只有审批中或已退回的报销单可以撤销");
+        }
+        ExpenseWorkflowRepository.BindingRow binding = repository
+                .findBinding(expense.tenantId(), BUSINESS_TYPE, expense.id())
+                .orElseThrow(() -> new BizException("报销单缺少流程绑定"));
+        if (!StringUtils.hasText(binding.workflowInstanceId())) {
+            throw new BizException("流程实例尚未创建，暂时不能撤销");
+        }
+        if ("CANCEL_REQUESTED".equals(binding.workflowStatus())) {
+            return toResponse(expense);
+        }
+
+        String effectiveRequestId = StringUtils.hasText(requestId) ? requestId.trim() : newId();
+        if (repository.markCancelRequested(expense.tenantId(), expense.id(), binding.workflowInstanceId()) != 1) {
+            throw new BizException("流程绑定状态已变化，请刷新后重试");
+        }
+        repository.insertOutbox(new ExpenseWorkflowRepository.OutboxRow(
+                newId(), newId(), BUSINESS_TYPE, expense.id(), EVENT_CANCEL,
+                writeJson(new ExpenseWorkflowContracts.WorkflowCancelPayload(
+                        request.operatorId(), request.reason())),
+                "expense-cancel:" + expense.id() + ":" + effectiveRequestId,
+                "PENDING", 0, LocalDateTime.now()
+        ));
+        return toResponse(expense);
+    }
+
     private Map<String, Object> buildVariables(ExpenseWorkflowRepository.ExpenseRow expense) {
         Map<String, Object> variables = new LinkedHashMap<>();
         variables.put("documentNumber", expense.documentNumber());
@@ -138,6 +213,26 @@ public class ExpenseWorkflowService {
         variables.put("currency", expense.currency());
         variables.put("description", expense.description());
         return variables;
+    }
+
+    private Map<String, Object> bindingMap(ExpenseWorkflowRepository.BindingRow binding) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        if (binding == null) {
+            return result;
+        }
+        result.put("id", binding.id());
+        result.put("workflowInstanceId", binding.workflowInstanceId());
+        result.put("workflowDefinitionKey", binding.workflowDefinitionKey());
+        result.put("workflowStatus", binding.workflowStatus());
+        result.put("businessStatus", binding.businessStatus());
+        result.put("submittedBy", binding.submittedBy());
+        return result;
+    }
+
+    private void validateApplicant(ExpenseWorkflowRepository.ExpenseRow expense, String operatorId) {
+        if (!expense.applicantId().equals(operatorId)) {
+            throw new BizException("只有报销单申请人可以执行该操作");
+        }
     }
 
     private ExpenseWorkflowRepository.ExpenseRow requireExpense(String expenseId) {

--- a/fi-service/src/main/resources/application.yml
+++ b/fi-service/src/main/resources/application.yml
@@ -44,3 +44,5 @@ fi:
     outbox:
       batch-size: ${FI_WORKFLOW_OUTBOX_BATCH_SIZE:20}
       dispatch-delay-ms: ${FI_WORKFLOW_OUTBOX_DISPATCH_DELAY_MS:5000}
+    reconciliation:
+      delay-ms: ${FI_WORKFLOW_RECONCILIATION_DELAY_MS:600000}

--- a/fi-service/src/main/resources/sql/fi_workflow_expense_v2.sql
+++ b/fi-service/src/main/resources/sql/fi_workflow_expense_v2.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS fi_workflow_reconciliation_issue (
+    id VARCHAR(40) PRIMARY KEY,
+    tenant_id VARCHAR(64) NOT NULL,
+    business_type VARCHAR(100) NOT NULL,
+    business_id VARCHAR(128) NOT NULL,
+    workflow_instance_id VARCHAR(40) NULL,
+    issue_type VARCHAR(64) NOT NULL,
+    old_business_status VARCHAR(32) NULL,
+    old_workflow_status VARCHAR(32) NULL,
+    actual_business_status VARCHAR(32) NULL,
+    actual_workflow_status VARCHAR(32) NULL,
+    resolve_status VARCHAR(32) NOT NULL,
+    detail_text VARCHAR(1000) NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uk_fi_reconciliation_issue (
+        tenant_id, business_type, business_id, issue_type, resolve_status
+    ),
+    KEY idx_fi_reconciliation_status (resolve_status, updated_at),
+    KEY idx_fi_reconciliation_business (tenant_id, business_type, business_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/fi-service/src/test/java/single/cjj/fi/expense/workflow/ExpenseWorkflowReconciliationServiceTest.java
+++ b/fi-service/src/test/java/single/cjj/fi/expense/workflow/ExpenseWorkflowReconciliationServiceTest.java
@@ -1,0 +1,41 @@
+package single.cjj.fi.expense.workflow;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ExpenseWorkflowReconciliationServiceTest {
+
+    @Mock
+    private ExpenseWorkflowRepository repository;
+
+    @Mock
+    private ExpenseWorkflowGateway gateway;
+
+    @Test
+    void completedWorkflowRepairsApprovingExpense() throws Exception {
+        ExpenseWorkflowRepository.BindingRow binding = new ExpenseWorkflowRepository.BindingRow(
+                "b1", "tenant", ExpenseWorkflowService.BUSINESS_TYPE, "exp1", "wf1",
+                "expense-reimbursement", "RUNNING", "APPROVING", "r1", "cb", "user1");
+        when(repository.findReconciliationCandidates(100)).thenReturn(List.of(binding));
+        when(gateway.getBusinessInstance("tenant", "exp1"))
+                .thenReturn(new ObjectMapper().readTree(
+                        "{\"instanceId\":\"wf1\",\"status\":\"COMPLETED\"}"));
+
+        ExpenseWorkflowContracts.ReconciliationResponse response =
+                new ExpenseWorkflowReconciliationService(repository, gateway).reconcile(100);
+
+        assertEquals(1, response.repaired());
+        verify(repository).reconcileStatus(
+                "tenant", "exp1", "wf1", "COMPLETED", "APPROVED", true);
+    }
+}

--- a/fi-service/src/test/java/single/cjj/fi/expense/workflow/ExpenseWorkflowServiceTest.java
+++ b/fi-service/src/test/java/single/cjj/fi/expense/workflow/ExpenseWorkflowServiceTest.java
@@ -21,6 +21,9 @@ class ExpenseWorkflowServiceTest {
     @Mock
     private ExpenseWorkflowRepository repository;
 
+    @Mock
+    private ExpenseWorkflowGateway gateway;
+
     @Test
     void draftSubmissionCreatesWorkflowStartOutbox() {
         ExpenseWorkflowRepository.ExpenseRow draft = expense("DRAFT", null, 0);
@@ -32,11 +35,11 @@ class ExpenseWorkflowServiceTest {
                 .thenReturn(Optional.empty());
         when(repository.markApproving("exp1", 0, null)).thenReturn(1);
 
-        ExpenseWorkflowService service = new ExpenseWorkflowService(
-                repository, new ObjectMapper(), "http://fi/api/fi/expense/workflow/events");
+        ExpenseWorkflowService service = service();
         service.submit("exp1", new ExpenseWorkflowContracts.SubmitExpenseRequest(
                 "user1", "expense-reimbursement", "submit"), "req1");
 
+        verify(gateway).requireUploadedCategory("tenant", "exp1", "INVOICE", 1);
         ArgumentCaptor<ExpenseWorkflowRepository.OutboxRow> captor =
                 ArgumentCaptor.forClass(ExpenseWorkflowRepository.OutboxRow.class);
         verify(repository).insertOutbox(captor.capture());
@@ -48,9 +51,7 @@ class ExpenseWorkflowServiceTest {
     void returnedSubmissionCreatesResubmitOutbox() {
         ExpenseWorkflowRepository.ExpenseRow returned = expense("RETURNED", "wf1", 3);
         ExpenseWorkflowRepository.ExpenseRow approving = expense("APPROVING", "wf1", 4);
-        ExpenseWorkflowRepository.BindingRow binding = new ExpenseWorkflowRepository.BindingRow(
-                "binding1", "tenant", ExpenseWorkflowService.BUSINESS_TYPE, "exp1", "wf1",
-                "expense-reimbursement", "WAITING_RESUBMIT", "RETURNED", "old", "callback", "user1");
+        ExpenseWorkflowRepository.BindingRow binding = binding("WAITING_RESUBMIT", "RETURNED");
         when(repository.findExpense("exp1"))
                 .thenReturn(Optional.of(returned))
                 .thenReturn(Optional.of(approving));
@@ -58,8 +59,7 @@ class ExpenseWorkflowServiceTest {
                 .thenReturn(Optional.of(binding));
         when(repository.markApproving("exp1", 3, "wf1")).thenReturn(1);
 
-        ExpenseWorkflowService service = new ExpenseWorkflowService(
-                repository, new ObjectMapper(), "http://fi/api/fi/expense/workflow/events");
+        ExpenseWorkflowService service = service();
         service.submit("exp1", new ExpenseWorkflowContracts.SubmitExpenseRequest(
                 "user1", null, "fixed"), "req2");
 
@@ -68,6 +68,59 @@ class ExpenseWorkflowServiceTest {
         verify(repository).insertOutbox(captor.capture());
         assertEquals(ExpenseWorkflowService.EVENT_RESUBMIT, captor.getValue().eventType());
         assertEquals("expense-resubmit:exp1:req2", captor.getValue().idempotencyKey());
+    }
+
+    @Test
+    void returnedExpenseCanBeEditedWithOptimisticVersion() {
+        ExpenseWorkflowRepository.ExpenseRow returned = expense("RETURNED", "wf1", 3);
+        ExpenseWorkflowRepository.ExpenseRow updated = new ExpenseWorkflowRepository.ExpenseRow(
+                "exp1", "tenant", "ER-1", "user1", "D002", new BigDecimal("120.00"),
+                "CNY", "updated", "RETURNED", "wf1", 4,
+                LocalDateTime.now(), null, null);
+        when(repository.findExpense("exp1"))
+                .thenReturn(Optional.of(returned))
+                .thenReturn(Optional.of(updated));
+        when(repository.updateEditable("exp1", "user1", 3, "D002",
+                new BigDecimal("120.00"), "CNY", "updated")).thenReturn(1);
+
+        ExpenseWorkflowContracts.ExpenseResponse response = service().update("exp1",
+                new ExpenseWorkflowContracts.UpdateExpenseRequest(
+                        "user1", "D002", new BigDecimal("120.00"), "CNY", "updated", 3));
+
+        assertEquals(4, response.version());
+        assertEquals("D002", response.departmentCode());
+    }
+
+    @Test
+    void approvingExpenseCreatesCancelOutbox() {
+        ExpenseWorkflowRepository.ExpenseRow approving = expense("APPROVING", "wf1", 2);
+        when(repository.findExpense("exp1")).thenReturn(Optional.of(approving));
+        when(repository.findBinding("tenant", ExpenseWorkflowService.BUSINESS_TYPE, "exp1"))
+                .thenReturn(Optional.of(binding("RUNNING", "APPROVING")));
+        when(repository.markCancelRequested("tenant", "exp1", "wf1")).thenReturn(1);
+
+        service().cancel("exp1", new ExpenseWorkflowContracts.CancelExpenseRequest(
+                "user1", "no longer needed"), "cancel-1");
+
+        ArgumentCaptor<ExpenseWorkflowRepository.OutboxRow> captor =
+                ArgumentCaptor.forClass(ExpenseWorkflowRepository.OutboxRow.class);
+        verify(repository).insertOutbox(captor.capture());
+        assertEquals(ExpenseWorkflowService.EVENT_CANCEL, captor.getValue().eventType());
+        assertEquals("expense-cancel:exp1:cancel-1", captor.getValue().idempotencyKey());
+    }
+
+    private ExpenseWorkflowService service() {
+        return new ExpenseWorkflowService(
+                repository, gateway, new ObjectMapper(),
+                "http://fi/api/fi/expense/workflow/events");
+    }
+
+    private ExpenseWorkflowRepository.BindingRow binding(String workflowStatus,
+                                                          String businessStatus) {
+        return new ExpenseWorkflowRepository.BindingRow(
+                "binding1", "tenant", ExpenseWorkflowService.BUSINESS_TYPE, "exp1", "wf1",
+                "expense-reimbursement", workflowStatus, businessStatus,
+                "old", "callback", "user1");
     }
 
     private ExpenseWorkflowRepository.ExpenseRow expense(

--- a/workflow-service/src/main/java/single/cjj/workflow/api/WorkflowContracts.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/api/WorkflowContracts.java
@@ -115,4 +115,20 @@ public final class WorkflowContracts {
             LocalDateTime completedAt
     ) {
     }
+
+    public record TimelineResponse(
+            String actionId,
+            String instanceId,
+            String taskId,
+            String nodeKey,
+            String nodeName,
+            String action,
+            String operatorId,
+            String comment,
+            String beforeStatus,
+            String afterStatus,
+            String requestId,
+            LocalDateTime occurredAt
+    ) {
+    }
 }

--- a/workflow-service/src/main/java/single/cjj/workflow/controller/WorkflowInstanceController.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/controller/WorkflowInstanceController.java
@@ -11,16 +11,22 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import single.cjj.bizfi.entity.ApiResponse;
 import single.cjj.workflow.api.WorkflowContracts;
+import single.cjj.workflow.service.WorkflowHistoryService;
 import single.cjj.workflow.service.WorkflowService;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/workflow")
 public class WorkflowInstanceController {
 
     private final WorkflowService workflowService;
+    private final WorkflowHistoryService historyService;
 
-    public WorkflowInstanceController(WorkflowService workflowService) {
+    public WorkflowInstanceController(WorkflowService workflowService,
+                                      WorkflowHistoryService historyService) {
         this.workflowService = workflowService;
+        this.historyService = historyService;
     }
 
     @PostMapping("/instances")
@@ -50,6 +56,18 @@ public class WorkflowInstanceController {
     public ApiResponse<WorkflowContracts.InstanceResponse> get(
             @PathVariable("instanceId") String instanceId) {
         return ApiResponse.success(workflowService.getInstance(instanceId));
+    }
+
+    @GetMapping("/instances/{instanceId}/tasks")
+    public ApiResponse<List<WorkflowContracts.TaskResponse>> tasks(
+            @PathVariable("instanceId") String instanceId) {
+        return ApiResponse.success(historyService.listTasks(instanceId));
+    }
+
+    @GetMapping("/instances/{instanceId}/timeline")
+    public ApiResponse<List<WorkflowContracts.TimelineResponse>> timeline(
+            @PathVariable("instanceId") String instanceId) {
+        return ApiResponse.success(historyService.listTimeline(instanceId));
     }
 
     @GetMapping("/business/{sourceSystem}/{businessType}/{businessId}")

--- a/workflow-service/src/main/java/single/cjj/workflow/service/WorkflowHistoryService.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/service/WorkflowHistoryService.java
@@ -1,0 +1,68 @@
+package single.cjj.workflow.service;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import single.cjj.workflow.api.WorkflowContracts;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class WorkflowHistoryService {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public WorkflowHistoryService(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public List<WorkflowContracts.TaskResponse> listTasks(String instanceId) {
+        return jdbcTemplate.query("""
+                SELECT id, instance_id, node_instance_id, node_key, task_name,
+                       assignee_type, assignee_value, status, version,
+                       created_at, completed_at
+                FROM wf_task
+                WHERE instance_id = ?
+                ORDER BY created_at, id
+                """, this::mapTask, instanceId);
+    }
+
+    public List<WorkflowContracts.TimelineResponse> listTimeline(String instanceId) {
+        return jdbcTemplate.query("""
+                SELECT l.id action_id, l.instance_id, l.task_id,
+                       COALESCE(t.node_key, n.node_key) node_key,
+                       COALESCE(t.task_name, n.node_name) node_name,
+                       l.action, l.operator_id, l.comment_text,
+                       l.before_status, l.after_status, l.request_id, l.created_at
+                FROM wf_action_log l
+                LEFT JOIN wf_task t ON t.id = l.task_id
+                LEFT JOIN wf_node_instance n ON n.id = t.node_instance_id
+                WHERE l.instance_id = ?
+                ORDER BY l.created_at, l.id
+                """, this::mapTimeline, instanceId);
+    }
+
+    private WorkflowContracts.TaskResponse mapTask(ResultSet rs, int rowNum) throws SQLException {
+        return new WorkflowContracts.TaskResponse(
+                rs.getString("id"), rs.getString("instance_id"),
+                rs.getString("node_instance_id"), rs.getString("node_key"),
+                rs.getString("task_name"), rs.getString("assignee_type"),
+                rs.getString("assignee_value"), rs.getString("status"),
+                rs.getInt("version"), rs.getObject("created_at", LocalDateTime.class),
+                rs.getObject("completed_at", LocalDateTime.class)
+        );
+    }
+
+    private WorkflowContracts.TimelineResponse mapTimeline(ResultSet rs, int rowNum) throws SQLException {
+        return new WorkflowContracts.TimelineResponse(
+                rs.getString("action_id"), rs.getString("instance_id"),
+                rs.getString("task_id"), rs.getString("node_key"),
+                rs.getString("node_name"), rs.getString("action"),
+                rs.getString("operator_id"), rs.getString("comment_text"),
+                rs.getString("before_status"), rs.getString("after_status"),
+                rs.getString("request_id"), rs.getObject("created_at", LocalDateTime.class)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- allow applicants to edit DRAFT and RETURNED expense reimbursements with optimistic version checks
- require at least one confirmed clean INVOICE attachment before submit or resubmit
- add finance-side workflow cancellation through the existing transactional Outbox
- aggregate document, binding, workflow instance, attachments, tasks, and timeline into one approval-detail API
- expose workflow instance task history and action timeline endpoints
- add scheduled and manual reconciliation for finance/workflow status drift
- persist reconciliation incidents and auto-repair outcomes
- add database migration, configuration, tests, and implementation documentation

## API additions

- `PUT /api/fi/expense-reimbursements/{expenseId}`
- `POST /api/fi/expense-reimbursements/{expenseId}/cancel`
- `GET /api/fi/expense-reimbursements/{expenseId}/approval-detail`
- `POST /api/fi/expense-reimbursements/admin/reconcile`
- `GET /api/workflow/instances/{instanceId}/tasks`
- `GET /api/workflow/instances/{instanceId}/timeline`

## Database

Run `fi-service/src/main/resources/sql/fi_workflow_expense_v2.sql` after the v1 migration.

## Validation

- submit verifies persisted `INVOICE` attachments in workflow-service
- edit and submit use optimistic concurrency
- cancel uses `WORKFLOW_CANCEL_REQUESTED` and retries through Outbox
- reconciliation maps workflow fact states back to finance document states
- tests cover start, resubmit, edit, cancel, and automatic reconciliation
