### PR TITLE
feat(workflow): add dynamic routing and unified task center

### DIFF
--- a/docs/business/workflow/workflow-phase4-dynamic-routing-task-center.md
+++ b/docs/business/workflow/workflow-phase4-dynamic-routing-task-center.md
@@ -1,0 +1,123 @@
+# 工作流第四期第一批：动态审批人、组合条件与统一任务中心
+
+## 1. 动态审批人
+
+人工节点的 `assigneeRule.type` 支持：
+
+- `USER`：固定用户，`value` 为用户 ID。
+- `ROLE`：固定角色，`value` 为角色编码。
+- `VARIABLE`：流程变量中的单个或多个用户。
+- `INITIATOR`：流程发起人。
+- `USERS`：静态用户候选列表，使用 `values`。
+- `ROLES`：静态角色候选列表，使用 `values`。
+- `USERS_VARIABLE`：流程变量中的用户候选列表。
+- `ROLES_VARIABLE`：流程变量中的角色候选列表。
+
+示例：
+
+```json
+{
+  "key": "financeReview",
+  "name": "财务审核",
+  "type": "USER_TASK",
+  "assigneeRule": {
+    "type": "USERS_VARIABLE",
+    "value": "approval.financeReviewers"
+  }
+}
+```
+
+解析出的用户和角色写入 `wf_task_candidate`。如果只有一个候选人，任务继续保留直接 `USER/ROLE` 指派；如果存在多个候选人，则任务使用 `CANDIDATE/MULTIPLE`，所有候选人共享同一任务。第一个合法候选人完成任务后，数据库乐观锁阻止其他候选人重复处理。
+
+## 2. 角色授权
+
+网关会删除客户端传入的以下身份头，并根据 JWT 重新生成：
+
+- `X-User-Id`
+- `X-Tenant-Id`
+- `X-User-Roles`
+
+角色声明按顺序读取：`roles`、`roleCodes`、`authorities`、`role`。角色值可以是数组、集合或逗号分隔字符串。
+
+工作流服务处理角色任务时，同时校验：
+
+1. 请求中的 `operatorId` 与可信 `X-User-Id` 一致。
+2. 用户或角色存在于 `wf_task_candidate`。
+3. 任务仍为 `PENDING/CLAIMED`。
+4. 任务版本未被其他请求更新。
+
+## 3. 组合条件
+
+连线条件支持嵌套 `ALL/ANY`，并支持点路径读取流程变量。
+
+```json
+{
+  "logic": "ALL",
+  "children": [
+    {
+      "field": "amount",
+      "operator": "GE",
+      "value": 5000
+    },
+    {
+      "logic": "ANY",
+      "children": [
+        {
+          "field": "applicant.region",
+          "operator": "EQ",
+          "value": "WEST"
+        },
+        {
+          "field": "urgent",
+          "operator": "EQ",
+          "value": true
+        }
+      ]
+    }
+  ]
+}
+```
+
+仍支持无条件默认连线。多条条件连线按照 `priority` 从高到低匹配。
+
+## 4. 统一任务中心
+
+```http
+GET /api/workflow/task-center
+```
+
+请求头：
+
+```http
+X-User-Id: user-1001
+X-User-Roles: FINANCE_REVIEWER,FINANCE_MANAGER
+```
+
+查询参数：
+
+- `tenantId`
+- `view=TODO|DONE|INITIATED`
+- `businessType`，可选
+- `keyword`，可选，匹配业务 ID、流程定义 Key、任务名称
+- `page`，默认 1
+- `size`，默认 20，最大 100
+
+视图定义：
+
+- `TODO`：直接分配给当前用户，或当前用户角色命中的共享候选任务。
+- `DONE`：当前用户实际执行过审批动作的任务。
+- `INITIATED`：当前用户发起的流程，并返回每个实例最近的任务信息。
+
+## 5. 数据库迁移
+
+在既有工作流 SQL 后执行：
+
+```text
+workflow-service/src/main/resources/sql/workflow_v3_dynamic_routing.sql
+```
+
+迁移会创建 `wf_task_candidate`，并把历史 `USER/ROLE` 直接任务回填为候选记录。
+
+## 6. 当前边界
+
+这一批实现的是共享候选任务，不是会签。多个候选人中任意一人处理后任务结束。全部通过、比例通过和并行分支将在后续会签/并行网关版本中实现。

--- a/gateway/src/main/java/single/cjj/gateway/security/GatewayAuthFilter.java
+++ b/gateway/src/main/java/single/cjj/gateway/security/GatewayAuthFilter.java
@@ -21,7 +21,10 @@ import reactor.core.publisher.Mono;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 @Slf4j
 @Component
@@ -45,6 +48,7 @@ public class GatewayAuthFilter implements GlobalFilter, Ordered {
     private static final List<String> INTERNAL_IDENTITY_HEADERS = List.of(
             "X-User-Id",
             "X-Tenant-Id",
+            "X-User-Roles",
             "X-OpenApi-App-Id",
             "X-OpenApi-Tenant-Id",
             "X-OpenApi-Verified"
@@ -73,15 +77,49 @@ public class GatewayAuthFilter implements GlobalFilter, Ordered {
             String userId = String.valueOf(claims.get("id"));
             Object tenantClaim = claims.get("tenantId");
             String tenantId = tenantClaim == null ? "default" : String.valueOf(tenantClaim);
+            String roles = resolveRoles(claims);
 
-            ServerHttpRequest mutated = request.mutate()
+            ServerHttpRequest.Builder builder = request.mutate()
                     .header("X-User-Id", userId)
-                    .header("X-Tenant-Id", tenantId)
-                    .build();
-            return chain.filter(sanitizedExchange.mutate().request(mutated).build());
+                    .header("X-Tenant-Id", tenantId);
+            if (StringUtils.hasText(roles)) {
+                builder.header("X-User-Roles", roles);
+            }
+            return chain.filter(sanitizedExchange.mutate().request(builder.build()).build());
         } catch (Exception e) {
             log.warn("gateway jwt verify failed: {}", e.getMessage());
             return unauthorized(exchange.getResponse(), "token无效或已过期");
+        }
+    }
+
+    private String resolveRoles(Claims claims) {
+        Object value = claims.get("roles");
+        if (value == null) {
+            value = claims.get("roleCodes");
+        }
+        if (value == null) {
+            value = claims.get("authorities");
+        }
+        if (value == null) {
+            value = claims.get("role");
+        }
+        Set<String> roles = new LinkedHashSet<>();
+        collectRoles(value, roles);
+        return String.join(",", roles);
+    }
+
+    private void collectRoles(Object value, Set<String> roles) {
+        if (value == null) {
+            return;
+        }
+        if (value instanceof Collection<?> collection) {
+            collection.forEach(item -> collectRoles(item, roles));
+            return;
+        }
+        for (String role : String.valueOf(value).split(",")) {
+            if (StringUtils.hasText(role)) {
+                roles.add(role.trim());
+            }
         }
     }
 

--- a/workflow-service/src/main/java/single/cjj/workflow/api/WorkflowContracts.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/api/WorkflowContracts.java
@@ -7,6 +7,7 @@ import single.cjj.workflow.model.WorkflowDefinition;
 
 import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 public final class WorkflowContracts {
@@ -83,6 +84,12 @@ public final class WorkflowContracts {
         RETURN_TO_INITIATOR
     }
 
+    public enum TaskCenterView {
+        TODO,
+        DONE,
+        INITIATED
+    }
+
     public record InstanceResponse(
             String instanceId,
             String tenantId,
@@ -129,6 +136,34 @@ public final class WorkflowContracts {
             String afterStatus,
             String requestId,
             LocalDateTime occurredAt
+    ) {
+    }
+
+    public record TaskCenterItem(
+            String taskId,
+            String instanceId,
+            String definitionKey,
+            String sourceSystem,
+            String businessType,
+            String businessId,
+            String initiatorId,
+            String currentNodeKey,
+            String taskName,
+            String assigneeType,
+            String assigneeValue,
+            String taskStatus,
+            String instanceStatus,
+            String action,
+            LocalDateTime createdAt,
+            LocalDateTime completedAt
+    ) {
+    }
+
+    public record TaskCenterPage(
+            List<TaskCenterItem> items,
+            long total,
+            int page,
+            int size
     ) {
     }
 }

--- a/workflow-service/src/main/java/single/cjj/workflow/controller/WorkflowTaskCenterController.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/controller/WorkflowTaskCenterController.java
@@ -1,0 +1,53 @@
+package single.cjj.workflow.controller;
+
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import single.cjj.bizfi.entity.ApiResponse;
+import single.cjj.workflow.api.WorkflowContracts;
+import single.cjj.workflow.service.WorkflowTaskCenterService;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+@RestController
+@RequestMapping("/workflow/task-center")
+public class WorkflowTaskCenterController {
+
+    private final WorkflowTaskCenterService taskCenterService;
+
+    public WorkflowTaskCenterController(WorkflowTaskCenterService taskCenterService) {
+        this.taskCenterService = taskCenterService;
+    }
+
+    @GetMapping
+    public ApiResponse<WorkflowContracts.TaskCenterPage> query(
+            @RequestHeader("X-User-Id") String userId,
+            @RequestHeader(value = "X-User-Roles", required = false) String roleHeader,
+            @RequestParam("tenantId") String tenantId,
+            @RequestParam(value = "view", defaultValue = "TODO") WorkflowContracts.TaskCenterView view,
+            @RequestParam(value = "businessType", required = false) String businessType,
+            @RequestParam(value = "keyword", required = false) String keyword,
+            @RequestParam(value = "page", defaultValue = "1") int page,
+            @RequestParam(value = "size", defaultValue = "20") int size) {
+        return ApiResponse.success(taskCenterService.query(
+                tenantId, userId, parseRoles(roleHeader), view,
+                businessType, keyword, page, size));
+    }
+
+    private Set<String> parseRoles(String roleHeader) {
+        if (!StringUtils.hasText(roleHeader)) {
+            return Set.of();
+        }
+        Set<String> roles = new LinkedHashSet<>();
+        Arrays.stream(roleHeader.split(","))
+                .map(String::trim)
+                .filter(StringUtils::hasText)
+                .forEach(roles::add);
+        return roles;
+    }
+}

--- a/workflow-service/src/main/java/single/cjj/workflow/controller/WorkflowTaskController.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/controller/WorkflowTaskController.java
@@ -1,6 +1,7 @@
 package single.cjj.workflow.controller;
 
 import jakarta.validation.Valid;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -9,8 +10,13 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import single.cjj.bizfi.entity.ApiResponse;
+import single.cjj.bizfi.exception.BizException;
 import single.cjj.workflow.api.WorkflowContracts;
 import single.cjj.workflow.service.WorkflowService;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 @RestController
 @RequestMapping("/workflow/tasks")
@@ -32,7 +38,26 @@ public class WorkflowTaskController {
     public ApiResponse<WorkflowContracts.InstanceResponse> action(
             @PathVariable("taskId") String taskId,
             @RequestHeader(value = "X-Request-Id", required = false) String requestId,
+            @RequestHeader(value = "X-User-Id", required = false) String trustedUserId,
+            @RequestHeader(value = "X-User-Roles", required = false) String roleHeader,
             @Valid @RequestBody WorkflowContracts.TaskActionRequest request) {
-        return ApiResponse.success(workflowService.actOnTask(taskId, request, requestId));
+        if (StringUtils.hasText(trustedUserId)
+                && !trustedUserId.trim().equals(request.operatorId())) {
+            throw new BizException("请求用户与任务操作人不一致");
+        }
+        return ApiResponse.success(workflowService.actOnTask(
+                taskId, request, requestId, parseRoles(roleHeader)));
+    }
+
+    private Set<String> parseRoles(String roleHeader) {
+        if (!StringUtils.hasText(roleHeader)) {
+            return Set.of();
+        }
+        Set<String> roles = new LinkedHashSet<>();
+        Arrays.stream(roleHeader.split(","))
+                .map(String::trim)
+                .filter(StringUtils::hasText)
+                .forEach(roles::add);
+        return roles;
     }
 }

--- a/workflow-service/src/main/java/single/cjj/workflow/engine/DefaultWorkflowAssigneeResolver.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/engine/DefaultWorkflowAssigneeResolver.java
@@ -1,0 +1,98 @@
+package single.cjj.workflow.engine;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import single.cjj.bizfi.exception.BizException;
+import single.cjj.workflow.model.WorkflowDefinition;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Component
+public class DefaultWorkflowAssigneeResolver implements WorkflowAssigneeResolver {
+
+    @Override
+    public boolean supports(WorkflowDefinition.AssigneeType type) {
+        return type != null;
+    }
+
+    @Override
+    public Resolution resolve(WorkflowDefinition.AssigneeRule rule, Context context) {
+        if (rule == null || rule.getType() == null) {
+            throw new BizException("人工节点未配置审批人规则");
+        }
+        List<Candidate> candidates = switch (rule.getType()) {
+            case USER -> typed("USER", rule.getValue());
+            case ROLE -> typed("ROLE", rule.getValue());
+            case INITIATOR -> typed("USER", context.initiatorId());
+            case USERS -> typed("USER", rule.getValues());
+            case ROLES -> typed("ROLE", rule.getValues());
+            case VARIABLE, USERS_VARIABLE -> typed(
+                    "USER", resolveVariable(context.variables(), rule.getValue()));
+            case ROLES_VARIABLE -> typed(
+                    "ROLE", resolveVariable(context.variables(), rule.getValue()));
+        };
+        if (candidates.isEmpty()) {
+            throw new BizException("审批人规则没有解析到任何候选人");
+        }
+        return new Resolution(candidates);
+    }
+
+    private List<Candidate> typed(String type, Object rawValue) {
+        Set<String> values = new LinkedHashSet<>();
+        flatten(rawValue, values);
+        List<Candidate> candidates = new ArrayList<>();
+        for (String value : values) {
+            if (StringUtils.hasText(value)) {
+                candidates.add(new Candidate(type, value.trim()));
+            }
+        }
+        return candidates;
+    }
+
+    private void flatten(Object value, Set<String> target) {
+        if (value == null) {
+            return;
+        }
+        if (value instanceof Collection<?> collection) {
+            collection.forEach(item -> flatten(item, target));
+            return;
+        }
+        if (value.getClass().isArray()) {
+            int length = Array.getLength(value);
+            for (int index = 0; index < length; index++) {
+                flatten(Array.get(value, index), target);
+            }
+            return;
+        }
+        String text = String.valueOf(value);
+        for (String part : text.split(",")) {
+            if (StringUtils.hasText(part)) {
+                target.add(part.trim());
+            }
+        }
+    }
+
+    private Object resolveVariable(Map<String, Object> variables, String path) {
+        if (!StringUtils.hasText(path)) {
+            throw new BizException("审批人变量名不能为空");
+        }
+        Object current = variables;
+        for (String segment : path.split("\\.")) {
+            if (!(current instanceof Map<?, ?> map)) {
+                current = null;
+                break;
+            }
+            current = map.get(segment);
+        }
+        if (current == null) {
+            throw new BizException("审批人变量不存在: " + path);
+        }
+        return current;
+    }
+}

--- a/workflow-service/src/main/java/single/cjj/workflow/engine/WorkflowAssigneeResolver.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/engine/WorkflowAssigneeResolver.java
@@ -1,0 +1,27 @@
+package single.cjj.workflow.engine;
+
+import single.cjj.workflow.model.WorkflowDefinition;
+
+import java.util.List;
+import java.util.Map;
+
+public interface WorkflowAssigneeResolver {
+
+    boolean supports(WorkflowDefinition.AssigneeType type);
+
+    Resolution resolve(WorkflowDefinition.AssigneeRule rule, Context context);
+
+    record Context(String instanceId,
+                   String initiatorId,
+                   Map<String, Object> variables) {
+    }
+
+    record Candidate(String type, String value) {
+    }
+
+    record Resolution(List<Candidate> candidates) {
+        public Resolution {
+            candidates = candidates == null ? List.of() : List.copyOf(candidates);
+        }
+    }
+}

--- a/workflow-service/src/main/java/single/cjj/workflow/engine/WorkflowAssigneeResolverRegistry.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/engine/WorkflowAssigneeResolverRegistry.java
@@ -1,0 +1,33 @@
+package single.cjj.workflow.engine;
+
+import org.springframework.stereotype.Component;
+import single.cjj.bizfi.exception.BizException;
+import single.cjj.workflow.model.WorkflowDefinition;
+
+import java.util.List;
+
+@Component
+public class WorkflowAssigneeResolverRegistry {
+
+    private final List<WorkflowAssigneeResolver> resolvers;
+
+    public WorkflowAssigneeResolverRegistry(List<WorkflowAssigneeResolver> resolvers) {
+        this.resolvers = List.copyOf(resolvers);
+    }
+
+    public WorkflowAssigneeResolver.Resolution resolve(WorkflowDefinition.AssigneeRule rule,
+                                                       WorkflowAssigneeResolver.Context context) {
+        if (rule == null || rule.getType() == null) {
+            throw new BizException("人工节点未配置审批人规则");
+        }
+        return resolvers.stream()
+                .filter(resolver -> resolver.supports(rule.getType()))
+                .findFirst()
+                .orElseThrow(() -> new BizException("没有可用的审批人解析器: " + rule.getType()))
+                .resolve(rule, context);
+    }
+
+    public static WorkflowAssigneeResolverRegistry defaultRegistry() {
+        return new WorkflowAssigneeResolverRegistry(List.of(new DefaultWorkflowAssigneeResolver()));
+    }
+}

--- a/workflow-service/src/main/java/single/cjj/workflow/engine/WorkflowConditionEvaluator.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/engine/WorkflowConditionEvaluator.java
@@ -44,7 +44,19 @@ public class WorkflowConditionEvaluator {
 
     public boolean matches(WorkflowDefinition.Condition condition,
                            Map<String, Object> variables) {
-        Object actual = variables.get(condition.getField());
+        if (condition == null) {
+            return true;
+        }
+        List<WorkflowDefinition.Condition> children = condition.getChildren();
+        if (children != null && !children.isEmpty()) {
+            WorkflowDefinition.ConditionLogic logic = condition.getLogic() == null
+                    ? WorkflowDefinition.ConditionLogic.ALL : condition.getLogic();
+            return logic == WorkflowDefinition.ConditionLogic.ANY
+                    ? children.stream().anyMatch(child -> matches(child, variables))
+                    : children.stream().allMatch(child -> matches(child, variables));
+        }
+
+        Object actual = resolvePath(variables, condition.getField());
         Object expected = condition.getValue();
         WorkflowDefinition.ConditionOperator operator = condition.getOperator();
         if (operator == null) {
@@ -65,6 +77,20 @@ public class WorkflowConditionEvaluator {
             case NOT_IN -> expected instanceof Collection<?> collection
                     && collection.stream().noneMatch(item -> equalsValue(actual, item));
         };
+    }
+
+    private Object resolvePath(Map<String, Object> variables, String path) {
+        if (variables == null || path == null || path.isBlank()) {
+            return null;
+        }
+        Object current = variables;
+        for (String segment : path.split("\\.")) {
+            if (!(current instanceof Map<?, ?> map)) {
+                return null;
+            }
+            current = map.get(segment);
+        }
+        return current;
     }
 
     private boolean equalsValue(Object actual, Object expected) {

--- a/workflow-service/src/main/java/single/cjj/workflow/model/WorkflowDefinition.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/model/WorkflowDefinition.java
@@ -55,6 +55,8 @@ public class WorkflowDefinition {
         private String field;
         private ConditionOperator operator;
         private Object value;
+        private ConditionLogic logic = ConditionLogic.ALL;
+        private List<Condition> children = new ArrayList<>();
     }
 
     @Data
@@ -62,6 +64,7 @@ public class WorkflowDefinition {
     public static class AssigneeRule {
         private AssigneeType type;
         private String value;
+        private List<String> values = new ArrayList<>();
     }
 
     public enum NodeType {
@@ -70,6 +73,11 @@ public class WorkflowDefinition {
         SERVICE_TASK,
         EXCLUSIVE_GATEWAY,
         END
+    }
+
+    public enum ConditionLogic {
+        ALL,
+        ANY
     }
 
     public enum ConditionOperator {
@@ -88,6 +96,11 @@ public class WorkflowDefinition {
     public enum AssigneeType {
         USER,
         ROLE,
-        VARIABLE
+        VARIABLE,
+        INITIATOR,
+        USERS,
+        ROLES,
+        USERS_VARIABLE,
+        ROLES_VARIABLE
     }
 }

--- a/workflow-service/src/main/java/single/cjj/workflow/repository/WorkflowTaskCandidateRepository.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/repository/WorkflowTaskCandidateRepository.java
@@ -1,0 +1,72 @@
+package single.cjj.workflow.repository;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import single.cjj.workflow.engine.WorkflowAssigneeResolver;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+@Repository
+public class WorkflowTaskCandidateRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public WorkflowTaskCandidateRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public void insertCandidates(String taskId,
+                                 List<WorkflowAssigneeResolver.Candidate> candidates) {
+        if (candidates == null || candidates.isEmpty()) {
+            return;
+        }
+        for (WorkflowAssigneeResolver.Candidate candidate : candidates) {
+            jdbcTemplate.update("""
+                    INSERT IGNORE INTO wf_task_candidate
+                        (id, task_id, candidate_type, candidate_value)
+                    VALUES (?, ?, ?, ?)
+                    """, newId(), taskId, candidate.type(), candidate.value());
+        }
+    }
+
+    public List<CandidateRow> findByTaskId(String taskId) {
+        return jdbcTemplate.query("""
+                SELECT task_id, candidate_type, candidate_value
+                FROM wf_task_candidate
+                WHERE task_id = ?
+                ORDER BY candidate_type, candidate_value
+                """, this::mapCandidate, taskId);
+    }
+
+    public boolean canOperate(String taskId, String userId, Set<String> roleCodes) {
+        Set<String> roles = roleCodes == null ? Set.of() : new LinkedHashSet<>(roleCodes);
+        return findByTaskId(taskId).stream().anyMatch(candidate ->
+                ("USER".equals(candidate.candidateType())
+                        && candidate.candidateValue().equals(userId))
+                        || ("ROLE".equals(candidate.candidateType())
+                        && roles.contains(candidate.candidateValue()))
+        );
+    }
+
+    private CandidateRow mapCandidate(ResultSet rs, int rowNum) throws SQLException {
+        return new CandidateRow(
+                rs.getString("task_id"),
+                rs.getString("candidate_type"),
+                rs.getString("candidate_value")
+        );
+    }
+
+    private String newId() {
+        return UUID.randomUUID().toString().replace("-", "");
+    }
+
+    public record CandidateRow(String taskId,
+                               String candidateType,
+                               String candidateValue) {
+    }
+}

--- a/workflow-service/src/main/java/single/cjj/workflow/service/WorkflowService.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/service/WorkflowService.java
@@ -3,22 +3,27 @@ package single.cjj.workflow.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import single.cjj.bizfi.exception.BizException;
 import single.cjj.workflow.api.WorkflowContracts;
+import single.cjj.workflow.engine.WorkflowAssigneeResolver;
+import single.cjj.workflow.engine.WorkflowAssigneeResolverRegistry;
 import single.cjj.workflow.engine.WorkflowConditionEvaluator;
 import single.cjj.workflow.engine.WorkflowNodeHandler;
 import single.cjj.workflow.engine.WorkflowNodeHandlerRegistry;
 import single.cjj.workflow.model.WorkflowDefinition;
 import single.cjj.workflow.repository.WorkflowRepository;
+import single.cjj.workflow.repository.WorkflowTaskCandidateRepository;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -42,15 +47,30 @@ public class WorkflowService {
     private final WorkflowConditionEvaluator conditionEvaluator;
     private final WorkflowNodeHandlerRegistry handlerRegistry;
     private final ObjectMapper objectMapper;
+    private final WorkflowAssigneeResolverRegistry assigneeResolverRegistry;
+    private final WorkflowTaskCandidateRepository candidateRepository;
+
+    @Autowired
+    public WorkflowService(WorkflowRepository repository,
+                           WorkflowConditionEvaluator conditionEvaluator,
+                           WorkflowNodeHandlerRegistry handlerRegistry,
+                           ObjectMapper objectMapper,
+                           WorkflowAssigneeResolverRegistry assigneeResolverRegistry,
+                           WorkflowTaskCandidateRepository candidateRepository) {
+        this.repository = repository;
+        this.conditionEvaluator = conditionEvaluator;
+        this.handlerRegistry = handlerRegistry;
+        this.objectMapper = objectMapper;
+        this.assigneeResolverRegistry = assigneeResolverRegistry;
+        this.candidateRepository = candidateRepository;
+    }
 
     public WorkflowService(WorkflowRepository repository,
                            WorkflowConditionEvaluator conditionEvaluator,
                            WorkflowNodeHandlerRegistry handlerRegistry,
                            ObjectMapper objectMapper) {
-        this.repository = repository;
-        this.conditionEvaluator = conditionEvaluator;
-        this.handlerRegistry = handlerRegistry;
-        this.objectMapper = objectMapper;
+        this(repository, conditionEvaluator, handlerRegistry, objectMapper,
+                WorkflowAssigneeResolverRegistry.defaultRegistry(), null);
     }
 
     @Transactional
@@ -58,27 +78,19 @@ public class WorkflowService {
             WorkflowContracts.DefinitionCreateRequest request) {
         validateDefinition(request.definition());
         repository.ensureDefinition(
-                request.tenantId(),
-                request.definitionKey(),
-                request.definitionName(),
-                request.createdBy()
-        );
+                request.tenantId(), request.definitionKey(),
+                request.definitionName(), request.createdBy());
         int version = repository.nextDefinitionVersion(request.tenantId(), request.definitionKey());
         repository.insertDefinitionVersion(
-                request.tenantId(),
-                request.definitionKey(),
-                request.definitionName(),
-                version,
-                writeJson(request.definition()),
-                request.createdBy()
-        );
+                request.tenantId(), request.definitionKey(), request.definitionName(),
+                version, writeJson(request.definition()), request.createdBy());
         return getDefinition(request.tenantId(), request.definitionKey(), version);
     }
 
     @Transactional
     public WorkflowContracts.DefinitionResponse publishDefinition(String tenantId,
-                                                                  String definitionKey,
-                                                                  int version) {
+                                                                   String definitionKey,
+                                                                   int version) {
         WorkflowRepository.DefinitionVersionRow row = repository
                 .findDefinition(tenantId, definitionKey, version)
                 .orElseThrow(() -> new BizException("流程定义版本不存在"));
@@ -91,7 +103,7 @@ public class WorkflowService {
     }
 
     public WorkflowContracts.DefinitionResponse getPublishedDefinition(String tenantId,
-                                                                       String definitionKey) {
+                                                                        String definitionKey) {
         WorkflowRepository.DefinitionVersionRow row = repository
                 .findPublishedDefinition(tenantId, definitionKey)
                 .orElseThrow(() -> new BizException("没有已发布的流程定义"));
@@ -99,8 +111,8 @@ public class WorkflowService {
     }
 
     public WorkflowContracts.DefinitionResponse getDefinition(String tenantId,
-                                                              String definitionKey,
-                                                              int version) {
+                                                               String definitionKey,
+                                                               int version) {
         WorkflowRepository.DefinitionVersionRow row = repository
                 .findDefinition(tenantId, definitionKey, version)
                 .orElseThrow(() -> new BizException("流程定义版本不存在"));
@@ -131,33 +143,19 @@ public class WorkflowService {
         String instanceId = newId();
         Map<String, Object> variables = request.safeVariables();
         variables.putIfAbsent("initiatorId", request.initiatorId());
-        String businessKey = request.sourceSystem() + ":" + request.businessType() + ":" + request.businessId();
+        String businessKey = request.sourceSystem() + ":"
+                + request.businessType() + ":" + request.businessId();
         LocalDateTime now = LocalDateTime.now();
 
         WorkflowRepository.InstanceRow instance = new WorkflowRepository.InstanceRow(
-                instanceId,
-                request.tenantId(),
-                request.definitionKey(),
-                definitionRow.version(),
-                request.sourceSystem(),
-                request.businessType(),
-                request.businessId(),
-                businessKey,
-                idempotencyKey,
-                request.initiatorId(),
-                null,
-                INSTANCE_RUNNING,
-                writeJson(variables),
-                request.callbackUrl(),
-                0,
-                now,
-                null
-        );
+                instanceId, request.tenantId(), request.definitionKey(), definitionRow.version(),
+                request.sourceSystem(), request.businessType(), request.businessId(), businessKey,
+                idempotencyKey, request.initiatorId(), null, INSTANCE_RUNNING,
+                writeJson(variables), request.callbackUrl(), 0, now, null);
         repository.insertInstance(instance);
         repository.insertActionLog(
                 newId(), instanceId, null, "START", request.initiatorId(),
-                "启动流程", null, INSTANCE_RUNNING, idempotencyKey
-        );
+                "启动流程", null, INSTANCE_RUNNING, idempotencyKey);
 
         WorkflowDefinition.Node startNode = definition.requireStartNode();
         String startNodeInstanceId = createNodeInstance(instanceId, startNode, variables);
@@ -168,14 +166,22 @@ public class WorkflowService {
 
     @Transactional
     public WorkflowContracts.InstanceResponse actOnTask(String taskId,
-                                                        WorkflowContracts.TaskActionRequest request,
-                                                        String requestId) {
+                                                         WorkflowContracts.TaskActionRequest request,
+                                                         String requestId) {
+        return actOnTask(taskId, request, requestId, Set.of());
+    }
+
+    @Transactional
+    public WorkflowContracts.InstanceResponse actOnTask(String taskId,
+                                                         WorkflowContracts.TaskActionRequest request,
+                                                         String requestId,
+                                                         Set<String> operatorRoles) {
         WorkflowRepository.TaskRow task = repository.findTask(taskId)
                 .orElseThrow(() -> new BizException("待办任务不存在"));
         if (!("PENDING".equals(task.status()) || "CLAIMED".equals(task.status()))) {
             throw new BizException("待办任务已经处理");
         }
-        validateOperator(task, request.operatorId());
+        validateOperator(task, request.operatorId(), operatorRoles);
 
         WorkflowRepository.InstanceRow instance = repository.findInstance(task.instanceId())
                 .orElseThrow(() -> new BizException("流程实例不存在"));
@@ -207,8 +213,7 @@ public class WorkflowService {
         repository.completeNode(task.nodeInstanceId(), writeJson(nodeOutput));
         repository.insertActionLog(
                 newId(), instance.id(), task.id(), request.action().name(),
-                request.operatorId(), request.comment(), task.status(), taskTerminalStatus, requestId
-        );
+                request.operatorId(), request.comment(), task.status(), taskTerminalStatus, requestId);
 
         switch (request.action()) {
             case REJECT -> rejectInstance(instance, variables);
@@ -266,15 +271,13 @@ public class WorkflowService {
         repository.completeNode(resubmitTask.nodeInstanceId(), writeJson(nodeOutput));
 
         int resumed = repository.resumeInstance(
-                instance.id(), instance.version(), resumeNodeKey, writeJson(variables)
-        );
+                instance.id(), instance.version(), resumeNodeKey, writeJson(variables));
         if (resumed != 1) {
             throw new BizException("流程状态已变化，请刷新后重试");
         }
         repository.insertActionLog(
                 newId(), instance.id(), resubmitTask.id(), "RESUBMIT", request.operatorId(),
-                request.comment(), INSTANCE_WAITING_RESUBMIT, INSTANCE_RUNNING, requestId
-        );
+                request.comment(), INSTANCE_WAITING_RESUBMIT, INSTANCE_RUNNING, requestId);
         activateUserTask(instance, resumeNode, variables);
         emitInstanceEvent(instance, "RESUBMITTED", INSTANCE_RUNNING, variables);
         return getInstance(instance.id());
@@ -306,8 +309,7 @@ public class WorkflowService {
         repository.cancelActiveNodes(instance.id());
         repository.insertActionLog(
                 newId(), instance.id(), null, "CANCEL", request.operatorId(), request.reason(),
-                instance.status(), INSTANCE_CANCELLED, requestId
-        );
+                instance.status(), INSTANCE_CANCELLED, requestId);
         emitInstanceEvent(instance, "CANCELLED", INSTANCE_CANCELLED, variables);
         return getInstance(instance.id());
     }
@@ -319,9 +321,9 @@ public class WorkflowService {
     }
 
     public WorkflowContracts.InstanceResponse getBusinessInstance(String tenantId,
-                                                                  String sourceSystem,
-                                                                  String businessType,
-                                                                  String businessId) {
+                                                                   String sourceSystem,
+                                                                   String businessType,
+                                                                   String businessId) {
         return repository.findLatestBusinessInstance(tenantId, sourceSystem, businessType, businessId)
                 .map(this::toInstanceResponse)
                 .orElseThrow(() -> new BizException("业务对象没有流程实例"));
@@ -352,8 +354,7 @@ public class WorkflowService {
         variables.put(VAR_RETURNED_AT, LocalDateTime.now().toString());
 
         int returned = repository.returnInstanceToInitiator(
-                instance.id(), instance.version(), writeJson(variables)
-        );
+                instance.id(), instance.version(), writeJson(variables));
         if (returned != 1) {
             throw new BizException("流程实例状态已变化，请刷新后重试");
         }
@@ -365,30 +366,16 @@ public class WorkflowService {
                                       Map<String, Object> variables) {
         String nodeInstanceId = newId();
         repository.insertNodeInstance(new WorkflowRepository.NodeInstanceRow(
-                nodeInstanceId,
-                instance.id(),
-                RESUBMIT_NODE_KEY,
-                "修改并重新提交",
-                WorkflowDefinition.NodeType.USER_TASK.name(),
-                "ACTIVE",
-                null,
-                writeJson(variables),
-                LocalDateTime.now()
-        ));
+                nodeInstanceId, instance.id(), RESUBMIT_NODE_KEY, "修改并重新提交",
+                WorkflowDefinition.NodeType.USER_TASK.name(), "ACTIVE", null,
+                writeJson(variables), LocalDateTime.now()));
+        String taskId = newId();
         repository.insertTask(new WorkflowRepository.TaskRow(
-                newId(),
-                instance.tenantId(),
-                instance.id(),
-                nodeInstanceId,
-                RESUBMIT_NODE_KEY,
-                "修改并重新提交",
-                "USER",
-                instance.initiatorId(),
-                "PENDING",
-                0,
-                LocalDateTime.now(),
-                null
-        ));
+                taskId, instance.tenantId(), instance.id(), nodeInstanceId,
+                RESUBMIT_NODE_KEY, "修改并重新提交", "USER", instance.initiatorId(),
+                "PENDING", 0, LocalDateTime.now(), null));
+        insertCandidates(taskId, List.of(
+                new WorkflowAssigneeResolver.Candidate("USER", instance.initiatorId())));
     }
 
     private void advanceFrom(WorkflowRepository.InstanceRow instance,
@@ -413,8 +400,7 @@ public class WorkflowService {
                             .require(node.getHandlerKey())
                             .execute(new WorkflowNodeHandler.ExecutionContext(
                                     instance.id(), node,
-                                    Collections.unmodifiableMap(new LinkedHashMap<>(variables))
-                            ));
+                                    Collections.unmodifiableMap(new LinkedHashMap<>(variables))));
                     if (!result.success()) {
                         throw new BizException(result.message());
                     }
@@ -433,8 +419,7 @@ public class WorkflowService {
                     String nodeInstanceId = createNodeInstance(instance.id(), node, variables);
                     repository.completeNode(nodeInstanceId, "{}");
                     int finished = repository.finishInstance(
-                            instance.id(), INSTANCE_COMPLETED, writeJson(variables)
-                    );
+                            instance.id(), INSTANCE_COMPLETED, writeJson(variables));
                     if (finished != 1) {
                         throw new BizException("流程实例状态已变化，请刷新后重试");
                     }
@@ -449,24 +434,28 @@ public class WorkflowService {
     private void activateUserTask(WorkflowRepository.InstanceRow instance,
                                   WorkflowDefinition.Node node,
                                   Map<String, Object> variables) {
-        Assignee assignee = resolveAssignee(node, variables);
+        WorkflowAssigneeResolver.Resolution resolution = assigneeResolverRegistry.resolve(
+                node.getAssigneeRule(),
+                new WorkflowAssigneeResolver.Context(instance.id(), instance.initiatorId(), variables));
+        List<WorkflowAssigneeResolver.Candidate> candidates = resolution.candidates();
+        String assigneeType = candidates.size() == 1 ? candidates.get(0).type() : "CANDIDATE";
+        String assigneeValue = candidates.size() == 1 ? candidates.get(0).value() : "MULTIPLE";
+
         String nodeInstanceId = createNodeInstance(instance.id(), node, variables);
         String taskId = newId();
         repository.insertTask(new WorkflowRepository.TaskRow(
-                taskId,
-                instance.tenantId(),
-                instance.id(),
-                nodeInstanceId,
-                node.getKey(),
-                node.getName(),
-                assignee.type(),
-                assignee.value(),
-                "PENDING",
-                0,
-                LocalDateTime.now(),
-                null
-        ));
+                taskId, instance.tenantId(), instance.id(), nodeInstanceId,
+                node.getKey(), node.getName(), assigneeType, assigneeValue,
+                "PENDING", 0, LocalDateTime.now(), null));
+        insertCandidates(taskId, candidates);
         repository.updateInstancePosition(instance.id(), node.getKey(), writeJson(variables));
+    }
+
+    private void insertCandidates(String taskId,
+                                  List<WorkflowAssigneeResolver.Candidate> candidates) {
+        if (candidateRepository != null) {
+            candidateRepository.insertCandidates(taskId, candidates);
+        }
     }
 
     private String createNodeInstance(String instanceId,
@@ -474,43 +463,38 @@ public class WorkflowService {
                                       Map<String, Object> variables) {
         String nodeInstanceId = newId();
         repository.insertNodeInstance(new WorkflowRepository.NodeInstanceRow(
-                nodeInstanceId,
-                instanceId,
-                node.getKey(),
+                nodeInstanceId, instanceId, node.getKey(),
                 StringUtils.hasText(node.getName()) ? node.getName() : node.getKey(),
-                node.getType().name(),
-                "ACTIVE",
-                node.getHandlerKey(),
-                writeJson(variables),
-                LocalDateTime.now()
-        ));
+                node.getType().name(), "ACTIVE", node.getHandlerKey(),
+                writeJson(variables), LocalDateTime.now()));
         return nodeInstanceId;
     }
 
-    private Assignee resolveAssignee(WorkflowDefinition.Node node,
-                                     Map<String, Object> variables) {
-        WorkflowDefinition.AssigneeRule rule = node.getAssigneeRule();
-        if (rule == null || rule.getType() == null || !StringUtils.hasText(rule.getValue())) {
-            throw new BizException("人工节点未配置审批人规则: " + node.getKey());
-        }
-        return switch (rule.getType()) {
-            case USER -> new Assignee("USER", rule.getValue());
-            case ROLE -> new Assignee("ROLE", rule.getValue());
-            case VARIABLE -> {
-                Object value = variables.get(rule.getValue());
-                if (value == null || !StringUtils.hasText(String.valueOf(value))) {
-                    throw new BizException("审批人变量不存在: " + rule.getValue());
+    private void validateOperator(WorkflowRepository.TaskRow task,
+                                  String operatorId,
+                                  Set<String> operatorRoles) {
+        Set<String> roles = operatorRoles == null ? Set.of() : operatorRoles;
+        if (candidateRepository != null) {
+            List<WorkflowTaskCandidateRepository.CandidateRow> candidates =
+                    candidateRepository.findByTaskId(task.id());
+            if (!candidates.isEmpty()) {
+                if (!candidateRepository.canOperate(task.id(), operatorId, roles)) {
+                    throw new BizException("当前用户不在该任务候选人范围内");
                 }
-                yield new Assignee("USER", String.valueOf(value));
+                return;
             }
-        };
-    }
-
-    private void validateOperator(WorkflowRepository.TaskRow task, String operatorId) {
-        if ("USER".equals(task.assigneeType()) && !task.assigneeValue().equals(operatorId)) {
+        }
+        if ("USER".equals(task.assigneeType())
+                && !task.assigneeValue().equals(operatorId)) {
             throw new BizException("当前用户不是该任务的处理人");
         }
-        // ROLE 类型由网关或权限服务校验角色成员关系；工作流服务保留最终任务并发校验。
+        if ("ROLE".equals(task.assigneeType())
+                && !roles.contains(task.assigneeValue())) {
+            throw new BizException("当前用户不具备任务要求的角色");
+        }
+        if ("CANDIDATE".equals(task.assigneeType())) {
+            throw new BizException("任务候选人数据缺失，无法授权处理");
+        }
     }
 
     private void validateInitiator(WorkflowRepository.InstanceRow instance, String operatorId) {
@@ -564,9 +548,8 @@ public class WorkflowService {
             if (node.getType() == WorkflowDefinition.NodeType.END) {
                 endCount++;
             }
-            if (node.getType() == WorkflowDefinition.NodeType.USER_TASK
-                    && node.getAssigneeRule() == null) {
-                throw new BizException("人工节点必须配置审批人规则: " + node.getKey());
+            if (node.getType() == WorkflowDefinition.NodeType.USER_TASK) {
+                validateAssigneeRule(node);
             }
             if (node.getType() == WorkflowDefinition.NodeType.SERVICE_TASK
                     && !StringUtils.hasText(node.getHandlerKey())) {
@@ -585,6 +568,43 @@ public class WorkflowService {
                     || !nodeKeys.contains(transition.getTo())) {
                 throw new BizException("流程连线引用了不存在的节点");
             }
+            validateCondition(transition.getCondition());
+        }
+    }
+
+    private void validateAssigneeRule(WorkflowDefinition.Node node) {
+        WorkflowDefinition.AssigneeRule rule = node.getAssigneeRule();
+        if (rule == null || rule.getType() == null) {
+            throw new BizException("人工节点必须配置审批人规则: " + node.getKey());
+        }
+        switch (rule.getType()) {
+            case INITIATOR -> {
+                return;
+            }
+            case USERS, ROLES -> {
+                if (rule.getValues() == null || rule.getValues().stream().noneMatch(StringUtils::hasText)) {
+                    throw new BizException("人工节点候选人列表不能为空: " + node.getKey());
+                }
+            }
+            default -> {
+                if (!StringUtils.hasText(rule.getValue())) {
+                    throw new BizException("人工节点审批人规则值不能为空: " + node.getKey());
+                }
+            }
+        }
+    }
+
+    private void validateCondition(WorkflowDefinition.Condition condition) {
+        if (condition == null) {
+            return;
+        }
+        List<WorkflowDefinition.Condition> children = condition.getChildren();
+        if (children != null && !children.isEmpty()) {
+            children.forEach(this::validateCondition);
+            return;
+        }
+        if (!StringUtils.hasText(condition.getField()) || condition.getOperator() == null) {
+            throw new BizException("流程条件必须配置 field 和 operator");
         }
     }
 
@@ -592,8 +612,7 @@ public class WorkflowService {
             WorkflowRepository.DefinitionVersionRow row) {
         return new WorkflowContracts.DefinitionResponse(
                 row.tenantId(), row.definitionKey(), row.definitionName(), row.version(),
-                row.status(), readDefinition(row.definitionJson()), row.createdAt(), row.publishedAt()
-        );
+                row.status(), readDefinition(row.definitionJson()), row.createdAt(), row.publishedAt());
     }
 
     private WorkflowContracts.InstanceResponse toInstanceResponse(
@@ -602,16 +621,14 @@ public class WorkflowService {
                 row.id(), row.tenantId(), row.definitionKey(), row.definitionVersion(),
                 row.sourceSystem(), row.businessType(), row.businessId(), row.initiatorId(),
                 row.currentNodeKey(), row.status(), row.version(), readMap(row.variablesJson()),
-                row.startedAt(), row.endedAt()
-        );
+                row.startedAt(), row.endedAt());
     }
 
     private WorkflowContracts.TaskResponse toTaskResponse(WorkflowRepository.TaskRow row) {
         return new WorkflowContracts.TaskResponse(
                 row.id(), row.instanceId(), row.nodeInstanceId(), row.nodeKey(),
                 row.taskName(), row.assigneeType(), row.assigneeValue(), row.status(),
-                row.version(), row.createdAt(), row.completedAt()
-        );
+                row.version(), row.createdAt(), row.completedAt());
     }
 
     private WorkflowDefinition readDefinition(String json) {
@@ -644,8 +661,5 @@ public class WorkflowService {
 
     private String newId() {
         return UUID.randomUUID().toString().replace("-", "");
-    }
-
-    private record Assignee(String type, String value) {
     }
 }

--- a/workflow-service/src/main/java/single/cjj/workflow/service/WorkflowTaskCenterService.java
+++ b/workflow-service/src/main/java/single/cjj/workflow/service/WorkflowTaskCenterService.java
@@ -1,0 +1,175 @@
+package single.cjj.workflow.service;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import single.cjj.workflow.api.WorkflowContracts;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+@Service
+public class WorkflowTaskCenterService {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public WorkflowTaskCenterService(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public WorkflowContracts.TaskCenterPage query(String tenantId,
+                                                   String userId,
+                                                   Set<String> roleCodes,
+                                                   WorkflowContracts.TaskCenterView view,
+                                                   String businessType,
+                                                   String keyword,
+                                                   int page,
+                                                   int size) {
+        int safePage = Math.max(page, 1);
+        int safeSize = Math.min(Math.max(size, 1), 100);
+        QueryPlan plan = buildPlan(
+                tenantId, userId,
+                roleCodes == null ? Set.of() : new LinkedHashSet<>(roleCodes),
+                view == null ? WorkflowContracts.TaskCenterView.TODO : view,
+                businessType, keyword);
+
+        Long totalValue = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM (" + plan.sql() + ") task_center_count",
+                Long.class,
+                plan.arguments().toArray());
+        long total = totalValue == null ? 0L : totalValue;
+
+        List<Object> pageArguments = new ArrayList<>(plan.arguments());
+        pageArguments.add(safeSize);
+        pageArguments.add((safePage - 1) * safeSize);
+        List<WorkflowContracts.TaskCenterItem> items = jdbcTemplate.query(
+                plan.sql() + " ORDER BY item_created_at DESC LIMIT ? OFFSET ?",
+                this::mapItem,
+                pageArguments.toArray());
+        return new WorkflowContracts.TaskCenterPage(items, total, safePage, safeSize);
+    }
+
+    private QueryPlan buildPlan(String tenantId,
+                                String userId,
+                                Set<String> roles,
+                                WorkflowContracts.TaskCenterView view,
+                                String businessType,
+                                String keyword) {
+        StringBuilder sql = new StringBuilder();
+        List<Object> args = new ArrayList<>();
+        switch (view) {
+            case TODO -> appendTodo(sql, args, tenantId, userId, roles);
+            case DONE -> appendDone(sql, args, tenantId, userId);
+            case INITIATED -> appendInitiated(sql, args, tenantId, userId);
+        }
+        if (StringUtils.hasText(businessType)) {
+            sql.append(" AND i.business_type = ?");
+            args.add(businessType.trim());
+        }
+        if (StringUtils.hasText(keyword)) {
+            sql.append(" AND (i.business_id LIKE ? OR i.definition_key LIKE ? OR COALESCE(t.task_name, '') LIKE ?)");
+            String pattern = "%" + keyword.trim() + "%";
+            args.add(pattern);
+            args.add(pattern);
+            args.add(pattern);
+        }
+        return new QueryPlan(sql.toString(), args);
+    }
+
+    private void appendTodo(StringBuilder sql,
+                            List<Object> args,
+                            String tenantId,
+                            String userId,
+                            Set<String> roles) {
+        sql.append(baseSelect("NULL", "t.created_at"));
+        sql.append(" FROM wf_task t JOIN wf_instance i ON i.id = t.instance_id")
+                .append(" WHERE t.tenant_id = ? AND t.status IN ('PENDING', 'CLAIMED') AND (")
+                .append("(t.assignee_type = 'USER' AND t.assignee_value = ?)")
+                .append(" OR EXISTS (SELECT 1 FROM wf_task_candidate c")
+                .append(" WHERE c.task_id = t.id AND c.candidate_type = 'USER' AND c.candidate_value = ?)");
+        args.add(tenantId);
+        args.add(userId);
+        args.add(userId);
+        if (!roles.isEmpty()) {
+            String placeholders = placeholders(roles.size());
+            sql.append(" OR (t.assignee_type = 'ROLE' AND t.assignee_value IN (")
+                    .append(placeholders).append("))")
+                    .append(" OR EXISTS (SELECT 1 FROM wf_task_candidate c")
+                    .append(" WHERE c.task_id = t.id AND c.candidate_type = 'ROLE'")
+                    .append(" AND c.candidate_value IN (").append(placeholders).append("))");
+            args.addAll(roles);
+            args.addAll(roles);
+        }
+        sql.append(")");
+    }
+
+    private void appendDone(StringBuilder sql,
+                            List<Object> args,
+                            String tenantId,
+                            String userId) {
+        sql.append(baseSelect("a.action", "a.created_at"));
+        sql.append(" FROM wf_action_log a")
+                .append(" JOIN wf_task t ON t.id = a.task_id")
+                .append(" JOIN wf_instance i ON i.id = t.instance_id")
+                .append(" WHERE t.tenant_id = ? AND a.operator_id = ?")
+                .append(" AND a.action IN ('APPROVE','REJECT','RETURN_TO_INITIATOR','RESUBMIT')");
+        args.add(tenantId);
+        args.add(userId);
+    }
+
+    private void appendInitiated(StringBuilder sql,
+                                 List<Object> args,
+                                 String tenantId,
+                                 String userId) {
+        sql.append(baseSelect("NULL", "COALESCE(t.created_at, i.started_at)"));
+        sql.append(" FROM wf_instance i")
+                .append(" LEFT JOIN wf_task t ON t.id = (")
+                .append("SELECT t2.id FROM wf_task t2 WHERE t2.instance_id = i.id")
+                .append(" ORDER BY t2.created_at DESC LIMIT 1)")
+                .append(" WHERE i.tenant_id = ? AND i.initiator_id = ?");
+        args.add(tenantId);
+        args.add(userId);
+    }
+
+    private String baseSelect(String actionExpression, String createdExpression) {
+        return "SELECT t.id AS task_id, i.id AS instance_id, i.definition_key,"
+                + " i.source_system, i.business_type, i.business_id, i.initiator_id,"
+                + " i.current_node_key, t.task_name, t.assignee_type, t.assignee_value,"
+                + " t.status AS task_status, i.status AS instance_status,"
+                + " " + actionExpression + " AS action_name,"
+                + " " + createdExpression + " AS item_created_at, t.completed_at";
+    }
+
+    private WorkflowContracts.TaskCenterItem mapItem(ResultSet rs, int rowNum) throws SQLException {
+        return new WorkflowContracts.TaskCenterItem(
+                rs.getString("task_id"),
+                rs.getString("instance_id"),
+                rs.getString("definition_key"),
+                rs.getString("source_system"),
+                rs.getString("business_type"),
+                rs.getString("business_id"),
+                rs.getString("initiator_id"),
+                rs.getString("current_node_key"),
+                rs.getString("task_name"),
+                rs.getString("assignee_type"),
+                rs.getString("assignee_value"),
+                rs.getString("task_status"),
+                rs.getString("instance_status"),
+                rs.getString("action_name"),
+                rs.getObject("item_created_at", LocalDateTime.class),
+                rs.getObject("completed_at", LocalDateTime.class)
+        );
+    }
+
+    private String placeholders(int count) {
+        return String.join(",", java.util.Collections.nCopies(count, "?"));
+    }
+
+    private record QueryPlan(String sql, List<Object> arguments) {
+    }
+}

--- a/workflow-service/src/main/resources/sql/workflow_v3_dynamic_routing.sql
+++ b/workflow-service/src/main/resources/sql/workflow_v3_dynamic_routing.sql
@@ -1,0 +1,22 @@
+-- Matrix workflow phase 4 batch 1: dynamic assignees and unified task center
+-- MySQL 8.0+
+
+CREATE TABLE IF NOT EXISTS wf_task_candidate (
+    id VARCHAR(40) PRIMARY KEY,
+    task_id VARCHAR(40) NOT NULL,
+    candidate_type VARCHAR(32) NOT NULL,
+    candidate_value VARCHAR(200) NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uk_wf_task_candidate (task_id, candidate_type, candidate_value),
+    KEY idx_wf_candidate_lookup (candidate_type, candidate_value, task_id),
+    KEY idx_wf_candidate_task (task_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='工作流共享任务候选用户与角色';
+
+-- Backfill direct assignments created before this migration.
+INSERT IGNORE INTO wf_task_candidate
+    (id, task_id, candidate_type, candidate_value, created_at)
+SELECT REPLACE(UUID(), '-', ''), id, assignee_type, assignee_value, created_at
+FROM wf_task
+WHERE assignee_type IN ('USER', 'ROLE')
+  AND assignee_value IS NOT NULL
+  AND assignee_value <> '';

--- a/workflow-service/src/test/java/single/cjj/workflow/engine/DefaultWorkflowAssigneeResolverTest.java
+++ b/workflow-service/src/test/java/single/cjj/workflow/engine/DefaultWorkflowAssigneeResolverTest.java
@@ -1,0 +1,55 @@
+package single.cjj.workflow.engine;
+
+import org.junit.jupiter.api.Test;
+import single.cjj.workflow.model.WorkflowDefinition;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DefaultWorkflowAssigneeResolverTest {
+
+    private final DefaultWorkflowAssigneeResolver resolver = new DefaultWorkflowAssigneeResolver();
+
+    @Test
+    void resolvesMultipleUsersFromNestedVariable() {
+        WorkflowDefinition.AssigneeRule rule = new WorkflowDefinition.AssigneeRule();
+        rule.setType(WorkflowDefinition.AssigneeType.USERS_VARIABLE);
+        rule.setValue("approval.reviewers");
+
+        WorkflowAssigneeResolver.Resolution resolution = resolver.resolve(
+                rule,
+                new WorkflowAssigneeResolver.Context(
+                        "wf1",
+                        "starter",
+                        Map.of("approval", Map.of("reviewers", List.of("u1", "u2", "u1")))
+                ));
+
+        assertEquals(List.of(
+                new WorkflowAssigneeResolver.Candidate("USER", "u1"),
+                new WorkflowAssigneeResolver.Candidate("USER", "u2")
+        ), resolution.candidates());
+    }
+
+    @Test
+    void resolvesStaticRolesAndInitiator() {
+        WorkflowDefinition.AssigneeRule roleRule = new WorkflowDefinition.AssigneeRule();
+        roleRule.setType(WorkflowDefinition.AssigneeType.ROLES);
+        roleRule.setValues(List.of("FINANCE_REVIEWER", "FINANCE_MANAGER"));
+        WorkflowAssigneeResolver.Resolution roles = resolver.resolve(
+                roleRule,
+                new WorkflowAssigneeResolver.Context("wf1", "starter", Map.of()));
+        assertEquals("ROLE", roles.candidates().get(0).type());
+        assertEquals(2, roles.candidates().size());
+
+        WorkflowDefinition.AssigneeRule initiatorRule = new WorkflowDefinition.AssigneeRule();
+        initiatorRule.setType(WorkflowDefinition.AssigneeType.INITIATOR);
+        WorkflowAssigneeResolver.Resolution initiator = resolver.resolve(
+                initiatorRule,
+                new WorkflowAssigneeResolver.Context("wf1", "starter", Map.of()));
+        assertEquals(List.of(
+                new WorkflowAssigneeResolver.Candidate("USER", "starter")
+        ), initiator.candidates());
+    }
+}

--- a/workflow-service/src/test/java/single/cjj/workflow/engine/WorkflowConditionEvaluatorCompositeTest.java
+++ b/workflow-service/src/test/java/single/cjj/workflow/engine/WorkflowConditionEvaluatorCompositeTest.java
@@ -1,0 +1,54 @@
+package single.cjj.workflow.engine;
+
+import org.junit.jupiter.api.Test;
+import single.cjj.workflow.model.WorkflowDefinition;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WorkflowConditionEvaluatorCompositeTest {
+
+    private final WorkflowConditionEvaluator evaluator = new WorkflowConditionEvaluator();
+
+    @Test
+    void evaluatesNestedAllAndAnyConditions() {
+        WorkflowDefinition.Condition amount = leaf(
+                "amount", WorkflowDefinition.ConditionOperator.GE, 1000);
+        WorkflowDefinition.Condition region = leaf(
+                "applicant.region", WorkflowDefinition.ConditionOperator.EQ, "WEST");
+        WorkflowDefinition.Condition urgent = leaf(
+                "urgent", WorkflowDefinition.ConditionOperator.EQ, true);
+
+        WorkflowDefinition.Condition any = new WorkflowDefinition.Condition();
+        any.setLogic(WorkflowDefinition.ConditionLogic.ANY);
+        any.setChildren(List.of(region, urgent));
+
+        WorkflowDefinition.Condition root = new WorkflowDefinition.Condition();
+        root.setLogic(WorkflowDefinition.ConditionLogic.ALL);
+        root.setChildren(List.of(amount, any));
+
+        assertTrue(evaluator.matches(root, Map.of(
+                "amount", 1200,
+                "urgent", false,
+                "applicant", Map.of("region", "WEST")
+        )));
+        assertFalse(evaluator.matches(root, Map.of(
+                "amount", 1200,
+                "urgent", false,
+                "applicant", Map.of("region", "EAST")
+        )));
+    }
+
+    private WorkflowDefinition.Condition leaf(String field,
+                                              WorkflowDefinition.ConditionOperator operator,
+                                              Object value) {
+        WorkflowDefinition.Condition condition = new WorkflowDefinition.Condition();
+        condition.setField(field);
+        condition.setOperator(operator);
+        condition.setValue(value);
+        return condition;
+    }
+}


### PR DESCRIPTION
## Summary

- add pluggable dynamic assignee resolution for fixed users, fixed roles, initiator, static candidate lists, and user/role variables
- persist shared task candidates in `wf_task_candidate`
- enforce user and role candidate authorization during task actions
- sanitize and regenerate trusted `X-User-Roles` at the gateway from JWT claims
- support nested `ALL` / `ANY` transition conditions and dotted variable paths
- add unified task-center views for TODO, DONE, and INITIATED workflows
- add migration, unit tests, and implementation documentation

## APIs

- `GET /api/workflow/task-center?tenantId=...&view=TODO|DONE|INITIATED`
- existing `POST /api/workflow/tasks/{taskId}/actions` now validates trusted user and role candidates

## Database

Run:

```text
workflow-service/src/main/resources/sql/workflow_v3_dynamic_routing.sql
```

The migration creates `wf_task_candidate` and backfills historical direct USER/ROLE assignments.

## Semantics

This batch implements shared candidate tasks: any valid candidate may complete the task, and optimistic locking prevents duplicate completion. It does not implement parallel approval or countersign; those remain a later workflow phase.

## Validation

- dynamic user and role resolution tests
- nested ALL/ANY condition tests
- workflow, gateway, and repository CI checks will run on this PR
