### PR TITLE
feat: add OpenAPI callback and reconciliation closure

### DIFF
--- a/docs/bus/platform/openapi/callback-reconcile-v3b.md
+++ b/docs/bus/platform/openapi/callback-reconcile-v3b.md
@@ -1,0 +1,92 @@
+# OpenAPI 第三期 B：回调与对账闭环
+
+## 目标
+
+外部凭证草稿写入进入终态后，Matrix 主动推送结果；回调、写入任务、财务凭证和 Outbox 之间出现不一致时，系统自动发现并进入异常处理台。
+
+## 回调配置
+
+回调地址固定配置在外部应用上，不接受单次写入请求覆盖，避免将 OpenAPI 服务变成任意 URL 请求代理。
+
+约束：
+
+- 默认仅允许 HTTPS。
+- 禁止 localhost、回环、链路本地、站点本地和组播地址。
+- 不跟随 HTTP 重定向。
+- 应用可以暂停回调；已生成但尚未发送的任务将标记为 `SKIPPED`。
+
+## 回调生成
+
+终态扫描器每 5 秒检查最近写入任务，并为以下状态补建唯一回调任务：
+
+- `SUCCEEDED` → `VOUCHER_WRITE_SUCCEEDED`
+- `MANUAL_REQUIRED` → `VOUCHER_WRITE_MANUAL_REQUIRED`
+
+唯一键为 `write_request_id + event_type`。服务在状态提交后宕机也不会丢失回调任务。
+
+## 回调签名
+
+请求头：
+
+- `X-Matrix-Callback-Event-Id`
+- `X-Matrix-Timestamp`
+- `X-Matrix-Nonce`
+- `X-Matrix-Signature`
+
+规范串：
+
+```text
+{eventId}\n{timestamp}\n{nonce}\n{SHA256(rawBody)}
+```
+
+使用应用当前 AppSecret 执行 HMAC-SHA256。接收方应以事件 ID 做幂等，并校验时间戳、Nonce 和签名。
+
+## 回调重试
+
+失败退避：1 分钟、5 分钟、15 分钟、1 小时、3 小时、6 小时。达到最大次数后进入 `DEAD`，管理员可在异常处理台重新激活。
+
+## 每日对账
+
+默认每天 02:30 扫描最近 7 天数据，最长可人工指定 90 天。检查：
+
+1. `SUCCEEDED` 任务没有对应财务凭证。
+2. 非成功任务已经存在财务凭证。
+3. 任务凭证 ID 与财务实际凭证 ID 不一致。
+4. Outbox 长时间处于 `PENDING/SENDING/FAILED/DEAD`。
+5. 回调进入 `DEAD`。
+6. 财务服务核验调用失败。
+
+## 自动修复边界
+
+允许自动或管理员触发修复：
+
+- 财务凭证存在但任务未成功：按财务结果将任务修复为成功。
+- Outbox 卡死：重新激活投递。
+- 回调死信：重新激活回调任务。
+
+不自动修改：
+
+- 成功任务对应凭证缺失。
+- 凭证 ID 不一致。
+
+这些问题必须人工核查后关闭，避免错误创建或覆盖财务数据。
+
+## 管理接口
+
+```text
+PUT  /api/openapi/admin/apps/{id}/callback
+GET  /api/openapi/admin/callbacks
+POST /api/openapi/admin/callbacks/{eventId}/retry
+GET  /api/openapi/admin/reconciliation
+POST /api/openapi/admin/reconciliation/run
+POST /api/openapi/admin/reconciliation/{recordId}/repair
+POST /api/openapi/admin/reconciliation/{recordId}/resolve
+```
+
+## 数据库
+
+在 V1、V2、V3 后执行：
+
+```bash
+mysql < sql/matrix_open_api_v4.sql
+```

--- a/docs/bus/platform/openapi/manifest.json
+++ b/docs/bus/platform/openapi/manifest.json
@@ -4,14 +4,15 @@
   "bizCode": "openapi",
   "bizName": "开放平台",
   "status": "development",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "busDocs": [
     "business.md",
     "rules.md",
     "api.md",
     "deployment.md",
     "governance-v2.md",
-    "voucher-write-v3.md"
+    "voucher-write-v3.md",
+    "callback-reconcile-v3b.md"
   ],
   "promptDocs": [
     "docs/prompt/platform/openapi/backend.md",

--- a/fi-service/src/main/java/single/cjj/fi/gl/controller/BizfiFiVoucherOpenApiReconcileController.java
+++ b/fi-service/src/main/java/single/cjj/fi/gl/controller/BizfiFiVoucherOpenApiReconcileController.java
@@ -1,0 +1,38 @@
+package single.cjj.fi.gl.controller;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import single.cjj.bizfi.entity.ApiResponse;
+import single.cjj.fi.gl.entity.BizfiFiVoucher;
+import single.cjj.fi.gl.service.BizfiFiVoucherService;
+import single.cjj.openapi.contract.OpenVoucherDraftCreateResult;
+
+@RestController
+@RequestMapping("/internal/openapi/v1/vouchers")
+public class BizfiFiVoucherOpenApiReconcileController {
+
+    private final BizfiFiVoucherService voucherService;
+
+    public BizfiFiVoucherOpenApiReconcileController(BizfiFiVoucherService voucherService) {
+        this.voucherService = voucherService;
+    }
+
+    @GetMapping("/by-source-request/{sourceRequestId}")
+    public ApiResponse<OpenVoucherDraftCreateResult> findBySourceRequest(
+            @PathVariable("sourceRequestId") String sourceRequestId,
+            @RequestHeader("X-OpenApi-Tenant-Id") String tenantId) {
+        BizfiFiVoucher voucher = voucherService.getOne(new LambdaQueryWrapper<BizfiFiVoucher>()
+                .eq(BizfiFiVoucher::getTenantId, tenantId.trim())
+                .eq(BizfiFiVoucher::getSourceRequestId, sourceRequestId.trim()), false);
+        if (voucher == null) {
+            return ApiResponse.success(null);
+        }
+        return ApiResponse.success(new OpenVoucherDraftCreateResult(
+                voucher.getFid(), voucher.getFnumber(), voucher.getFstatus()
+        ));
+    }
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/client/FiVoucherWriteClient.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/client/FiVoucherWriteClient.java
@@ -1,8 +1,11 @@
 package single.cjj.openapi.client;
 
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import single.cjj.bizfi.entity.ApiResponse;
 import single.cjj.openapi.contract.OpenVoucherDraftCreateCommand;
 import single.cjj.openapi.contract.OpenVoucherDraftCreateResult;
@@ -18,5 +21,11 @@ public interface FiVoucherWriteClient {
     @PostMapping("/drafts")
     ApiResponse<OpenVoucherDraftCreateResult> createDraft(
             @RequestBody OpenVoucherDraftCreateCommand command
+    );
+
+    @GetMapping("/by-source-request/{sourceRequestId}")
+    ApiResponse<OpenVoucherDraftCreateResult> findBySourceRequest(
+            @PathVariable("sourceRequestId") String sourceRequestId,
+            @RequestHeader("X-OpenApi-Tenant-Id") String tenantId
     );
 }

--- a/openapi-service/src/main/java/single/cjj/openapi/controller/OpenApiAdminController.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/controller/OpenApiAdminController.java
@@ -18,6 +18,7 @@ import single.cjj.openapi.exception.OpenApiCallException;
 import single.cjj.openapi.mapper.OpenApiAppMapper;
 import single.cjj.openapi.mapper.OpenApiDefinitionMapper;
 import single.cjj.openapi.mapper.OpenApiGrantMapper;
+import single.cjj.openapi.service.OpenApiCallbackUrlValidator;
 import single.cjj.openapi.service.OpenApiSecretService;
 
 import java.time.LocalDateTime;
@@ -39,15 +40,18 @@ public class OpenApiAdminController {
     private final OpenApiDefinitionMapper definitionMapper;
     private final OpenApiGrantMapper grantMapper;
     private final OpenApiSecretService secretService;
+    private final OpenApiCallbackUrlValidator callbackUrlValidator;
 
     public OpenApiAdminController(OpenApiAppMapper appMapper,
                                   OpenApiDefinitionMapper definitionMapper,
                                   OpenApiGrantMapper grantMapper,
-                                  OpenApiSecretService secretService) {
+                                  OpenApiSecretService secretService,
+                                  OpenApiCallbackUrlValidator callbackUrlValidator) {
         this.appMapper = appMapper;
         this.definitionMapper = definitionMapper;
         this.grantMapper = grantMapper;
         this.secretService = secretService;
+        this.callbackUrlValidator = callbackUrlValidator;
     }
 
     @PostMapping("/apps")
@@ -55,6 +59,12 @@ public class OpenApiAdminController {
         if (request == null || !StringUtils.hasText(request.appName())) {
             throw new OpenApiCallException("OPENAPI_40001", "应用名称不能为空", 400);
         }
+        String callbackUrl = callbackUrlValidator.validateAndNormalize(request.callbackUrl());
+        boolean callbackEnabled = Boolean.TRUE.equals(request.callbackEnabled());
+        if (callbackEnabled && !StringUtils.hasText(callbackUrl)) {
+            throw new OpenApiCallException("OPENAPI_CALLBACK_40001", "启用回调时必须配置回调地址", 400);
+        }
+
         OpenApiSecretService.GeneratedCredential credential = secretService.generateCredential();
         LocalDateTime now = LocalDateTime.now();
 
@@ -70,16 +80,14 @@ public class OpenApiAdminController {
         app.setIpWhitelist(request.ipWhitelist());
         app.setQpsLimit(normalizePositive(request.qpsLimit(), 10, 10000));
         app.setMaxPageSize(normalizePositive(request.maxPageSize(), 200, 500));
+        app.setCallbackEnabled(callbackEnabled);
+        app.setCallbackUrl(callbackUrl);
         app.setCreatedAt(now);
         app.setUpdatedAt(now);
         appMapper.insert(app);
 
         return ApiResponse.success(new CreateAppResponse(
-                app.getId(),
-                app.getAppId(),
-                app.getAppName(),
-                app.getAppKey(),
-                credential.appSecret()
+                app.getId(), app.getAppId(), app.getAppName(), app.getAppKey(), credential.appSecret()
         ));
     }
 
@@ -179,7 +187,9 @@ public class OpenApiAdminController {
             LocalDateTime validTo,
             String ipWhitelist,
             Integer qpsLimit,
-            Integer maxPageSize) {
+            Integer maxPageSize,
+            Boolean callbackEnabled,
+            String callbackUrl) {
     }
 
     public record CreateAppResponse(
@@ -212,24 +222,17 @@ public class OpenApiAdminController {
             String ipWhitelist,
             Integer qpsLimit,
             Integer maxPageSize,
+            Boolean callbackEnabled,
+            String callbackUrl,
             LocalDateTime createdAt,
             LocalDateTime updatedAt) {
 
         private static AppView from(OpenApiApp app) {
             return new AppView(
-                    app.getId(),
-                    app.getAppId(),
-                    app.getAppName(),
-                    app.getAppKey(),
-                    app.getTenantId(),
-                    app.getStatus(),
-                    app.getValidFrom(),
-                    app.getValidTo(),
-                    app.getIpWhitelist(),
-                    app.getQpsLimit(),
-                    app.getMaxPageSize(),
-                    app.getCreatedAt(),
-                    app.getUpdatedAt()
+                    app.getId(), app.getAppId(), app.getAppName(), app.getAppKey(), app.getTenantId(),
+                    app.getStatus(), app.getValidFrom(), app.getValidTo(), app.getIpWhitelist(),
+                    app.getQpsLimit(), app.getMaxPageSize(), Boolean.TRUE.equals(app.getCallbackEnabled()),
+                    app.getCallbackUrl(), app.getCreatedAt(), app.getUpdatedAt()
             );
         }
     }

--- a/openapi-service/src/main/java/single/cjj/openapi/controller/OpenApiReliabilityAdminController.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/controller/OpenApiReliabilityAdminController.java
@@ -1,0 +1,181 @@
+package single.cjj.openapi.controller;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import single.cjj.bizfi.entity.ApiResponse;
+import single.cjj.openapi.contract.OpenApiPageResponse;
+import single.cjj.openapi.entity.OpenApiApp;
+import single.cjj.openapi.entity.OpenApiCallbackTask;
+import single.cjj.openapi.entity.OpenApiReconcileRecord;
+import single.cjj.openapi.exception.OpenApiCallException;
+import single.cjj.openapi.mapper.OpenApiAppMapper;
+import single.cjj.openapi.mapper.OpenApiCallbackTaskMapper;
+import single.cjj.openapi.mapper.OpenApiReconcileRecordMapper;
+import single.cjj.openapi.service.OpenApiCallbackTaskService;
+import single.cjj.openapi.service.OpenApiCallbackUrlValidator;
+import single.cjj.openapi.service.OpenApiReconciliationService;
+
+import java.time.LocalDateTime;
+
+@RestController
+@RequestMapping("/openapi/admin")
+public class OpenApiReliabilityAdminController {
+
+    private final OpenApiAppMapper appMapper;
+    private final OpenApiCallbackTaskMapper callbackTaskMapper;
+    private final OpenApiReconcileRecordMapper reconcileRecordMapper;
+    private final OpenApiCallbackTaskService callbackTaskService;
+    private final OpenApiReconciliationService reconciliationService;
+    private final OpenApiCallbackUrlValidator callbackUrlValidator;
+
+    public OpenApiReliabilityAdminController(OpenApiAppMapper appMapper,
+                                             OpenApiCallbackTaskMapper callbackTaskMapper,
+                                             OpenApiReconcileRecordMapper reconcileRecordMapper,
+                                             OpenApiCallbackTaskService callbackTaskService,
+                                             OpenApiReconciliationService reconciliationService,
+                                             OpenApiCallbackUrlValidator callbackUrlValidator) {
+        this.appMapper = appMapper;
+        this.callbackTaskMapper = callbackTaskMapper;
+        this.reconcileRecordMapper = reconcileRecordMapper;
+        this.callbackTaskService = callbackTaskService;
+        this.reconciliationService = reconciliationService;
+        this.callbackUrlValidator = callbackUrlValidator;
+    }
+
+    @PutMapping("/apps/{id}/callback")
+    public ApiResponse<Boolean> updateCallbackSettings(
+            @PathVariable("id") Long id,
+            @RequestBody CallbackSettingsRequest request) {
+        OpenApiApp app = appMapper.selectById(id);
+        if (app == null) {
+            throw new OpenApiCallException("OPENAPI_40401", "应用不存在", 404);
+        }
+        if (request == null) {
+            throw new OpenApiCallException("OPENAPI_CALLBACK_40001", "回调配置不能为空", 400);
+        }
+        String callbackUrl = callbackUrlValidator.validateAndNormalize(request.callbackUrl());
+        boolean enabled = Boolean.TRUE.equals(request.enabled());
+        if (enabled && !StringUtils.hasText(callbackUrl)) {
+            throw new OpenApiCallException("OPENAPI_CALLBACK_40001", "启用回调时必须配置回调地址", 400);
+        }
+        app.setCallbackEnabled(enabled);
+        app.setCallbackUrl(callbackUrl);
+        app.setUpdatedAt(LocalDateTime.now());
+        return ApiResponse.success(appMapper.updateById(app) > 0);
+    }
+
+    @GetMapping("/callbacks")
+    public ApiResponse<OpenApiPageResponse<OpenApiCallbackTask>> listCallbacks(
+            @RequestParam(value = "pageNo", defaultValue = "1") int pageNo,
+            @RequestParam(value = "pageSize", defaultValue = "20") int pageSize,
+            @RequestParam(value = "eventId", required = false) String eventId,
+            @RequestParam(value = "requestId", required = false) String requestId,
+            @RequestParam(value = "appId", required = false) Long appId,
+            @RequestParam(value = "status", required = false) String status) {
+        int safePageNo = Math.max(1, pageNo);
+        int safePageSize = Math.max(1, Math.min(pageSize, 200));
+        LambdaQueryWrapper<OpenApiCallbackTask> wrapper = new LambdaQueryWrapper<>();
+        if (StringUtils.hasText(eventId)) {
+            wrapper.eq(OpenApiCallbackTask::getEventId, eventId.trim());
+        }
+        if (StringUtils.hasText(requestId)) {
+            wrapper.eq(OpenApiCallbackTask::getRequestId, requestId.trim());
+        }
+        if (appId != null) {
+            wrapper.eq(OpenApiCallbackTask::getAppId, appId);
+        }
+        if (StringUtils.hasText(status)) {
+            wrapper.eq(OpenApiCallbackTask::getStatus, status.trim().toUpperCase());
+        }
+        wrapper.orderByDesc(OpenApiCallbackTask::getCreatedAt)
+                .orderByDesc(OpenApiCallbackTask::getId);
+        IPage<OpenApiCallbackTask> page = callbackTaskMapper.selectPage(
+                new Page<>(safePageNo, safePageSize), wrapper
+        );
+        return ApiResponse.success(OpenApiPageResponse.of(
+                page.getTotal(), safePageNo, safePageSize, page.getRecords()
+        ));
+    }
+
+    @PostMapping("/callbacks/{eventId}/retry")
+    public ApiResponse<Boolean> retryCallback(@PathVariable("eventId") String eventId) {
+        return ApiResponse.success(callbackTaskService.manualRetry(eventId));
+    }
+
+    @GetMapping("/reconciliation")
+    public ApiResponse<OpenApiPageResponse<OpenApiReconcileRecord>> listReconciliation(
+            @RequestParam(value = "pageNo", defaultValue = "1") int pageNo,
+            @RequestParam(value = "pageSize", defaultValue = "20") int pageSize,
+            @RequestParam(value = "recordId", required = false) String recordId,
+            @RequestParam(value = "requestId", required = false) String requestId,
+            @RequestParam(value = "issueType", required = false) String issueType,
+            @RequestParam(value = "severity", required = false) String severity,
+            @RequestParam(value = "status", required = false) String status) {
+        int safePageNo = Math.max(1, pageNo);
+        int safePageSize = Math.max(1, Math.min(pageSize, 200));
+        LambdaQueryWrapper<OpenApiReconcileRecord> wrapper = new LambdaQueryWrapper<>();
+        if (StringUtils.hasText(recordId)) {
+            wrapper.eq(OpenApiReconcileRecord::getRecordId, recordId.trim());
+        }
+        if (StringUtils.hasText(requestId)) {
+            wrapper.eq(OpenApiReconcileRecord::getRequestId, requestId.trim());
+        }
+        if (StringUtils.hasText(issueType)) {
+            wrapper.eq(OpenApiReconcileRecord::getIssueType, issueType.trim().toUpperCase());
+        }
+        if (StringUtils.hasText(severity)) {
+            wrapper.eq(OpenApiReconcileRecord::getSeverity, severity.trim().toUpperCase());
+        }
+        if (StringUtils.hasText(status)) {
+            wrapper.eq(OpenApiReconcileRecord::getStatus, status.trim().toUpperCase());
+        }
+        wrapper.orderByDesc(OpenApiReconcileRecord::getDetectedAt)
+                .orderByDesc(OpenApiReconcileRecord::getId);
+        IPage<OpenApiReconcileRecord> page = reconcileRecordMapper.selectPage(
+                new Page<>(safePageNo, safePageSize), wrapper
+        );
+        return ApiResponse.success(OpenApiPageResponse.of(
+                page.getTotal(), safePageNo, safePageSize, page.getRecords()
+        ));
+    }
+
+    @PostMapping("/reconciliation/run")
+    public ApiResponse<OpenApiReconciliationService.ReconcileSummary> runReconciliation(
+            @RequestParam(value = "lookbackDays", defaultValue = "7") int lookbackDays) {
+        return ApiResponse.success(reconciliationService.run(lookbackDays));
+    }
+
+    @PostMapping("/reconciliation/{recordId}/repair")
+    public ApiResponse<Boolean> repair(
+            @PathVariable("recordId") String recordId,
+            @RequestHeader(value = "X-User-Id", required = false) String operator) {
+        return ApiResponse.success(reconciliationService.repair(recordId, operator));
+    }
+
+    @PostMapping("/reconciliation/{recordId}/resolve")
+    public ApiResponse<Boolean> resolve(
+            @PathVariable("recordId") String recordId,
+            @RequestHeader(value = "X-User-Id", required = false) String operator,
+            @RequestBody(required = false) ResolveRequest request) {
+        return ApiResponse.success(reconciliationService.manualResolve(
+                recordId, operator, request == null ? null : request.resolution()
+        ));
+    }
+
+    public record CallbackSettingsRequest(Boolean enabled, String callbackUrl) {
+    }
+
+    public record ResolveRequest(String resolution) {
+    }
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/entity/OpenApiApp.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/entity/OpenApiApp.java
@@ -24,6 +24,8 @@ public class OpenApiApp {
     private String ipWhitelist;
     private Integer qpsLimit;
     private Integer maxPageSize;
+    private Boolean callbackEnabled;
+    private String callbackUrl;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 }

--- a/openapi-service/src/main/java/single/cjj/openapi/entity/OpenApiCallbackTask.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/entity/OpenApiCallbackTask.java
@@ -1,0 +1,32 @@
+package single.cjj.openapi.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@TableName("matrix_open_api_callback_task")
+public class OpenApiCallbackTask {
+
+    @TableId(type = IdType.AUTO)
+    private Long id;
+    private String eventId;
+    private Long writeRequestId;
+    private String requestId;
+    private Long appId;
+    private String callbackUrl;
+    private String eventType;
+    private String payloadJson;
+    private String status;
+    private Integer retryCount;
+    private Integer maxRetry;
+    private LocalDateTime nextAttemptAt;
+    private Integer lastHttpStatus;
+    private String errorMessage;
+    private LocalDateTime sentAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/entity/OpenApiReconcileRecord.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/entity/OpenApiReconcileRecord.java
@@ -1,0 +1,33 @@
+package single.cjj.openapi.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@TableName("matrix_open_api_reconcile_record")
+public class OpenApiReconcileRecord {
+
+    @TableId(type = IdType.AUTO)
+    private Long id;
+    private String recordId;
+    private String issueKey;
+    private String issueType;
+    private String severity;
+    private Long writeRequestId;
+    private String requestId;
+    private Long appId;
+    private String expectedStatus;
+    private String actualStatus;
+    private String detailMessage;
+    private String status;
+    private String resolution;
+    private String resolvedBy;
+    private LocalDateTime detectedAt;
+    private LocalDateTime resolvedAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/mapper/OpenApiCallbackTaskMapper.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/mapper/OpenApiCallbackTaskMapper.java
@@ -1,0 +1,7 @@
+package single.cjj.openapi.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import single.cjj.openapi.entity.OpenApiCallbackTask;
+
+public interface OpenApiCallbackTaskMapper extends BaseMapper<OpenApiCallbackTask> {
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/mapper/OpenApiReconcileRecordMapper.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/mapper/OpenApiReconcileRecordMapper.java
@@ -1,0 +1,7 @@
+package single.cjj.openapi.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import single.cjj.openapi.entity.OpenApiReconcileRecord;
+
+public interface OpenApiReconcileRecordMapper extends BaseMapper<OpenApiReconcileRecord> {
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/service/OpenApiCallbackDispatcher.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/service/OpenApiCallbackDispatcher.java
@@ -1,0 +1,177 @@
+package single.cjj.openapi.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import single.cjj.openapi.entity.OpenApiApp;
+import single.cjj.openapi.entity.OpenApiCallbackTask;
+import single.cjj.openapi.mapper.OpenApiAppMapper;
+import single.cjj.openapi.mapper.OpenApiCallbackTaskMapper;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+@Slf4j
+@Component
+public class OpenApiCallbackDispatcher {
+
+    private static final Set<String> DISPATCHABLE = Set.of("PENDING", "FAILED");
+
+    private final OpenApiCallbackTaskMapper callbackTaskMapper;
+    private final OpenApiAppMapper appMapper;
+    private final OpenApiSecretService secretService;
+    private final OpenApiCallbackSignatureService signatureService;
+    private final OpenApiCallbackUrlValidator urlValidator;
+    private final HttpClient httpClient;
+    private final int requestTimeoutSeconds;
+
+    public OpenApiCallbackDispatcher(OpenApiCallbackTaskMapper callbackTaskMapper,
+                                     OpenApiAppMapper appMapper,
+                                     OpenApiSecretService secretService,
+                                     OpenApiCallbackSignatureService signatureService,
+                                     OpenApiCallbackUrlValidator urlValidator,
+                                     @Value("${matrix.openapi.callback.connect-timeout-seconds:3}") int connectTimeoutSeconds,
+                                     @Value("${matrix.openapi.callback.request-timeout-seconds:5}") int requestTimeoutSeconds) {
+        this.callbackTaskMapper = callbackTaskMapper;
+        this.appMapper = appMapper;
+        this.secretService = secretService;
+        this.signatureService = signatureService;
+        this.urlValidator = urlValidator;
+        this.requestTimeoutSeconds = Math.max(1, requestTimeoutSeconds);
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(Math.max(1, connectTimeoutSeconds)))
+                .followRedirects(HttpClient.Redirect.NEVER)
+                .build();
+    }
+
+    @Scheduled(fixedDelayString = "${matrix.openapi.callback.dispatch-poll-ms:3000}")
+    public void dispatch() {
+        LocalDateTime now = LocalDateTime.now();
+        List<OpenApiCallbackTask> tasks = callbackTaskMapper.selectList(
+                new LambdaQueryWrapper<OpenApiCallbackTask>()
+                        .in(OpenApiCallbackTask::getStatus, DISPATCHABLE)
+                        .le(OpenApiCallbackTask::getNextAttemptAt, now)
+                        .orderByAsc(OpenApiCallbackTask::getId)
+                        .last("LIMIT 50")
+        );
+        for (OpenApiCallbackTask task : tasks) {
+            dispatchOne(task);
+        }
+    }
+
+    private void dispatchOne(OpenApiCallbackTask task) {
+        LocalDateTime now = LocalDateTime.now();
+        int claimed = callbackTaskMapper.update(null, new LambdaUpdateWrapper<OpenApiCallbackTask>()
+                .eq(OpenApiCallbackTask::getId, task.getId())
+                .in(OpenApiCallbackTask::getStatus, DISPATCHABLE)
+                .set(OpenApiCallbackTask::getStatus, "SENDING")
+                .set(OpenApiCallbackTask::getUpdatedAt, now));
+        if (claimed == 0) {
+            return;
+        }
+
+        try {
+            OpenApiApp app = appMapper.selectById(task.getAppId());
+            if (app == null || !Boolean.TRUE.equals(app.getCallbackEnabled())) {
+                markSkipped(task, "应用回调已关闭");
+                return;
+            }
+            String callbackUrl = urlValidator.validateAndNormalize(task.getCallbackUrl());
+            String timestamp = String.valueOf(System.currentTimeMillis());
+            String nonce = UUID.randomUUID().toString().replace("-", "");
+            String secret = secretService.decrypt(app.getAppSecretCipher());
+            String signature = signatureService.sign(
+                    secret, task.getEventId(), timestamp, nonce, task.getPayloadJson()
+            );
+
+            HttpRequest request = HttpRequest.newBuilder(URI.create(callbackUrl))
+                    .timeout(Duration.ofSeconds(requestTimeoutSeconds))
+                    .header("Content-Type", "application/json")
+                    .header("User-Agent", "Matrix-OpenAPI-Callback/1.0")
+                    .header("X-Matrix-Callback-Event-Id", task.getEventId())
+                    .header("X-Matrix-Timestamp", timestamp)
+                    .header("X-Matrix-Nonce", nonce)
+                    .header("X-Matrix-Signature", signature)
+                    .POST(HttpRequest.BodyPublishers.ofString(task.getPayloadJson()))
+                    .build();
+            HttpResponse<String> response = httpClient.send(
+                    request, HttpResponse.BodyHandlers.ofString()
+            );
+            if (response.statusCode() >= 200 && response.statusCode() < 300) {
+                markSucceeded(task, response.statusCode());
+            } else {
+                markFailed(task, response.statusCode(), "回调HTTP状态异常: " + response.statusCode());
+            }
+        } catch (Exception e) {
+            markFailed(task, null, e.getMessage());
+        }
+    }
+
+    private void markSucceeded(OpenApiCallbackTask task, int httpStatus) {
+        LocalDateTime now = LocalDateTime.now();
+        callbackTaskMapper.update(null, new LambdaUpdateWrapper<OpenApiCallbackTask>()
+                .eq(OpenApiCallbackTask::getId, task.getId())
+                .eq(OpenApiCallbackTask::getStatus, "SENDING")
+                .set(OpenApiCallbackTask::getStatus, "SUCCEEDED")
+                .set(OpenApiCallbackTask::getLastHttpStatus, httpStatus)
+                .set(OpenApiCallbackTask::getErrorMessage, null)
+                .set(OpenApiCallbackTask::getSentAt, now)
+                .set(OpenApiCallbackTask::getUpdatedAt, now));
+    }
+
+    private void markSkipped(OpenApiCallbackTask task, String message) {
+        callbackTaskMapper.update(null, new LambdaUpdateWrapper<OpenApiCallbackTask>()
+                .eq(OpenApiCallbackTask::getId, task.getId())
+                .eq(OpenApiCallbackTask::getStatus, "SENDING")
+                .set(OpenApiCallbackTask::getStatus, "SKIPPED")
+                .set(OpenApiCallbackTask::getErrorMessage, truncate(message, 1000))
+                .set(OpenApiCallbackTask::getUpdatedAt, LocalDateTime.now()));
+    }
+
+    private void markFailed(OpenApiCallbackTask task, Integer httpStatus, String message) {
+        int retryCount = (task.getRetryCount() == null ? 0 : task.getRetryCount()) + 1;
+        int maxRetry = task.getMaxRetry() == null ? 6 : task.getMaxRetry();
+        boolean exhausted = retryCount >= maxRetry;
+        LocalDateTime now = LocalDateTime.now();
+        callbackTaskMapper.update(null, new LambdaUpdateWrapper<OpenApiCallbackTask>()
+                .eq(OpenApiCallbackTask::getId, task.getId())
+                .eq(OpenApiCallbackTask::getStatus, "SENDING")
+                .set(OpenApiCallbackTask::getStatus, exhausted ? "DEAD" : "FAILED")
+                .set(OpenApiCallbackTask::getRetryCount, retryCount)
+                .set(OpenApiCallbackTask::getNextAttemptAt,
+                        exhausted ? null : now.plusMinutes(retryDelayMinutes(retryCount)))
+                .set(OpenApiCallbackTask::getLastHttpStatus, httpStatus)
+                .set(OpenApiCallbackTask::getErrorMessage, truncate(message, 1000))
+                .set(OpenApiCallbackTask::getUpdatedAt, now));
+        log.warn("OpenAPI callback failed, eventId={}, retry={}, message={}",
+                task.getEventId(), retryCount, message);
+    }
+
+    private long retryDelayMinutes(int retryCount) {
+        return switch (retryCount) {
+            case 1 -> 1;
+            case 2 -> 5;
+            case 3 -> 15;
+            case 4 -> 60;
+            case 5 -> 180;
+            default -> 360;
+        };
+    }
+
+    private String truncate(String value, int maxLength) {
+        if (value == null) {
+            return null;
+        }
+        return value.length() <= maxLength ? value : value.substring(0, maxLength);
+    }
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/service/OpenApiCallbackSignatureService.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/service/OpenApiCallbackSignatureService.java
@@ -1,0 +1,28 @@
+package single.cjj.openapi.service;
+
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+
+@Service
+public class OpenApiCallbackSignatureService {
+
+    private final OpenApiSignatureService signatureService;
+
+    public OpenApiCallbackSignatureService(OpenApiSignatureService signatureService) {
+        this.signatureService = signatureService;
+    }
+
+    public String canonical(String eventId, String timestamp, String nonce, byte[] body) {
+        return String.join("\n",
+                eventId == null ? "" : eventId,
+                timestamp == null ? "" : timestamp,
+                nonce == null ? "" : nonce,
+                signatureService.sha256Hex(body == null ? new byte[0] : body));
+    }
+
+    public String sign(String appSecret, String eventId, String timestamp, String nonce, String body) {
+        byte[] bytes = body == null ? new byte[0] : body.getBytes(StandardCharsets.UTF_8);
+        return signatureService.sign(appSecret, canonical(eventId, timestamp, nonce, bytes));
+    }
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/service/OpenApiCallbackTaskService.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/service/OpenApiCallbackTaskService.java
@@ -1,0 +1,144 @@
+package single.cjj.openapi.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import single.cjj.openapi.entity.OpenApiApp;
+import single.cjj.openapi.entity.OpenApiCallbackTask;
+import single.cjj.openapi.entity.OpenApiWriteRequest;
+import single.cjj.openapi.exception.OpenApiCallException;
+import single.cjj.openapi.mapper.OpenApiAppMapper;
+import single.cjj.openapi.mapper.OpenApiCallbackTaskMapper;
+import single.cjj.openapi.mapper.OpenApiWriteRequestMapper;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+public class OpenApiCallbackTaskService {
+
+    private static final Set<String> TERMINAL_STATUSES = Set.of("SUCCEEDED", "MANUAL_REQUIRED");
+    private static final Set<String> MANUALLY_RETRYABLE = Set.of("FAILED", "DEAD");
+
+    private final OpenApiWriteRequestMapper writeRequestMapper;
+    private final OpenApiCallbackTaskMapper callbackTaskMapper;
+    private final OpenApiAppMapper appMapper;
+    private final ObjectMapper objectMapper;
+
+    public OpenApiCallbackTaskService(OpenApiWriteRequestMapper writeRequestMapper,
+                                      OpenApiCallbackTaskMapper callbackTaskMapper,
+                                      OpenApiAppMapper appMapper,
+                                      ObjectMapper objectMapper) {
+        this.writeRequestMapper = writeRequestMapper;
+        this.callbackTaskMapper = callbackTaskMapper;
+        this.appMapper = appMapper;
+        this.objectMapper = objectMapper;
+    }
+
+    @Scheduled(fixedDelayString = "${matrix.openapi.callback.materialize-poll-ms:5000}")
+    public void materializeTerminalCallbacks() {
+        List<OpenApiWriteRequest> requests = writeRequestMapper.selectList(
+                new LambdaQueryWrapper<OpenApiWriteRequest>()
+                        .in(OpenApiWriteRequest::getStatus, TERMINAL_STATUSES)
+                        .orderByDesc(OpenApiWriteRequest::getUpdatedAt)
+                        .last("LIMIT 100")
+        );
+        for (OpenApiWriteRequest request : requests) {
+            materialize(request);
+        }
+    }
+
+    @Transactional
+    public boolean materialize(OpenApiWriteRequest request) {
+        if (request == null || !TERMINAL_STATUSES.contains(request.getStatus())) {
+            return false;
+        }
+        OpenApiApp app = appMapper.selectById(request.getAppId());
+        if (app == null || !Boolean.TRUE.equals(app.getCallbackEnabled())
+                || !StringUtils.hasText(app.getCallbackUrl())) {
+            return false;
+        }
+        String eventType = "SUCCEEDED".equals(request.getStatus())
+                ? "VOUCHER_WRITE_SUCCEEDED"
+                : "VOUCHER_WRITE_MANUAL_REQUIRED";
+        Long count = callbackTaskMapper.selectCount(new LambdaQueryWrapper<OpenApiCallbackTask>()
+                .eq(OpenApiCallbackTask::getWriteRequestId, request.getId())
+                .eq(OpenApiCallbackTask::getEventType, eventType));
+        if (count != null && count > 0) {
+            return false;
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        OpenApiCallbackTask task = new OpenApiCallbackTask();
+        task.setEventId("cb_" + UUID.randomUUID().toString().replace("-", ""));
+        task.setWriteRequestId(request.getId());
+        task.setRequestId(request.getRequestId());
+        task.setAppId(request.getAppId());
+        task.setCallbackUrl(app.getCallbackUrl());
+        task.setEventType(eventType);
+        task.setPayloadJson(payload(request, eventType));
+        task.setStatus("PENDING");
+        task.setRetryCount(0);
+        task.setMaxRetry(6);
+        task.setNextAttemptAt(now);
+        task.setCreatedAt(now);
+        task.setUpdatedAt(now);
+        try {
+            callbackTaskMapper.insert(task);
+            return true;
+        } catch (DuplicateKeyException ignored) {
+            return false;
+        }
+    }
+
+    @Transactional
+    public boolean manualRetry(String eventId) {
+        OpenApiCallbackTask task = callbackTaskMapper.selectOne(
+                new LambdaQueryWrapper<OpenApiCallbackTask>().eq(OpenApiCallbackTask::getEventId, eventId)
+        );
+        if (task == null) {
+            throw new OpenApiCallException("OPENAPI_40401", "回调任务不存在", 404);
+        }
+        if (!MANUALLY_RETRYABLE.contains(task.getStatus())) {
+            throw new OpenApiCallException("OPENAPI_CALLBACK_40901", "只有失败或死信回调可以重试", 409);
+        }
+        LocalDateTime now = LocalDateTime.now();
+        int updated = callbackTaskMapper.update(null, new LambdaUpdateWrapper<OpenApiCallbackTask>()
+                .eq(OpenApiCallbackTask::getId, task.getId())
+                .in(OpenApiCallbackTask::getStatus, MANUALLY_RETRYABLE)
+                .set(OpenApiCallbackTask::getStatus, "PENDING")
+                .set(OpenApiCallbackTask::getRetryCount, 0)
+                .set(OpenApiCallbackTask::getNextAttemptAt, now)
+                .set(OpenApiCallbackTask::getErrorMessage, null)
+                .set(OpenApiCallbackTask::getUpdatedAt, now));
+        return updated > 0;
+    }
+
+    private String payload(OpenApiWriteRequest request, String eventType) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("eventType", eventType);
+        payload.put("requestId", request.getRequestId());
+        payload.put("externalBizNo", request.getExternalBizNo());
+        payload.put("status", request.getStatus());
+        payload.put("voucherId", request.getVoucherId());
+        payload.put("voucherNumber", request.getVoucherNumber());
+        payload.put("errorCode", request.getErrorCode());
+        payload.put("errorMessage", request.getErrorMessage());
+        payload.put("finishedAt", request.getFinishedAt());
+        try {
+            return objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("构造回调报文失败", e);
+        }
+    }
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/service/OpenApiCallbackUrlValidator.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/service/OpenApiCallbackUrlValidator.java
@@ -1,0 +1,59 @@
+package single.cjj.openapi.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import single.cjj.openapi.exception.OpenApiCallException;
+
+import java.net.InetAddress;
+import java.net.URI;
+
+@Service
+public class OpenApiCallbackUrlValidator {
+
+    private final boolean allowHttp;
+
+    public OpenApiCallbackUrlValidator(
+            @Value("${matrix.openapi.callback.allow-http:false}") boolean allowHttp) {
+        this.allowHttp = allowHttp;
+    }
+
+    public String validateAndNormalize(String callbackUrl) {
+        if (!StringUtils.hasText(callbackUrl)) {
+            return null;
+        }
+        try {
+            URI uri = URI.create(callbackUrl.trim());
+            String scheme = uri.getScheme();
+            if (!("https".equalsIgnoreCase(scheme) || (allowHttp && "http".equalsIgnoreCase(scheme)))) {
+                throw badRequest("回调地址必须使用HTTPS");
+            }
+            if (!StringUtils.hasText(uri.getHost()) || uri.getUserInfo() != null || uri.getFragment() != null) {
+                throw badRequest("回调地址格式不合法");
+            }
+            String host = uri.getHost().trim();
+            if ("localhost".equalsIgnoreCase(host) || host.endsWith(".localhost")) {
+                throw badRequest("回调地址不能指向本机");
+            }
+            InetAddress[] addresses = InetAddress.getAllByName(host);
+            for (InetAddress address : addresses) {
+                if (address.isAnyLocalAddress()
+                        || address.isLoopbackAddress()
+                        || address.isLinkLocalAddress()
+                        || address.isSiteLocalAddress()
+                        || address.isMulticastAddress()) {
+                    throw badRequest("回调地址不能指向内网或保留地址");
+                }
+            }
+            return uri.normalize().toString();
+        } catch (OpenApiCallException e) {
+            throw e;
+        } catch (Exception e) {
+            throw badRequest("回调地址无法解析");
+        }
+    }
+
+    private OpenApiCallException badRequest(String message) {
+        return new OpenApiCallException("OPENAPI_CALLBACK_40001", message, 400);
+    }
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/service/OpenApiReconciliationService.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/service/OpenApiReconciliationService.java
@@ -1,0 +1,329 @@
+package single.cjj.openapi.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import single.cjj.bizfi.entity.ApiResponse;
+import single.cjj.openapi.client.FiVoucherWriteClient;
+import single.cjj.openapi.contract.OpenVoucherDraftCreateResult;
+import single.cjj.openapi.entity.OpenApiCallbackTask;
+import single.cjj.openapi.entity.OpenApiOutboxEvent;
+import single.cjj.openapi.entity.OpenApiReconcileRecord;
+import single.cjj.openapi.entity.OpenApiWriteRequest;
+import single.cjj.openapi.exception.OpenApiCallException;
+import single.cjj.openapi.mapper.OpenApiCallbackTaskMapper;
+import single.cjj.openapi.mapper.OpenApiOutboxEventMapper;
+import single.cjj.openapi.mapper.OpenApiReconcileRecordMapper;
+import single.cjj.openapi.mapper.OpenApiWriteRequestMapper;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+@Service
+public class OpenApiReconciliationService {
+
+    private final OpenApiWriteRequestMapper writeRequestMapper;
+    private final OpenApiOutboxEventMapper outboxMapper;
+    private final OpenApiCallbackTaskMapper callbackTaskMapper;
+    private final OpenApiReconcileRecordMapper reconcileRecordMapper;
+    private final FiVoucherWriteClient fiVoucherWriteClient;
+    private final OpenApiWriteStateService writeStateService;
+    private final OpenApiCallbackTaskService callbackTaskService;
+    private final int defaultLookbackDays;
+    private final int stuckMinutes;
+
+    public OpenApiReconciliationService(OpenApiWriteRequestMapper writeRequestMapper,
+                                        OpenApiOutboxEventMapper outboxMapper,
+                                        OpenApiCallbackTaskMapper callbackTaskMapper,
+                                        OpenApiReconcileRecordMapper reconcileRecordMapper,
+                                        FiVoucherWriteClient fiVoucherWriteClient,
+                                        OpenApiWriteStateService writeStateService,
+                                        OpenApiCallbackTaskService callbackTaskService,
+                                        @Value("${matrix.openapi.reconcile.lookback-days:7}") int defaultLookbackDays,
+                                        @Value("${matrix.openapi.reconcile.stuck-minutes:10}") int stuckMinutes) {
+        this.writeRequestMapper = writeRequestMapper;
+        this.outboxMapper = outboxMapper;
+        this.callbackTaskMapper = callbackTaskMapper;
+        this.reconcileRecordMapper = reconcileRecordMapper;
+        this.fiVoucherWriteClient = fiVoucherWriteClient;
+        this.writeStateService = writeStateService;
+        this.callbackTaskService = callbackTaskService;
+        this.defaultLookbackDays = Math.max(1, Math.min(defaultLookbackDays, 90));
+        this.stuckMinutes = Math.max(1, stuckMinutes);
+    }
+
+    @Scheduled(cron = "${matrix.openapi.reconcile.cron:0 30 2 * * ?}")
+    public void scheduledRun() {
+        run(defaultLookbackDays);
+    }
+
+    public ReconcileSummary run(int lookbackDays) {
+        int safeDays = Math.max(1, Math.min(lookbackDays, 90));
+        LocalDateTime from = LocalDateTime.now().minusDays(safeDays);
+        List<OpenApiWriteRequest> requests = writeRequestMapper.selectList(
+                new LambdaQueryWrapper<OpenApiWriteRequest>()
+                        .ge(OpenApiWriteRequest::getCreatedAt, from)
+                        .orderByAsc(OpenApiWriteRequest::getId)
+                        .last("LIMIT 5000")
+        );
+        int issues = 0;
+        for (OpenApiWriteRequest request : requests) {
+            issues += reconcileWriteRequest(request);
+        }
+        issues += reconcileOutbox(from);
+        issues += reconcileCallbacks(from);
+        return new ReconcileSummary(safeDays, requests.size(), issues, LocalDateTime.now());
+    }
+
+    private int reconcileWriteRequest(OpenApiWriteRequest request) {
+        OpenVoucherDraftCreateResult actual = null;
+        try {
+            ApiResponse<OpenVoucherDraftCreateResult> response = fiVoucherWriteClient.findBySourceRequest(
+                    request.getRequestId(), request.getTenantId()
+            );
+            if (response != null && response.getCode() == 200) {
+                actual = response.getData();
+            }
+        } catch (Exception e) {
+            upsertIssue(
+                    "FINANCE_LOOKUP_FAILED:" + request.getRequestId(),
+                    "FINANCE_LOOKUP_FAILED", "WARNING", request,
+                    request.getStatus(), "LOOKUP_FAILED", "财务服务核验失败: " + e.getMessage()
+            );
+            return 1;
+        }
+        resolveIfOpen("FINANCE_LOOKUP_FAILED:" + request.getRequestId(), "财务服务核验恢复正常");
+
+        if ("SUCCEEDED".equals(request.getStatus()) && actual == null) {
+            upsertIssue(
+                    "VOUCHER_MISSING:" + request.getRequestId(),
+                    "VOUCHER_MISSING", "CRITICAL", request,
+                    "VOUCHER_EXISTS", "NOT_FOUND", "任务成功但财务凭证不存在"
+            );
+            return 1;
+        }
+        resolveIfOpen("VOUCHER_MISSING:" + request.getRequestId(), "财务凭证已存在");
+
+        if (!"SUCCEEDED".equals(request.getStatus()) && actual != null) {
+            upsertIssue(
+                    "TASK_STATUS_MISMATCH:" + request.getRequestId(),
+                    "TASK_STATUS_MISMATCH", "HIGH", request,
+                    "SUCCEEDED", request.getStatus(), "财务凭证已存在，但写入任务未标记成功"
+            );
+            return 1;
+        }
+        resolveIfOpen("TASK_STATUS_MISMATCH:" + request.getRequestId(), "任务与凭证状态已一致");
+
+        if (actual != null && request.getVoucherId() != null
+                && !Objects.equals(request.getVoucherId(), actual.getVoucherId())) {
+            upsertIssue(
+                    "VOUCHER_ID_MISMATCH:" + request.getRequestId(),
+                    "VOUCHER_ID_MISMATCH", "HIGH", request,
+                    String.valueOf(request.getVoucherId()), String.valueOf(actual.getVoucherId()),
+                    "任务记录的凭证ID与财务实际凭证不一致"
+            );
+            return 1;
+        }
+        resolveIfOpen("VOUCHER_ID_MISMATCH:" + request.getRequestId(), "凭证ID已一致");
+        return 0;
+    }
+
+    private int reconcileOutbox(LocalDateTime from) {
+        LocalDateTime cutoff = LocalDateTime.now().minusMinutes(stuckMinutes);
+        List<OpenApiOutboxEvent> events = outboxMapper.selectList(
+                new LambdaQueryWrapper<OpenApiOutboxEvent>()
+                        .ge(OpenApiOutboxEvent::getCreatedAt, from)
+                        .in(OpenApiOutboxEvent::getStatus, "PENDING", "SENDING", "FAILED", "DEAD")
+                        .orderByAsc(OpenApiOutboxEvent::getId)
+                        .last("LIMIT 5000")
+        );
+        int issues = 0;
+        for (OpenApiOutboxEvent event : events) {
+            String issueKey = "OUTBOX_STUCK:" + event.getEventId();
+            boolean stuck = "DEAD".equals(event.getStatus())
+                    || event.getUpdatedAt() == null
+                    || event.getUpdatedAt().isBefore(cutoff);
+            if (stuck) {
+                OpenApiWriteRequest request = writeRequestMapper.selectById(event.getAggregateId());
+                upsertIssue(
+                        issueKey, "OUTBOX_STUCK",
+                        "DEAD".equals(event.getStatus()) ? "CRITICAL" : "HIGH",
+                        request, "SENT", event.getStatus(),
+                        "Outbox事件长时间未成功投递: " + event.getEventId()
+                );
+                issues++;
+            } else {
+                resolveIfOpen(issueKey, "Outbox事件已恢复");
+            }
+        }
+        return issues;
+    }
+
+    private int reconcileCallbacks(LocalDateTime from) {
+        List<OpenApiCallbackTask> tasks = callbackTaskMapper.selectList(
+                new LambdaQueryWrapper<OpenApiCallbackTask>()
+                        .ge(OpenApiCallbackTask::getCreatedAt, from)
+                        .orderByAsc(OpenApiCallbackTask::getId)
+                        .last("LIMIT 5000")
+        );
+        int issues = 0;
+        for (OpenApiCallbackTask task : tasks) {
+            String issueKey = "CALLBACK_DEAD:" + task.getEventId();
+            if ("DEAD".equals(task.getStatus())) {
+                OpenApiWriteRequest request = writeRequestMapper.selectById(task.getWriteRequestId());
+                upsertIssue(
+                        issueKey, "CALLBACK_DEAD", "HIGH", request,
+                        "SUCCEEDED", task.getStatus(),
+                        "回调超过最大重试次数: " + task.getEventId()
+                );
+                issues++;
+            } else {
+                resolveIfOpen(issueKey, "回调任务已恢复");
+            }
+        }
+        return issues;
+    }
+
+    @Transactional
+    public boolean repair(String recordId, String operator) {
+        OpenApiReconcileRecord record = requireRecord(recordId);
+        if (!"OPEN".equals(record.getStatus())) {
+            throw new OpenApiCallException("OPENAPI_RECONCILE_40901", "只有未处理异常可以修复", 409);
+        }
+        if ("TASK_STATUS_MISMATCH".equals(record.getIssueType())) {
+            OpenApiWriteRequest request = writeRequestMapper.selectById(record.getWriteRequestId());
+            ApiResponse<OpenVoucherDraftCreateResult> response = fiVoucherWriteClient.findBySourceRequest(
+                    request.getRequestId(), request.getTenantId()
+            );
+            if (response == null || response.getData() == null) {
+                throw new OpenApiCallException("OPENAPI_RECONCILE_40902", "财务凭证仍不存在，无法修复任务状态", 409);
+            }
+            writeStateService.markSucceeded(request.getId(), response.getData());
+            resolve(record, operator, "已按财务实际凭证修复写入任务状态");
+            return true;
+        }
+        if ("OUTBOX_STUCK".equals(record.getIssueType())) {
+            OpenApiOutboxEvent event = outboxMapper.selectOne(
+                    new LambdaQueryWrapper<OpenApiOutboxEvent>()
+                            .eq(OpenApiOutboxEvent::getAggregateId, record.getWriteRequestId())
+                            .orderByDesc(OpenApiOutboxEvent::getId)
+                            .last("LIMIT 1")
+            );
+            if (event == null) {
+                throw new OpenApiCallException("OPENAPI_RECONCILE_40902", "Outbox事件不存在", 409);
+            }
+            outboxMapper.update(null, new LambdaUpdateWrapper<OpenApiOutboxEvent>()
+                    .eq(OpenApiOutboxEvent::getId, event.getId())
+                    .set(OpenApiOutboxEvent::getStatus, "FAILED")
+                    .set(OpenApiOutboxEvent::getNextAttemptAt, LocalDateTime.now())
+                    .set(OpenApiOutboxEvent::getErrorMessage, null)
+                    .set(OpenApiOutboxEvent::getUpdatedAt, LocalDateTime.now()));
+            resolve(record, operator, "已重新激活Outbox事件");
+            return true;
+        }
+        if ("CALLBACK_DEAD".equals(record.getIssueType())) {
+            String eventId = record.getIssueKey().substring("CALLBACK_DEAD:".length());
+            callbackTaskService.manualRetry(eventId);
+            resolve(record, operator, "已重新激活回调任务");
+            return true;
+        }
+        throw new OpenApiCallException("OPENAPI_RECONCILE_40902", "该异常需要人工核查后手动关闭", 409);
+    }
+
+    @Transactional
+    public boolean manualResolve(String recordId, String operator, String resolution) {
+        OpenApiReconcileRecord record = requireRecord(recordId);
+        resolve(record, operator, resolution == null ? "管理员手动关闭" : resolution);
+        return true;
+    }
+
+    private void upsertIssue(String issueKey,
+                             String issueType,
+                             String severity,
+                             OpenApiWriteRequest request,
+                             String expectedStatus,
+                             String actualStatus,
+                             String detail) {
+        OpenApiReconcileRecord record = reconcileRecordMapper.selectOne(
+                new LambdaQueryWrapper<OpenApiReconcileRecord>()
+                        .eq(OpenApiReconcileRecord::getIssueKey, issueKey)
+        );
+        LocalDateTime now = LocalDateTime.now();
+        if (record == null) {
+            record = new OpenApiReconcileRecord();
+            record.setRecordId("rec_" + UUID.randomUUID().toString().replace("-", ""));
+            record.setIssueKey(issueKey);
+            record.setCreatedAt(now);
+        }
+        record.setIssueType(issueType);
+        record.setSeverity(severity);
+        record.setWriteRequestId(request == null ? null : request.getId());
+        record.setRequestId(request == null ? null : request.getRequestId());
+        record.setAppId(request == null ? null : request.getAppId());
+        record.setExpectedStatus(expectedStatus);
+        record.setActualStatus(actualStatus);
+        record.setDetailMessage(truncate(detail, 1000));
+        record.setStatus("OPEN");
+        record.setResolution(null);
+        record.setResolvedBy(null);
+        record.setResolvedAt(null);
+        record.setDetectedAt(now);
+        record.setUpdatedAt(now);
+        if (record.getId() == null) {
+            reconcileRecordMapper.insert(record);
+        } else {
+            reconcileRecordMapper.updateById(record);
+        }
+    }
+
+    private void resolveIfOpen(String issueKey, String resolution) {
+        OpenApiReconcileRecord record = reconcileRecordMapper.selectOne(
+                new LambdaQueryWrapper<OpenApiReconcileRecord>()
+                        .eq(OpenApiReconcileRecord::getIssueKey, issueKey)
+                        .eq(OpenApiReconcileRecord::getStatus, "OPEN")
+        );
+        if (record != null) {
+            resolve(record, "system", resolution);
+        }
+    }
+
+    private void resolve(OpenApiReconcileRecord record, String operator, String resolution) {
+        LocalDateTime now = LocalDateTime.now();
+        record.setStatus("RESOLVED");
+        record.setResolution(truncate(resolution, 1000));
+        record.setResolvedBy(operator == null ? "admin" : operator);
+        record.setResolvedAt(now);
+        record.setUpdatedAt(now);
+        reconcileRecordMapper.updateById(record);
+    }
+
+    private OpenApiReconcileRecord requireRecord(String recordId) {
+        OpenApiReconcileRecord record = reconcileRecordMapper.selectOne(
+                new LambdaQueryWrapper<OpenApiReconcileRecord>()
+                        .eq(OpenApiReconcileRecord::getRecordId, recordId)
+        );
+        if (record == null) {
+            throw new OpenApiCallException("OPENAPI_40401", "对账异常不存在", 404);
+        }
+        return record;
+    }
+
+    private String truncate(String value, int maxLength) {
+        if (value == null) {
+            return null;
+        }
+        return value.length() <= maxLength ? value : value.substring(0, maxLength);
+    }
+
+    public record ReconcileSummary(
+            int lookbackDays,
+            int scannedWriteRequests,
+            int detectedIssues,
+            LocalDateTime finishedAt) {
+    }
+}

--- a/openapi-service/src/main/java/single/cjj/openapi/service/OpenApiReconciliationService.java
+++ b/openapi-service/src/main/java/single/cjj/openapi/service/OpenApiReconciliationService.java
@@ -3,6 +3,8 @@ package single.cjj.openapi.service;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,13 +21,18 @@ import single.cjj.openapi.mapper.OpenApiOutboxEventMapper;
 import single.cjj.openapi.mapper.OpenApiReconcileRecordMapper;
 import single.cjj.openapi.mapper.OpenApiWriteRequestMapper;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 
 @Service
 public class OpenApiReconciliationService {
+
+    private static final Set<String> ACTIVE_OUTBOX_STATUSES = Set.of("PENDING", "SENDING", "FAILED", "DEAD");
+    private static final String SCHEDULE_LOCK_KEY = "openapi:reconcile:scheduled-lock";
 
     private final OpenApiWriteRequestMapper writeRequestMapper;
     private final OpenApiOutboxEventMapper outboxMapper;
@@ -34,6 +41,7 @@ public class OpenApiReconciliationService {
     private final FiVoucherWriteClient fiVoucherWriteClient;
     private final OpenApiWriteStateService writeStateService;
     private final OpenApiCallbackTaskService callbackTaskService;
+    private final StringRedisTemplate redisTemplate;
     private final int defaultLookbackDays;
     private final int stuckMinutes;
 
@@ -44,6 +52,7 @@ public class OpenApiReconciliationService {
                                         FiVoucherWriteClient fiVoucherWriteClient,
                                         OpenApiWriteStateService writeStateService,
                                         OpenApiCallbackTaskService callbackTaskService,
+                                        StringRedisTemplate redisTemplate,
                                         @Value("${matrix.openapi.reconcile.lookback-days:7}") int defaultLookbackDays,
                                         @Value("${matrix.openapi.reconcile.stuck-minutes:10}") int stuckMinutes) {
         this.writeRequestMapper = writeRequestMapper;
@@ -53,13 +62,19 @@ public class OpenApiReconciliationService {
         this.fiVoucherWriteClient = fiVoucherWriteClient;
         this.writeStateService = writeStateService;
         this.callbackTaskService = callbackTaskService;
+        this.redisTemplate = redisTemplate;
         this.defaultLookbackDays = Math.max(1, Math.min(defaultLookbackDays, 90));
         this.stuckMinutes = Math.max(1, stuckMinutes);
     }
 
     @Scheduled(cron = "${matrix.openapi.reconcile.cron:0 30 2 * * ?}")
     public void scheduledRun() {
-        run(defaultLookbackDays);
+        Boolean locked = redisTemplate.opsForValue().setIfAbsent(
+                SCHEDULE_LOCK_KEY, UUID.randomUUID().toString(), Duration.ofHours(1)
+        );
+        if (Boolean.TRUE.equals(locked)) {
+            run(defaultLookbackDays);
+        }
     }
 
     public ReconcileSummary run(int lookbackDays) {
@@ -138,16 +153,16 @@ public class OpenApiReconciliationService {
         List<OpenApiOutboxEvent> events = outboxMapper.selectList(
                 new LambdaQueryWrapper<OpenApiOutboxEvent>()
                         .ge(OpenApiOutboxEvent::getCreatedAt, from)
-                        .in(OpenApiOutboxEvent::getStatus, "PENDING", "SENDING", "FAILED", "DEAD")
                         .orderByAsc(OpenApiOutboxEvent::getId)
                         .last("LIMIT 5000")
         );
         int issues = 0;
         for (OpenApiOutboxEvent event : events) {
             String issueKey = "OUTBOX_STUCK:" + event.getEventId();
-            boolean stuck = "DEAD".equals(event.getStatus())
+            boolean active = ACTIVE_OUTBOX_STATUSES.contains(event.getStatus());
+            boolean stuck = active && ("DEAD".equals(event.getStatus())
                     || event.getUpdatedAt() == null
-                    || event.getUpdatedAt().isBefore(cutoff);
+                    || event.getUpdatedAt().isBefore(cutoff));
             if (stuck) {
                 OpenApiWriteRequest request = writeRequestMapper.selectById(event.getAggregateId());
                 upsertIssue(
@@ -208,11 +223,10 @@ public class OpenApiReconciliationService {
             return true;
         }
         if ("OUTBOX_STUCK".equals(record.getIssueType())) {
+            String eventId = record.getIssueKey().substring("OUTBOX_STUCK:".length());
             OpenApiOutboxEvent event = outboxMapper.selectOne(
                     new LambdaQueryWrapper<OpenApiOutboxEvent>()
-                            .eq(OpenApiOutboxEvent::getAggregateId, record.getWriteRequestId())
-                            .orderByDesc(OpenApiOutboxEvent::getId)
-                            .last("LIMIT 1")
+                            .eq(OpenApiOutboxEvent::getEventId, eventId)
             );
             if (event == null) {
                 throw new OpenApiCallException("OPENAPI_RECONCILE_40902", "Outbox事件不存在", 409);
@@ -260,6 +274,33 @@ public class OpenApiReconciliationService {
             record.setIssueKey(issueKey);
             record.setCreatedAt(now);
         }
+        applyIssue(record, issueType, severity, request, expectedStatus, actualStatus, detail, now);
+        if (record.getId() == null) {
+            try {
+                reconcileRecordMapper.insert(record);
+            } catch (DuplicateKeyException race) {
+                OpenApiReconcileRecord existing = reconcileRecordMapper.selectOne(
+                        new LambdaQueryWrapper<OpenApiReconcileRecord>()
+                                .eq(OpenApiReconcileRecord::getIssueKey, issueKey)
+                );
+                if (existing != null) {
+                    applyIssue(existing, issueType, severity, request, expectedStatus, actualStatus, detail, now);
+                    reconcileRecordMapper.updateById(existing);
+                }
+            }
+        } else {
+            reconcileRecordMapper.updateById(record);
+        }
+    }
+
+    private void applyIssue(OpenApiReconcileRecord record,
+                            String issueType,
+                            String severity,
+                            OpenApiWriteRequest request,
+                            String expectedStatus,
+                            String actualStatus,
+                            String detail,
+                            LocalDateTime now) {
         record.setIssueType(issueType);
         record.setSeverity(severity);
         record.setWriteRequestId(request == null ? null : request.getId());
@@ -274,11 +315,6 @@ public class OpenApiReconciliationService {
         record.setResolvedAt(null);
         record.setDetectedAt(now);
         record.setUpdatedAt(now);
-        if (record.getId() == null) {
-            reconcileRecordMapper.insert(record);
-        } else {
-            reconcileRecordMapper.updateById(record);
-        }
     }
 
     private void resolveIfOpen(String issueKey, String resolution) {

--- a/openapi-service/src/main/resources/application.yml
+++ b/openapi-service/src/main/resources/application.yml
@@ -56,6 +56,16 @@ matrix:
       recovery-poll-ms: ${OPENAPI_WRITE_RECOVERY_POLL_MS:60000}
       stale-processing-minutes: ${OPENAPI_STALE_PROCESSING_MINUTES:5}
       publisher-confirm-timeout-ms: ${OPENAPI_PUBLISHER_CONFIRM_TIMEOUT_MS:5000}
+    callback:
+      allow-http: ${OPENAPI_CALLBACK_ALLOW_HTTP:false}
+      materialize-poll-ms: ${OPENAPI_CALLBACK_MATERIALIZE_POLL_MS:5000}
+      dispatch-poll-ms: ${OPENAPI_CALLBACK_DISPATCH_POLL_MS:3000}
+      connect-timeout-seconds: ${OPENAPI_CALLBACK_CONNECT_TIMEOUT_SECONDS:3}
+      request-timeout-seconds: ${OPENAPI_CALLBACK_REQUEST_TIMEOUT_SECONDS:5}
+    reconcile:
+      cron: ${OPENAPI_RECONCILE_CRON:0 30 2 * * ?}
+      lookback-days: ${OPENAPI_RECONCILE_LOOKBACK_DAYS:7}
+      stuck-minutes: ${OPENAPI_RECONCILE_STUCK_MINUTES:10}
 
 management:
   endpoints:

--- a/openapi-service/src/test/java/single/cjj/openapi/service/OpenApiCallbackSignatureServiceTest.java
+++ b/openapi-service/src/test/java/single/cjj/openapi/service/OpenApiCallbackSignatureServiceTest.java
@@ -1,0 +1,28 @@
+package single.cjj.openapi.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class OpenApiCallbackSignatureServiceTest {
+
+    private final OpenApiCallbackSignatureService service =
+            new OpenApiCallbackSignatureService(new OpenApiSignatureService());
+
+    @Test
+    void shouldBuildStableCallbackSignature() {
+        String body = "{\"requestId\":\"req_1\",\"status\":\"SUCCEEDED\"}";
+        String canonical = service.canonical(
+                "cb_event_1", "1784710000000", "nonce-1", body.getBytes()
+        );
+        assertEquals(
+                "cb_event_1\n1784710000000\nnonce-1\n" +
+                        "d0c4360ad112a6319c720932b7ca12ced56de8ab470780488ca531be70273a23",
+                canonical
+        );
+        assertEquals(
+                "23c2f39361f248f39882d1462578c585163966a496e5c27845c309449ff4eb51",
+                service.sign("secret", "cb_event_1", "1784710000000", "nonce-1", body)
+        );
+    }
+}

--- a/openapi-service/src/test/java/single/cjj/openapi/service/OpenApiCallbackUrlValidatorTest.java
+++ b/openapi-service/src/test/java/single/cjj/openapi/service/OpenApiCallbackUrlValidatorTest.java
@@ -1,0 +1,35 @@
+package single.cjj.openapi.service;
+
+import org.junit.jupiter.api.Test;
+import single.cjj.openapi.exception.OpenApiCallException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class OpenApiCallbackUrlValidatorTest {
+
+    private final OpenApiCallbackUrlValidator validator = new OpenApiCallbackUrlValidator(false);
+
+    @Test
+    void shouldAllowEmptyWhenCallbackIsDisabled() {
+        assertNull(validator.validateAndNormalize("  "));
+    }
+
+    @Test
+    void shouldRejectHttpAndLocalAddresses() {
+        OpenApiCallException http = assertThrows(
+                OpenApiCallException.class,
+                () -> validator.validateAndNormalize("http://example.com/callback")
+        );
+        assertEquals("OPENAPI_CALLBACK_40001", http.getCode());
+        assertThrows(
+                OpenApiCallException.class,
+                () -> validator.validateAndNormalize("https://localhost/callback")
+        );
+        assertThrows(
+                OpenApiCallException.class,
+                () -> validator.validateAndNormalize("https://127.0.0.1/callback")
+        );
+    }
+}

--- a/sql/matrix_open_api_v4.sql
+++ b/sql/matrix_open_api_v4.sql
@@ -1,0 +1,60 @@
+-- Matrix OpenAPI V4
+-- 第三阶段B：结果回调、回调重试、每日对账与异常处理台
+-- 前置：matrix_open_api_v1.sql、matrix_open_api_v2.sql、matrix_open_api_v3.sql
+
+ALTER TABLE matrix_open_api_app
+    ADD COLUMN callback_enabled TINYINT(1) NOT NULL DEFAULT 0 COMMENT '是否启用结果回调' AFTER max_page_size,
+    ADD COLUMN callback_url VARCHAR(1000) NULL COMMENT '固定HTTPS回调地址' AFTER callback_enabled;
+
+CREATE TABLE matrix_open_api_callback_task (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    event_id VARCHAR(64) NOT NULL,
+    write_request_id BIGINT NOT NULL,
+    request_id VARCHAR(64) NOT NULL,
+    app_id BIGINT NOT NULL,
+    callback_url VARCHAR(1000) NOT NULL,
+    event_type VARCHAR(64) NOT NULL COMMENT 'VOUCHER_WRITE_SUCCEEDED/VOUCHER_WRITE_MANUAL_REQUIRED',
+    payload_json JSON NOT NULL,
+    status VARCHAR(20) NOT NULL COMMENT 'PENDING/SENDING/SUCCEEDED/FAILED/DEAD/SKIPPED',
+    retry_count INT NOT NULL DEFAULT 0,
+    max_retry INT NOT NULL DEFAULT 6,
+    next_attempt_at DATETIME NULL,
+    last_http_status INT NULL,
+    error_message VARCHAR(1000) NULL,
+    sent_at DATETIME NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_open_api_callback_event (event_id),
+    UNIQUE KEY uk_open_api_callback_write_type (write_request_id, event_type),
+    KEY idx_open_api_callback_dispatch (status, next_attempt_at, id),
+    KEY idx_open_api_callback_request (request_id, created_at),
+    KEY idx_open_api_callback_app (app_id, created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='OpenAPI结果回调任务';
+
+CREATE TABLE matrix_open_api_reconcile_record (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    record_id VARCHAR(64) NOT NULL,
+    issue_key VARCHAR(200) NOT NULL,
+    issue_type VARCHAR(64) NOT NULL COMMENT 'VOUCHER_MISSING/TASK_STATUS_MISMATCH/VOUCHER_ID_MISMATCH/OUTBOX_STUCK/CALLBACK_DEAD/FINANCE_LOOKUP_FAILED',
+    severity VARCHAR(20) NOT NULL COMMENT 'WARNING/HIGH/CRITICAL',
+    write_request_id BIGINT NULL,
+    request_id VARCHAR(64) NULL,
+    app_id BIGINT NULL,
+    expected_status VARCHAR(100) NULL,
+    actual_status VARCHAR(100) NULL,
+    detail_message VARCHAR(1000) NULL,
+    status VARCHAR(20) NOT NULL COMMENT 'OPEN/RESOLVED',
+    resolution VARCHAR(1000) NULL,
+    resolved_by VARCHAR(100) NULL,
+    detected_at DATETIME NOT NULL,
+    resolved_at DATETIME NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_open_api_reconcile_record (record_id),
+    UNIQUE KEY uk_open_api_reconcile_issue (issue_key),
+    KEY idx_open_api_reconcile_status (status, severity, detected_at),
+    KEY idx_open_api_reconcile_request (request_id, detected_at),
+    KEY idx_open_api_reconcile_app (app_id, detected_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='OpenAPI对账异常记录';


### PR DESCRIPTION
## What changed

- add application-level fixed HTTPS callback configuration with SSRF-oriented validation
- create terminal-state callback tasks for succeeded and manual-required voucher writes
- sign callback bodies using event ID, timestamp, nonce, and raw-body SHA-256
- dispatch callbacks without redirects and with timeout, retry backoff, dead-letter state, and manual retry
- add daily reconciliation for voucher/task mismatches, missing vouchers, stuck Outbox events, callback dead letters, and finance lookup failures
- add controlled repair actions and manual resolution records
- add V4 schema, tests, and architecture/deployment documentation

## Safety boundary

Callback URLs cannot be supplied per write request. By default they must be public HTTPS addresses. Missing vouchers and voucher-ID conflicts are never auto-repaired.

## Database

Apply after V1, V2, and V3:

```bash
mysql < sql/matrix_open_api_v4.sql
```

## Validation

OpenAPI CI runs:

```bash
mvn -q -pl openapi-service,fi-service,gateway -am test
```

## Target

Merge into `dev`, not `main`.