### PR TITLE
feat(im): complete application and callback business flow

### DIFF
--- a/docs/im/im-notification-phase3.md
+++ b/docs/im/im-notification-phase3.md
@@ -1,0 +1,41 @@
+# Matrix 统一消息推送平台：三期业务闭环
+
+三期不新增前端页面，重点完善多业务系统正式接入所需的后端闭环。
+
+## 本期能力
+
+1. **可靠性加固**
+   - Outbox `PROCESSING` 超时恢复。
+   - RabbitMQ 渠道队列配置死信交换机和 DLQ。
+   - Broker 异常不再无限 requeue，死信持久化到 `im_dead_letter`。
+   - 定时对账消息聚合状态，以及 LOCAL 渠道成功但站内消息缺失的异常。
+
+2. **动态应用接入**
+   - `im_application` 保存租户、允许渠道、IP 白名单、限流、回调地址和状态。
+   - AppSecret 与 CallbackSecret 使用 AES-256-GCM 加密保存。
+   - 支持应用新增/更新、密钥轮换和只读列表。
+   - 保留配置文件凭证作为迁移期兼容方案。
+
+3. **并发幂等**
+   - 对 `(app_code, request_id)` 并发唯一键冲突进行事务外查询。
+   - 重复请求返回原 `messageNo`，并标记 `idempotentReplay=true`。
+
+4. **最终结果回调**
+   - 最终消息状态生成 `im_callback_task`。
+   - 回调使用 `X-IM-Timestamp`、`X-IM-Nonce`、`X-IM-Signature` 和 HMAC-SHA256。
+   - 支持指数退避、超时恢复、最终 DEAD 状态。
+   - 回调地址必须与应用登记地址一致，防止任意 URL 回调。
+
+5. **Scheduler 真实接入**
+   - Scheduler 告警和 `matrix_scheduler_im_outbox` 在同一事务内创建。
+   - 异步 HMAC 调用 IM，不影响调度告警主事务。
+   - IM 最终状态回调 Scheduler，形成 `告警 → IM → LOCAL/EMAIL → 回调` 闭环。
+
+## 部署顺序
+
+1. 执行 `docs/sql/im-platform-phase3.sql`。
+2. 执行 `scheduler-service/src/main/resources/db/migration/V4__scheduler_im_notification_outbox.sql`。
+3. 配置独立的 `IM_SECRET_MASTER_KEY`。
+4. 调用 `POST /api/im/applications` 创建 `scheduler` 应用，并保存只返回一次的密钥。
+5. 将应用密钥、回调地址和接收用户配置到 Scheduler。
+6. 设置 `SCHEDULER_IM_ENABLED=true`。

--- a/docs/sql/im-platform-phase3.sql
+++ b/docs/sql/im-platform-phase3.sql
@@ -1,0 +1,69 @@
+-- Matrix unified notification platform - phase 3
+-- Reliability hardening, dynamic applications, callbacks and dead letters
+-- MySQL 8.0+
+
+ALTER TABLE im_outbox_event
+    ADD COLUMN processing_started_time DATETIME(3) NULL AFTER last_error,
+    ADD COLUMN updated_time DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+        ON UPDATE CURRENT_TIMESTAMP(3) AFTER created_time,
+    ADD KEY idx_im_outbox_processing (status, updated_time);
+
+CREATE TABLE IF NOT EXISTS im_application (
+    app_code                    VARCHAR(64)  NOT NULL,
+    app_name                    VARCHAR(128) NOT NULL,
+    tenant_id                   VARCHAR(64)  NOT NULL DEFAULT 'default',
+    app_secret_ciphertext       VARCHAR(1000) NOT NULL,
+    allowed_channels            VARCHAR(255) NOT NULL,
+    allowed_ips                 VARCHAR(2000) NOT NULL DEFAULT '*',
+    rate_limit_per_minute       INT NOT NULL DEFAULT 600,
+    callback_url                VARCHAR(1000) NULL,
+    callback_secret_ciphertext  VARCHAR(1000) NULL,
+    status                      VARCHAR(32) NOT NULL DEFAULT 'ENABLED',
+    created_time                DATETIME(3) NOT NULL,
+    updated_time                DATETIME(3) NOT NULL,
+    PRIMARY KEY (app_code),
+    KEY idx_im_application_tenant_status (tenant_id, status)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='IM 开放接口接入应用';
+
+CREATE TABLE IF NOT EXISTS im_callback_task (
+    id                          VARCHAR(32) NOT NULL,
+    event_id                    VARCHAR(160) NOT NULL,
+    message_id                  VARCHAR(32) NOT NULL,
+    message_status              VARCHAR(32) NOT NULL,
+    app_code                    VARCHAR(64) NOT NULL,
+    callback_url                VARCHAR(1000) NOT NULL,
+    callback_secret_ciphertext  VARCHAR(1000) NOT NULL,
+    payload_json                JSON NOT NULL,
+    status                      VARCHAR(32) NOT NULL,
+    retry_count                 INT NOT NULL DEFAULT 0,
+    max_retry_count             INT NOT NULL DEFAULT 6,
+    next_retry_time             DATETIME(3) NULL,
+    processing_started_time     DATETIME(3) NULL,
+    response_code               INT NULL,
+    response_body               VARCHAR(2000) NULL,
+    last_error                  VARCHAR(1000) NULL,
+    created_time                DATETIME(3) NOT NULL,
+    updated_time                DATETIME(3) NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_im_callback_event (event_id),
+    UNIQUE KEY uk_im_callback_message_status (message_id, message_status),
+    KEY idx_im_callback_due (status, next_retry_time, created_time),
+    KEY idx_im_callback_processing (status, processing_started_time)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='消息最终结果回调任务';
+
+CREATE TABLE IF NOT EXISTS im_dead_letter (
+    id              VARCHAR(32) NOT NULL,
+    queue_name      VARCHAR(128) NOT NULL,
+    message_id      VARCHAR(160) NOT NULL,
+    payload_json    LONGTEXT NOT NULL,
+    reason          VARCHAR(1000) NULL,
+    status          VARCHAR(32) NOT NULL DEFAULT 'PENDING',
+    created_time    DATETIME(3) NOT NULL,
+    updated_time    DATETIME(3) NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_im_dead_letter_message (queue_name, message_id),
+    KEY idx_im_dead_letter_status_time (status, created_time)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='IM RabbitMQ 死信持久化记录';
+
+-- 应用密钥必须通过 POST /api/im/applications 创建或更新。
+-- API 只在创建/轮换时返回一次明文密钥，数据库保存 AES-GCM 密文。

--- a/gateway/src/main/java/single/cjj/gateway/security/GatewayAuthFilter.java
+++ b/gateway/src/main/java/single/cjj/gateway/security/GatewayAuthFilter.java
@@ -34,12 +34,14 @@ public class GatewayAuthFilter implements GlobalFilter, Ordered {
             "/api/actuator/**",
             "/api/swagger-ui/**",
             "/api/v3/api-docs/**",
-            // OpenAPI 使用 AppKey + HMAC，由 openapi-service 再次执行强校验。
+            // OpenAPI 使用 AppKey + HMAC，由 openapi-service 或 im-service 再次执行强校验。
             "/api/open-api/**",
             // 调度执行器内部接口由 scheduler-service 使用共享密钥再次校验。
             "/api/scheduler/executors/register",
             "/api/scheduler/executors/heartbeat",
-            "/api/scheduler/callback/**"
+            "/api/scheduler/callback/**",
+            // IM 最终结果回调使用 X-IM-* HMAC 请求头，由 scheduler-service 校验。
+            "/api/scheduler/im/callbacks"
     );
 
     private static final List<String> INTERNAL_IDENTITY_HEADERS = List.of(

--- a/gateway/src/main/java/single/cjj/gateway/security/GatewayAuthFilter.java
+++ b/gateway/src/main/java/single/cjj/gateway/security/GatewayAuthFilter.java
@@ -21,7 +21,10 @@ import reactor.core.publisher.Mono;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 @Slf4j
 @Component
@@ -47,6 +50,7 @@ public class GatewayAuthFilter implements GlobalFilter, Ordered {
     private static final List<String> INTERNAL_IDENTITY_HEADERS = List.of(
             "X-User-Id",
             "X-Tenant-Id",
+            "X-User-Roles",
             "X-OpenApi-App-Id",
             "X-OpenApi-Tenant-Id",
             "X-OpenApi-Verified"
@@ -75,15 +79,49 @@ public class GatewayAuthFilter implements GlobalFilter, Ordered {
             String userId = String.valueOf(claims.get("id"));
             Object tenantClaim = claims.get("tenantId");
             String tenantId = tenantClaim == null ? "default" : String.valueOf(tenantClaim);
+            String roles = resolveRoles(claims);
 
-            ServerHttpRequest mutated = request.mutate()
+            ServerHttpRequest.Builder builder = request.mutate()
                     .header("X-User-Id", userId)
-                    .header("X-Tenant-Id", tenantId)
-                    .build();
-            return chain.filter(sanitizedExchange.mutate().request(mutated).build());
+                    .header("X-Tenant-Id", tenantId);
+            if (StringUtils.hasText(roles)) {
+                builder.header("X-User-Roles", roles);
+            }
+            return chain.filter(sanitizedExchange.mutate().request(builder.build()).build());
         } catch (Exception e) {
             log.warn("gateway jwt verify failed: {}", e.getMessage());
             return unauthorized(exchange.getResponse(), "token无效或已过期");
+        }
+    }
+
+    private String resolveRoles(Claims claims) {
+        Object value = claims.get("roles");
+        if (value == null) {
+            value = claims.get("roleCodes");
+        }
+        if (value == null) {
+            value = claims.get("authorities");
+        }
+        if (value == null) {
+            value = claims.get("role");
+        }
+        Set<String> roles = new LinkedHashSet<>();
+        collectRoles(value, roles);
+        return String.join(",", roles);
+    }
+
+    private void collectRoles(Object value, Set<String> roles) {
+        if (value == null) {
+            return;
+        }
+        if (value instanceof Collection<?> collection) {
+            collection.forEach(item -> collectRoles(item, roles));
+            return;
+        }
+        for (String role : String.valueOf(value).split(",")) {
+            if (StringUtils.hasText(role)) {
+                roles.add(role.trim());
+            }
         }
     }
 

--- a/im-service/src/main/java/single/cjj/im/application/ImApplicationController.java
+++ b/im-service/src/main/java/single/cjj/im/application/ImApplicationController.java
@@ -1,0 +1,38 @@
+package single.cjj.im.application;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import single.cjj.bizfi.entity.ApiResponse;
+import single.cjj.im.application.ImApplicationService.ApplicationSecretResponse;
+import single.cjj.im.application.ImApplicationService.ApplicationUpsertRequest;
+import single.cjj.im.application.ImApplicationService.ApplicationView;
+
+import java.util.List;
+
+@RestController
+public class ImApplicationController {
+
+    private final ImApplicationService applicationService;
+
+    public ImApplicationController(ImApplicationService applicationService) {
+        this.applicationService = applicationService;
+    }
+
+    @PostMapping("/im/applications")
+    public ApiResponse<ApplicationSecretResponse> upsert(@RequestBody ApplicationUpsertRequest request) {
+        return ApiResponse.success("IM 应用配置已保存", applicationService.upsert(request));
+    }
+
+    @PostMapping("/im/applications/{appCode}/rotate-secret")
+    public ApiResponse<ApplicationSecretResponse> rotateSecret(@PathVariable("appCode") String appCode) {
+        return ApiResponse.success("IM 应用密钥已轮换", applicationService.rotateSecret(appCode));
+    }
+
+    @GetMapping("/im/applications")
+    public ApiResponse<List<ApplicationView>> list() {
+        return ApiResponse.success(applicationService.list());
+    }
+}

--- a/im-service/src/main/java/single/cjj/im/application/ImApplicationService.java
+++ b/im-service/src/main/java/single/cjj/im/application/ImApplicationService.java
@@ -1,0 +1,380 @@
+package single.cjj.im.application;
+
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import single.cjj.im.service.ImBusinessException;
+
+import java.net.InetAddress;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class ImApplicationService {
+
+    private static final Set<String> ALL_CHANNELS = Set.of("LOCAL", "EMAIL");
+
+    private final NamedParameterJdbcTemplate jdbc;
+    private final StringRedisTemplate redis;
+    private final ImSecretCodec secretCodec;
+    private final ImOpenApiProperties fallbackProperties;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public ImApplicationService(NamedParameterJdbcTemplate jdbc,
+                                StringRedisTemplate redis,
+                                ImSecretCodec secretCodec,
+                                ImOpenApiProperties fallbackProperties) {
+        this.jdbc = jdbc;
+        this.redis = redis;
+        this.secretCodec = secretCodec;
+        this.fallbackProperties = fallbackProperties;
+    }
+
+    public AuthenticatedApplication authenticate(String appCode, String sourceIp) {
+        AuthenticatedApplication application = requireEnabled(appCode);
+        if (!ipAllowed(sourceIp, application.allowedIps())) {
+            throw new ApplicationAuthenticationException("调用方 IP 不在白名单内");
+        }
+        return application;
+    }
+
+    public void enforceRateLimit(AuthenticatedApplication application) {
+        applyRateLimit(application);
+    }
+
+    public AuthenticatedApplication requireEnabled(String appCode) {
+        if (!StringUtils.hasText(appCode)) {
+            throw new ApplicationAuthenticationException("调用应用不能为空");
+        }
+        ApplicationRow row = findRow(appCode.trim()).orElse(null);
+        if (row != null) {
+            if (!"ENABLED".equals(row.status())) {
+                throw new ApplicationAuthenticationException("调用应用未启用");
+            }
+            return new AuthenticatedApplication(
+                    row.appCode(),
+                    row.appName(),
+                    row.tenantId(),
+                    secretCodec.decrypt(row.appSecretCiphertext()),
+                    split(row.allowedChannels()),
+                    split(row.allowedIps()),
+                    row.rateLimitPerMinute(),
+                    row.callbackUrl(),
+                    secretCodec.decrypt(StringUtils.hasText(row.callbackSecretCiphertext())
+                            ? row.callbackSecretCiphertext()
+                            : row.appSecretCiphertext()),
+                    false
+            );
+        }
+
+        String fallbackSecret = fallbackProperties.getCredentials().get(appCode.trim());
+        if (!StringUtils.hasText(fallbackSecret)) {
+            throw new ApplicationAuthenticationException("未知或未启用的调用应用");
+        }
+        return new AuthenticatedApplication(
+                appCode.trim(),
+                appCode.trim(),
+                "default",
+                fallbackSecret,
+                ALL_CHANNELS,
+                Set.of("*"),
+                fallbackProperties.getFallbackRateLimitPerMinute(),
+                null,
+                fallbackSecret,
+                true
+        );
+    }
+
+    public ApplicationSecretResponse upsert(ApplicationUpsertRequest request) {
+        if (request == null || !StringUtils.hasText(request.appCode()) || !StringUtils.hasText(request.appName())) {
+            throw new ImBusinessException("appCode 和 appName 不能为空");
+        }
+        Set<String> channels = normalizeChannels(request.allowedChannels());
+        if (channels.isEmpty() || !ALL_CHANNELS.containsAll(channels)) {
+            throw new ImBusinessException("allowedChannels 仅支持 LOCAL、EMAIL");
+        }
+        String appCode = request.appCode().trim();
+        ApplicationRow existing = findRow(appCode).orElse(null);
+        String generatedSecret = StringUtils.hasText(request.appSecret())
+                ? request.appSecret().trim()
+                : existing == null ? generateSecret() : null;
+        String encryptedSecret = generatedSecret == null
+                ? existing.appSecretCiphertext()
+                : secretCodec.encrypt(generatedSecret);
+        String callbackSecret = StringUtils.hasText(request.callbackSecret())
+                ? request.callbackSecret().trim()
+                : generatedSecret;
+        String encryptedCallbackSecret = callbackSecret == null
+                ? existing == null ? encryptedSecret : existing.callbackSecretCiphertext()
+                : secretCodec.encrypt(callbackSecret);
+        LocalDateTime now = LocalDateTime.now();
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("appCode", appCode)
+                .addValue("appName", request.appName().trim())
+                .addValue("tenantId", textOrDefault(request.tenantId(), "default"))
+                .addValue("appSecretCiphertext", encryptedSecret)
+                .addValue("allowedChannels", String.join(",", channels))
+                .addValue("allowedIps", normalizeCsv(request.allowedIps(), "*"))
+                .addValue("rateLimitPerMinute", Math.max(1, request.rateLimitPerMinute() == null ? 600 : request.rateLimitPerMinute()))
+                .addValue("callbackUrl", blankToNull(request.callbackUrl()))
+                .addValue("callbackSecretCiphertext", encryptedCallbackSecret)
+                .addValue("status", textOrDefault(request.status(), "ENABLED").toUpperCase(Locale.ROOT))
+                .addValue("now", now);
+        jdbc.update("""
+                INSERT INTO im_application (
+                    app_code,app_name,tenant_id,app_secret_ciphertext,allowed_channels,allowed_ips,
+                    rate_limit_per_minute,callback_url,callback_secret_ciphertext,status,created_time,updated_time
+                ) VALUES (
+                    :appCode,:appName,:tenantId,:appSecretCiphertext,:allowedChannels,:allowedIps,
+                    :rateLimitPerMinute,:callbackUrl,:callbackSecretCiphertext,:status,:now,:now
+                )
+                ON DUPLICATE KEY UPDATE
+                    app_name=VALUES(app_name),tenant_id=VALUES(tenant_id),
+                    app_secret_ciphertext=VALUES(app_secret_ciphertext),
+                    allowed_channels=VALUES(allowed_channels),allowed_ips=VALUES(allowed_ips),
+                    rate_limit_per_minute=VALUES(rate_limit_per_minute),
+                    callback_url=VALUES(callback_url),
+                    callback_secret_ciphertext=VALUES(callback_secret_ciphertext),
+                    status=VALUES(status),updated_time=VALUES(updated_time)
+                """, params);
+        return new ApplicationSecretResponse(appCode, generatedSecret, generatedSecret != null);
+    }
+
+    public ApplicationSecretResponse rotateSecret(String appCode) {
+        ApplicationRow row = findRow(appCode).orElseThrow(() -> new ImBusinessException("IM 应用不存在"));
+        String secret = generateSecret();
+        String encrypted = secretCodec.encrypt(secret);
+        jdbc.update("""
+                UPDATE im_application
+                SET app_secret_ciphertext=:secret,
+                    callback_secret_ciphertext=:secret,
+                    updated_time=:now
+                WHERE app_code=:appCode
+                """, Map.of("appCode", row.appCode(), "secret", encrypted, "now", LocalDateTime.now()));
+        return new ApplicationSecretResponse(row.appCode(), secret, true);
+    }
+
+    public List<ApplicationView> list() {
+        return jdbc.query("""
+                SELECT app_code,app_name,tenant_id,allowed_channels,allowed_ips,rate_limit_per_minute,
+                       callback_url,status,created_time,updated_time
+                FROM im_application
+                ORDER BY app_code
+                """, (rs, rowNum) -> new ApplicationView(
+                rs.getString("app_code"),
+                rs.getString("app_name"),
+                rs.getString("tenant_id"),
+                split(rs.getString("allowed_channels")),
+                split(rs.getString("allowed_ips")),
+                rs.getInt("rate_limit_per_minute"),
+                rs.getString("callback_url"),
+                rs.getString("status"),
+                rs.getTimestamp("created_time").toLocalDateTime(),
+                rs.getTimestamp("updated_time").toLocalDateTime()
+        ));
+    }
+
+    private java.util.Optional<ApplicationRow> findRow(String appCode) {
+        try {
+            ApplicationRow row = jdbc.queryForObject("""
+                    SELECT app_code,app_name,tenant_id,app_secret_ciphertext,allowed_channels,allowed_ips,
+                           rate_limit_per_minute,callback_url,callback_secret_ciphertext,status
+                    FROM im_application
+                    WHERE app_code=:appCode
+                    LIMIT 1
+                    """, Map.of("appCode", appCode), (rs, rowNum) -> new ApplicationRow(
+                    rs.getString("app_code"),
+                    rs.getString("app_name"),
+                    rs.getString("tenant_id"),
+                    rs.getString("app_secret_ciphertext"),
+                    rs.getString("allowed_channels"),
+                    rs.getString("allowed_ips"),
+                    rs.getInt("rate_limit_per_minute"),
+                    rs.getString("callback_url"),
+                    rs.getString("callback_secret_ciphertext"),
+                    rs.getString("status")
+            ));
+            return java.util.Optional.ofNullable(row);
+        } catch (EmptyResultDataAccessException e) {
+            return java.util.Optional.empty();
+        }
+    }
+
+    private void applyRateLimit(AuthenticatedApplication application) {
+        long minute = LocalDateTime.now(ZoneOffset.UTC).atZone(ZoneOffset.UTC).toEpochSecond() / 60;
+        String key = "im:open-api:rate:" + application.appCode() + ":" + minute;
+        Long value = redis.opsForValue().increment(key);
+        if (value != null && value == 1L) {
+            redis.expire(key, Duration.ofMinutes(2));
+        }
+        if (value != null && value > application.rateLimitPerMinute()) {
+            throw new ApplicationAuthenticationException("调用频率超过应用限额");
+        }
+    }
+
+    private boolean ipAllowed(String sourceIp, Set<String> allowedIps) {
+        if (allowedIps.isEmpty() || allowedIps.contains("*")) {
+            return true;
+        }
+        if (!StringUtils.hasText(sourceIp)) {
+            return false;
+        }
+        String ip = sourceIp.trim();
+        return allowedIps.stream().anyMatch(rule -> matchesIpRule(ip, rule));
+    }
+
+    private boolean matchesIpRule(String ip, String rule) {
+        if (ip.equals(rule)) {
+            return true;
+        }
+        if (!rule.contains("/")) {
+            return false;
+        }
+        try {
+            String[] parts = rule.split("/", 2);
+            byte[] address = InetAddress.getByName(ip).getAddress();
+            byte[] network = InetAddress.getByName(parts[0]).getAddress();
+            int prefix = Integer.parseInt(parts[1]);
+            if (address.length != network.length || prefix < 0 || prefix > address.length * 8) {
+                return false;
+            }
+            int fullBytes = prefix / 8;
+            int remainingBits = prefix % 8;
+            for (int i = 0; i < fullBytes; i++) {
+                if (address[i] != network[i]) {
+                    return false;
+                }
+            }
+            if (remainingBits == 0) {
+                return true;
+            }
+            int mask = 0xFF << (8 - remainingBits);
+            return (address[fullBytes] & mask) == (network[fullBytes] & mask);
+        } catch (Exception ignored) {
+            return false;
+        }
+    }
+
+    private Set<String> normalizeChannels(Set<String> channels) {
+        if (channels == null) {
+            return Set.of();
+        }
+        return channels.stream()
+                .filter(StringUtils::hasText)
+                .map(value -> value.trim().toUpperCase(Locale.ROOT))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    private Set<String> split(String csv) {
+        if (!StringUtils.hasText(csv)) {
+            return Set.of();
+        }
+        return Arrays.stream(csv.split(","))
+                .map(String::trim)
+                .filter(StringUtils::hasText)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    private String normalizeCsv(Set<String> values, String fallback) {
+        if (values == null || values.isEmpty()) {
+            return fallback;
+        }
+        return values.stream().filter(StringUtils::hasText).map(String::trim).collect(Collectors.joining(","));
+    }
+
+    private String generateSecret() {
+        byte[] bytes = new byte[32];
+        secureRandom.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    private String textOrDefault(String value, String fallback) {
+        return StringUtils.hasText(value) ? value.trim() : fallback;
+    }
+
+    private String blankToNull(String value) {
+        return StringUtils.hasText(value) ? value.trim() : null;
+    }
+
+    private record ApplicationRow(
+            String appCode,
+            String appName,
+            String tenantId,
+            String appSecretCiphertext,
+            String allowedChannels,
+            String allowedIps,
+            int rateLimitPerMinute,
+            String callbackUrl,
+            String callbackSecretCiphertext,
+            String status
+    ) {
+    }
+
+    public record AuthenticatedApplication(
+            String appCode,
+            String appName,
+            String tenantId,
+            String appSecret,
+            Set<String> allowedChannels,
+            Set<String> allowedIps,
+            int rateLimitPerMinute,
+            String callbackUrl,
+            String callbackSecret,
+            boolean configurationFallback
+    ) {
+    }
+
+    public record ApplicationUpsertRequest(
+            String appCode,
+            String appName,
+            String tenantId,
+            String appSecret,
+            Set<String> allowedChannels,
+            Set<String> allowedIps,
+            Integer rateLimitPerMinute,
+            String callbackUrl,
+            String callbackSecret,
+            String status
+    ) {
+    }
+
+    public record ApplicationSecretResponse(
+            String appCode,
+            String secret,
+            boolean secretChanged
+    ) {
+    }
+
+    public record ApplicationView(
+            String appCode,
+            String appName,
+            String tenantId,
+            Set<String> allowedChannels,
+            Set<String> allowedIps,
+            int rateLimitPerMinute,
+            String callbackUrl,
+            String status,
+            LocalDateTime createdTime,
+            LocalDateTime updatedTime
+    ) {
+    }
+
+    public static class ApplicationAuthenticationException extends RuntimeException {
+        public ApplicationAuthenticationException(String message) {
+            super(message);
+        }
+    }
+}

--- a/im-service/src/main/java/single/cjj/im/application/ImOpenApiProperties.java
+++ b/im-service/src/main/java/single/cjj/im/application/ImOpenApiProperties.java
@@ -1,0 +1,38 @@
+package single.cjj.im.application;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@ConfigurationProperties(prefix = "im.open-api")
+public class ImOpenApiProperties {
+
+    private int signatureWindowSeconds = 300;
+    private int fallbackRateLimitPerMinute = 600;
+    private Map<String, String> credentials = new HashMap<>();
+
+    public int getSignatureWindowSeconds() {
+        return signatureWindowSeconds;
+    }
+
+    public void setSignatureWindowSeconds(int signatureWindowSeconds) {
+        this.signatureWindowSeconds = Math.max(30, signatureWindowSeconds);
+    }
+
+    public int getFallbackRateLimitPerMinute() {
+        return fallbackRateLimitPerMinute;
+    }
+
+    public void setFallbackRateLimitPerMinute(int fallbackRateLimitPerMinute) {
+        this.fallbackRateLimitPerMinute = Math.max(1, fallbackRateLimitPerMinute);
+    }
+
+    public Map<String, String> getCredentials() {
+        return credentials;
+    }
+
+    public void setCredentials(Map<String, String> credentials) {
+        this.credentials = credentials == null ? new HashMap<>() : credentials;
+    }
+}

--- a/im-service/src/main/java/single/cjj/im/application/ImSecretCodec.java
+++ b/im-service/src/main/java/single/cjj/im/application/ImSecretCodec.java
@@ -1,0 +1,76 @@
+package single.cjj.im.application;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+@Component
+public class ImSecretCodec {
+
+    private static final String PREFIX = "v1:";
+    private static final int IV_LENGTH = 12;
+    private static final int TAG_BITS = 128;
+
+    private final SecretKeySpec key;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public ImSecretCodec(@Value("${im.security.master-key}") String encodedKey) {
+        byte[] raw = Base64.getDecoder().decode(encodedKey);
+        if (raw.length != 32) {
+            throw new IllegalArgumentException("im.security.master-key must be a Base64 encoded 32-byte key");
+        }
+        this.key = new SecretKeySpec(raw, "AES");
+    }
+
+    public String encrypt(String plainText) {
+        if (!StringUtils.hasText(plainText)) {
+            return null;
+        }
+        try {
+            byte[] iv = new byte[IV_LENGTH];
+            secureRandom.nextBytes(iv);
+            Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            cipher.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(TAG_BITS, iv));
+            byte[] encrypted = cipher.doFinal(plainText.getBytes(StandardCharsets.UTF_8));
+            byte[] payload = ByteBuffer.allocate(iv.length + encrypted.length)
+                    .put(iv)
+                    .put(encrypted)
+                    .array();
+            return PREFIX + Base64.getEncoder().encodeToString(payload);
+        } catch (Exception e) {
+            throw new IllegalStateException("IM secret encryption failed", e);
+        }
+    }
+
+    public String decrypt(String cipherText) {
+        if (!StringUtils.hasText(cipherText)) {
+            return null;
+        }
+        if (!cipherText.startsWith(PREFIX)) {
+            throw new IllegalArgumentException("Unsupported IM secret format");
+        }
+        try {
+            byte[] payload = Base64.getDecoder().decode(cipherText.substring(PREFIX.length()));
+            if (payload.length <= IV_LENGTH) {
+                throw new IllegalArgumentException("Invalid encrypted IM secret");
+            }
+            byte[] iv = new byte[IV_LENGTH];
+            byte[] encrypted = new byte[payload.length - IV_LENGTH];
+            System.arraycopy(payload, 0, iv, 0, IV_LENGTH);
+            System.arraycopy(payload, IV_LENGTH, encrypted, 0, encrypted.length);
+            Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            cipher.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(TAG_BITS, iv));
+            return new String(cipher.doFinal(encrypted), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new IllegalStateException("IM secret decryption failed", e);
+        }
+    }
+}

--- a/im-service/src/main/java/single/cjj/im/callback/ImCallbackService.java
+++ b/im-service/src/main/java/single/cjj/im/callback/ImCallbackService.java
@@ -1,0 +1,247 @@
+package single.cjj.im.callback;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import single.cjj.im.application.ImApplicationService;
+import single.cjj.im.application.ImApplicationService.AuthenticatedApplication;
+import single.cjj.im.application.ImSecretCodec;
+import single.cjj.im.domain.ImModels.ChannelStatusResponse;
+import single.cjj.im.repository.ImMessageRepository;
+import single.cjj.im.reliability.ImOperationsRepository;
+import single.cjj.im.reliability.ImOperationsRepository.CallbackTaskRecord;
+import single.cjj.im.reliability.ImOperationsRepository.FinalMessageCandidate;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.web.client.RestClient;
+
+@Service
+public class ImCallbackService {
+
+    private final ImOperationsRepository operationsRepository;
+    private final ImMessageRepository messageRepository;
+    private final ImApplicationService applicationService;
+    private final ImSecretCodec secretCodec;
+    private final ObjectMapper objectMapper;
+    private final RestClient restClient;
+    private final int batchSize;
+    private final int maxRetryCount;
+    private final int processingTimeoutMinutes;
+
+    public ImCallbackService(ImOperationsRepository operationsRepository,
+                             ImMessageRepository messageRepository,
+                             ImApplicationService applicationService,
+                             ImSecretCodec secretCodec,
+                             ObjectMapper objectMapper,
+                             RestClient.Builder restClientBuilder,
+                             @Value("${im.callback.batch-size:100}") int batchSize,
+                             @Value("${im.callback.max-retry-count:6}") int maxRetryCount,
+                             @Value("${im.callback.processing-timeout-minutes:10}") int processingTimeoutMinutes) {
+        this.operationsRepository = operationsRepository;
+        this.messageRepository = messageRepository;
+        this.applicationService = applicationService;
+        this.secretCodec = secretCodec;
+        this.objectMapper = objectMapper;
+        this.restClient = restClientBuilder.build();
+        this.batchSize = Math.max(1, Math.min(batchSize, 500));
+        this.maxRetryCount = Math.max(1, maxRetryCount);
+        this.processingTimeoutMinutes = Math.max(1, processingTimeoutMinutes);
+    }
+
+    @Scheduled(fixedDelayString = "${im.callback.prepare-delay-ms:3000}")
+    public void prepareFinalCallbacks() {
+        List<FinalMessageCandidate> candidates =
+                operationsRepository.findFinalMessagesMissingCallbacks(batchSize);
+        for (FinalMessageCandidate candidate : candidates) {
+            try {
+                prepareOne(candidate);
+            } catch (Exception e) {
+                operationsRepository.updateMessageCallbackStatus(
+                        candidate.messageId(),
+                        "CONFIG_ERROR",
+                        LocalDateTime.now()
+                );
+            }
+        }
+    }
+
+    @Scheduled(fixedDelayString = "${im.callback.dispatch-delay-ms:3000}")
+    public void dispatchDueCallbacks() {
+        LocalDateTime now = LocalDateTime.now();
+        for (CallbackTaskRecord task : operationsRepository.findDueCallbackTasks(now, batchSize)) {
+            if (operationsRepository.claimCallback(task.id(), now) == 0) {
+                continue;
+            }
+            dispatchOne(task);
+        }
+    }
+
+    @Scheduled(fixedDelayString = "${im.callback.recovery-delay-ms:60000}")
+    public void recoverStaleCallbacks() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime deadline = now.minusMinutes(processingTimeoutMinutes);
+        for (String id : operationsRepository.findStaleCallbackIds(deadline, batchSize)) {
+            operationsRepository.recoverStaleCallback(id, now.plusMinutes(1), now);
+        }
+    }
+
+    private void prepareOne(FinalMessageCandidate candidate) {
+        AuthenticatedApplication application = applicationService.requireEnabled(candidate.appCode());
+        if (!candidate.callbackUrl().equals(application.callbackUrl())) {
+            throw new IllegalStateException("Message callback URL no longer matches registered application callback");
+        }
+        String eventId = "message-final:" + candidate.messageNo() + ":" + candidate.messageStatus();
+        String payload = payload(candidate, eventId);
+        LocalDateTime now = LocalDateTime.now();
+        int inserted = operationsRepository.insertCallbackTask(new CallbackTaskRecord(
+                uuid(),
+                eventId,
+                candidate.messageId(),
+                candidate.messageStatus(),
+                candidate.appCode(),
+                candidate.callbackUrl(),
+                secretCodec.encrypt(application.callbackSecret()),
+                payload,
+                "PENDING",
+                0,
+                maxRetryCount,
+                now,
+                null,
+                null,
+                null,
+                null,
+                now,
+                now
+        ));
+        if (inserted > 0) {
+            operationsRepository.updateMessageCallbackStatus(candidate.messageId(), "PENDING", now);
+        }
+    }
+
+    private void dispatchOne(CallbackTaskRecord task) {
+        int responseCode = 0;
+        String responseBody = null;
+        try {
+            String timestamp = String.valueOf(System.currentTimeMillis());
+            String nonce = UUID.randomUUID().toString().replace("-", "");
+            String signature = sign(
+                    secretCodec.decrypt(task.callbackSecretCiphertext()),
+                    task.callbackUrl(),
+                    timestamp,
+                    nonce,
+                    task.payloadJson()
+            );
+            ResponseEntity<String> response = restClient.post()
+                    .uri(task.callbackUrl())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("X-IM-Timestamp", timestamp)
+                    .header("X-IM-Nonce", nonce)
+                    .header("X-IM-Signature", signature)
+                    .header("X-IM-Event-Id", task.eventId())
+                    .body(task.payloadJson())
+                    .retrieve()
+                    .toEntity(String.class);
+            responseCode = response.getStatusCode().value();
+            responseBody = response.getBody();
+            operationsRepository.markCallbackSuccess(task.id(), responseCode, responseBody, LocalDateTime.now());
+            operationsRepository.updateMessageCallbackStatus(task.messageId(), "SUCCESS", LocalDateTime.now());
+        } catch (Exception e) {
+            int retryCount = task.retryCount() + 1;
+            String error = safeMessage(e);
+            if (retryCount >= task.maxRetryCount()) {
+                operationsRepository.markCallbackDead(
+                        task.id(), retryCount, responseCode == 0 ? null : responseCode,
+                        responseBody, error, LocalDateTime.now());
+                operationsRepository.updateMessageCallbackStatus(task.messageId(), "DEAD", LocalDateTime.now());
+            } else {
+                operationsRepository.markCallbackRetry(
+                        task.id(), retryCount, nextRetryTime(retryCount),
+                        responseCode == 0 ? null : responseCode, responseBody, error, LocalDateTime.now());
+                operationsRepository.updateMessageCallbackStatus(task.messageId(), "RETRYING", LocalDateTime.now());
+            }
+        }
+    }
+
+    private String payload(FinalMessageCandidate candidate, String eventId) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("eventId", eventId);
+        body.put("messageNo", candidate.messageNo());
+        body.put("requestId", candidate.requestId());
+        body.put("status", candidate.messageStatus());
+        body.put("occurredTime", candidate.occurredTime());
+        List<Map<String, Object>> channels = new ArrayList<>();
+        for (ChannelStatusResponse channel : messageRepository.findChannelStatusResponses(candidate.messageId())) {
+            Map<String, Object> item = new LinkedHashMap<>();
+            item.put("channelTaskId", channel.channelTaskId());
+            item.put("recipientId", channel.recipientId());
+            item.put("channel", channel.channel());
+            item.put("status", channel.status());
+            item.put("retryCount", channel.retryCount());
+            item.put("providerMessageId", channel.providerMessageId());
+            item.put("errorCode", channel.errorCode());
+            item.put("errorMessage", channel.errorMessage());
+            channels.add(item);
+        }
+        body.put("channels", channels);
+        try {
+            return objectMapper.writeValueAsString(body);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Callback payload serialization failed", e);
+        }
+    }
+
+    public static String sign(String secret,
+                              String callbackUrl,
+                              String timestamp,
+                              String nonce,
+                              String payload) {
+        try {
+            String path = URI.create(callbackUrl).getRawPath();
+            String bodyHash = HexFormat.of().formatHex(
+                    MessageDigest.getInstance("SHA-256").digest(payload.getBytes(StandardCharsets.UTF_8)));
+            String canonical = "POST\n" + path + "\n" + timestamp + "\n" + nonce + "\n" + bodyHash;
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            return HexFormat.of().formatHex(mac.doFinal(canonical.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception e) {
+            throw new IllegalStateException("Callback signature generation failed", e);
+        }
+    }
+
+    private LocalDateTime nextRetryTime(int retryCount) {
+        long minutes = switch (retryCount) {
+            case 1 -> 1;
+            case 2 -> 5;
+            case 3 -> 15;
+            case 4 -> 60;
+            case 5 -> 360;
+            default -> 1440;
+        };
+        return LocalDateTime.now().plusMinutes(minutes);
+    }
+
+    private String safeMessage(Exception e) {
+        return e.getMessage() == null || e.getMessage().isBlank()
+                ? e.getClass().getSimpleName()
+                : e.getMessage();
+    }
+
+    private String uuid() {
+        return UUID.randomUUID().toString().replace("-", "");
+    }
+}

--- a/im-service/src/main/java/single/cjj/im/config/ImRabbitConfiguration.java
+++ b/im-service/src/main/java/single/cjj/im/config/ImRabbitConfiguration.java
@@ -15,18 +15,43 @@ public class ImRabbitConfiguration {
     public static final String CHANNEL_TASK_QUEUE = "matrix.im.channel-task.queue";
     public static final String CHANNEL_TASK_ROUTING_KEY = "im.channel-task.dispatch";
 
+    public static final String DEAD_LETTER_EXCHANGE = "matrix.im.dead-letter";
+    public static final String CHANNEL_TASK_DLQ = "matrix.im.channel-task.dlq";
+    public static final String CHANNEL_TASK_DEAD_ROUTING_KEY = "im.channel-task.dead";
+
     @Bean
     DirectExchange imEventExchange() {
         return new DirectExchange(EXCHANGE, true, false);
     }
 
     @Bean
+    DirectExchange imDeadLetterExchange() {
+        return new DirectExchange(DEAD_LETTER_EXCHANGE, true, false);
+    }
+
+    @Bean
     Queue channelTaskQueue() {
-        return QueueBuilder.durable(CHANNEL_TASK_QUEUE).build();
+        return QueueBuilder.durable(CHANNEL_TASK_QUEUE)
+                .deadLetterExchange(DEAD_LETTER_EXCHANGE)
+                .deadLetterRoutingKey(CHANNEL_TASK_DEAD_ROUTING_KEY)
+                .build();
+    }
+
+    @Bean
+    Queue channelTaskDeadLetterQueue() {
+        return QueueBuilder.durable(CHANNEL_TASK_DLQ).build();
     }
 
     @Bean
     Binding channelTaskBinding(DirectExchange imEventExchange, Queue channelTaskQueue) {
         return BindingBuilder.bind(channelTaskQueue).to(imEventExchange).with(CHANNEL_TASK_ROUTING_KEY);
+    }
+
+    @Bean
+    Binding channelTaskDeadLetterBinding(DirectExchange imDeadLetterExchange,
+                                         Queue channelTaskDeadLetterQueue) {
+        return BindingBuilder.bind(channelTaskDeadLetterQueue)
+                .to(imDeadLetterExchange)
+                .with(CHANNEL_TASK_DEAD_ROUTING_KEY);
     }
 }

--- a/im-service/src/main/java/single/cjj/im/controller/ImMessageController.java
+++ b/im-service/src/main/java/single/cjj/im/controller/ImMessageController.java
@@ -20,6 +20,7 @@ import single.cjj.im.domain.ImModels.TemplateUpsertRequest;
 import single.cjj.im.realtime.RealtimeNotificationService;
 import single.cjj.im.security.OpenApiSignatureFilter;
 import single.cjj.im.service.MessageCommandService;
+import single.cjj.im.service.ReliableMessageFacade;
 
 import java.util.List;
 import java.util.Map;
@@ -28,11 +29,14 @@ import java.util.Map;
 public class ImMessageController {
 
     private final MessageCommandService messageService;
+    private final ReliableMessageFacade reliableMessageFacade;
     private final RealtimeNotificationService realtimeService;
 
     public ImMessageController(MessageCommandService messageService,
+                               ReliableMessageFacade reliableMessageFacade,
                                RealtimeNotificationService realtimeService) {
         this.messageService = messageService;
+        this.reliableMessageFacade = reliableMessageFacade;
         this.realtimeService = realtimeService;
     }
 
@@ -40,14 +44,14 @@ public class ImMessageController {
     public ApiResponse<AcceptedResponse> send(
             @RequestAttribute(OpenApiSignatureFilter.APP_CODE_ATTRIBUTE) String appCode,
             @Valid @RequestBody SendMessageRequest request) {
-        return ApiResponse.success("消息已可靠受理", messageService.acceptDirect(appCode, request));
+        return ApiResponse.success("消息已可靠受理", reliableMessageFacade.acceptDirect(appCode, request));
     }
 
     @PostMapping("/open-api/v1/messages/template-send")
     public ApiResponse<AcceptedResponse> templateSend(
             @RequestAttribute(OpenApiSignatureFilter.APP_CODE_ATTRIBUTE) String appCode,
             @Valid @RequestBody SendMessageRequest request) {
-        return ApiResponse.success("模板消息已可靠受理", messageService.acceptTemplate(appCode, request));
+        return ApiResponse.success("模板消息已可靠受理", reliableMessageFacade.acceptTemplate(appCode, request));
     }
 
     @GetMapping("/open-api/v1/messages/{messageNo}")

--- a/im-service/src/main/java/single/cjj/im/reliability/ImOperationsRepository.java
+++ b/im-service/src/main/java/single/cjj/im/reliability/ImOperationsRepository.java
@@ -1,0 +1,360 @@
+package single.cjj.im.reliability;
+
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+@Repository
+public class ImOperationsRepository {
+
+    private final NamedParameterJdbcTemplate jdbc;
+
+    public ImOperationsRepository(NamedParameterJdbcTemplate jdbc) {
+        this.jdbc = jdbc;
+    }
+
+    public List<String> findStaleOutboxIds(LocalDateTime deadline, int limit) {
+        return jdbc.queryForList("""
+                SELECT id
+                FROM im_outbox_event
+                WHERE status='PROCESSING' AND updated_time<:deadline
+                ORDER BY updated_time,id
+                LIMIT :limit
+                """, Map.of("deadline", deadline, "limit", limit), String.class);
+    }
+
+    public int recoverStaleOutbox(String id, LocalDateTime nextRetryTime, LocalDateTime now) {
+        return jdbc.update("""
+                UPDATE im_outbox_event
+                SET status='RETRYING',
+                    retry_count=retry_count+1,
+                    next_retry_time=:nextRetryTime,
+                    last_error='OUTBOX_PROCESSING_TIMEOUT',
+                    processing_started_time=NULL,
+                    updated_time=:now
+                WHERE id=:id AND status='PROCESSING'
+                """, Map.of("id", id, "nextRetryTime", nextRetryTime, "now", now));
+    }
+
+    public void insertDeadLetter(String id,
+                                 String queueName,
+                                 String messageId,
+                                 String payload,
+                                 String reason,
+                                 LocalDateTime now) {
+        jdbc.update("""
+                INSERT INTO im_dead_letter (
+                    id,queue_name,message_id,payload_json,reason,status,created_time,updated_time
+                ) VALUES (
+                    :id,:queueName,:messageId,:payload,:reason,'PENDING',:now,:now
+                )
+                ON DUPLICATE KEY UPDATE
+                    reason=VALUES(reason),payload_json=VALUES(payload_json),updated_time=VALUES(updated_time)
+                """, new MapSqlParameterSource()
+                .addValue("id", id)
+                .addValue("queueName", queueName)
+                .addValue("messageId", messageId)
+                .addValue("payload", payload)
+                .addValue("reason", truncate(reason, 1000))
+                .addValue("now", now));
+    }
+
+    public List<String> findAggregateMismatchMessageIds(int limit) {
+        return jdbc.queryForList("""
+                SELECT m.id
+                FROM im_message_task m
+                WHERE m.status IN ('ACCEPTED','PROCESSING')
+                   OR m.success_channels <> (
+                       SELECT COUNT(*) FROM im_channel_task c
+                       WHERE c.message_id=m.id AND c.status='SUCCESS'
+                   )
+                   OR m.failed_channels <> (
+                       SELECT COUNT(*) FROM im_channel_task c
+                       WHERE c.message_id=m.id
+                         AND c.status IN ('FAILED','DEAD','UNKNOWN','EXPIRED','CANCELLED')
+                   )
+                ORDER BY m.updated_time,m.id
+                LIMIT :limit
+                """, Map.of("limit", limit), String.class);
+    }
+
+    public List<String> findMissingLocalNotificationTaskIds(int limit) {
+        return jdbc.queryForList("""
+                SELECT c.id
+                FROM im_channel_task c
+                JOIN im_message_recipient r ON r.id=c.recipient_id
+                WHERE c.channel_type='LOCAL'
+                  AND c.status='SUCCESS'
+                  AND NOT EXISTS (
+                      SELECT 1 FROM im_local_notification n
+                      WHERE n.message_id=c.message_id AND n.user_id=r.receiver_id
+                  )
+                ORDER BY c.updated_time,c.id
+                LIMIT :limit
+                """, Map.of("limit", limit), String.class);
+    }
+
+    public int requeueMissingLocalTask(String channelTaskId, LocalDateTime now) {
+        return jdbc.update("""
+                UPDATE im_channel_task
+                SET status='RETRYING',
+                    next_retry_time=:now,
+                    last_error_code='LOCAL_NOTIFICATION_MISSING',
+                    last_error_message='渠道成功但站内消息缺失，已由对账任务重新投递',
+                    updated_time=:now
+                WHERE id=:id AND channel_type='LOCAL' AND status='SUCCESS'
+                """, Map.of("id", channelTaskId, "now", now));
+    }
+
+    public void insertRecoveryOutbox(String id,
+                                     String eventId,
+                                     String channelTaskId,
+                                     String payload,
+                                     LocalDateTime now) {
+        jdbc.update("""
+                INSERT IGNORE INTO im_outbox_event (
+                    id,event_id,aggregate_type,aggregate_id,event_type,payload_json,status,retry_count,
+                    next_retry_time,last_error,created_time,published_time,processing_started_time,updated_time
+                ) VALUES (
+                    :id,:eventId,'CHANNEL_TASK',:channelTaskId,'CHANNEL_TASK_RECONCILED',:payload,
+                    'PENDING',0,:now,NULL,:now,NULL,NULL,:now
+                )
+                """, Map.of(
+                "id", id,
+                "eventId", eventId,
+                "channelTaskId", channelTaskId,
+                "payload", payload,
+                "now", now
+        ));
+    }
+
+    public List<FinalMessageCandidate> findFinalMessagesMissingCallbacks(int limit) {
+        return jdbc.query("""
+                SELECT m.id,m.message_no,m.app_code,m.request_id,m.status,m.callback_url,m.updated_time
+                FROM im_message_task m
+                WHERE m.callback_url IS NOT NULL
+                  AND m.callback_url<>''
+                  AND m.status IN ('SUCCESS','PARTIAL_SUCCESS','FAILED','UNKNOWN','EXPIRED')
+                  AND NOT EXISTS (
+                      SELECT 1 FROM im_callback_task c
+                      WHERE c.message_id=m.id AND c.message_status=m.status
+                  )
+                ORDER BY m.updated_time,m.id
+                LIMIT :limit
+                """, Map.of("limit", limit), (rs, rowNum) -> new FinalMessageCandidate(
+                rs.getString("id"),
+                rs.getString("message_no"),
+                rs.getString("app_code"),
+                rs.getString("request_id"),
+                rs.getString("status"),
+                rs.getString("callback_url"),
+                rs.getTimestamp("updated_time").toLocalDateTime()
+        ));
+    }
+
+    public int insertCallbackTask(CallbackTaskRecord task) {
+        return jdbc.update("""
+                INSERT IGNORE INTO im_callback_task (
+                    id,event_id,message_id,message_status,app_code,callback_url,callback_secret_ciphertext,
+                    payload_json,status,retry_count,max_retry_count,next_retry_time,processing_started_time,
+                    response_code,response_body,last_error,created_time,updated_time
+                ) VALUES (
+                    :id,:eventId,:messageId,:messageStatus,:appCode,:callbackUrl,:callbackSecretCiphertext,
+                    :payloadJson,:status,:retryCount,:maxRetryCount,:nextRetryTime,:processingStartedTime,
+                    :responseCode,:responseBody,:lastError,:createdTime,:updatedTime
+                )
+                """, beanParams(task));
+    }
+
+    public List<CallbackTaskRecord> findDueCallbackTasks(LocalDateTime now, int limit) {
+        return jdbc.query("""
+                SELECT *
+                FROM im_callback_task
+                WHERE status IN ('PENDING','RETRYING')
+                  AND (next_retry_time IS NULL OR next_retry_time<=:now)
+                ORDER BY created_time,id
+                LIMIT :limit
+                """, Map.of("now", now, "limit", limit), (rs, rowNum) -> new CallbackTaskRecord(
+                rs.getString("id"),
+                rs.getString("event_id"),
+                rs.getString("message_id"),
+                rs.getString("message_status"),
+                rs.getString("app_code"),
+                rs.getString("callback_url"),
+                rs.getString("callback_secret_ciphertext"),
+                rs.getString("payload_json"),
+                rs.getString("status"),
+                rs.getInt("retry_count"),
+                rs.getInt("max_retry_count"),
+                timestamp(rs.getTimestamp("next_retry_time")),
+                timestamp(rs.getTimestamp("processing_started_time")),
+                (Integer) rs.getObject("response_code"),
+                rs.getString("response_body"),
+                rs.getString("last_error"),
+                rs.getTimestamp("created_time").toLocalDateTime(),
+                rs.getTimestamp("updated_time").toLocalDateTime()
+        ));
+    }
+
+    public int claimCallback(String id, LocalDateTime now) {
+        return jdbc.update("""
+                UPDATE im_callback_task
+                SET status='PROCESSING',processing_started_time=:now,updated_time=:now
+                WHERE id=:id AND status IN ('PENDING','RETRYING')
+                  AND (next_retry_time IS NULL OR next_retry_time<=:now)
+                """, Map.of("id", id, "now", now));
+    }
+
+    public void markCallbackSuccess(String id, int responseCode, String responseBody, LocalDateTime now) {
+        jdbc.update("""
+                UPDATE im_callback_task
+                SET status='SUCCESS',response_code=:responseCode,response_body=:responseBody,
+                    last_error=NULL,processing_started_time=NULL,updated_time=:now
+                WHERE id=:id
+                """, new MapSqlParameterSource()
+                .addValue("id", id)
+                .addValue("responseCode", responseCode)
+                .addValue("responseBody", truncate(responseBody, 2000))
+                .addValue("now", now));
+    }
+
+    public void markCallbackRetry(String id,
+                                  int retryCount,
+                                  LocalDateTime nextRetryTime,
+                                  Integer responseCode,
+                                  String responseBody,
+                                  String error,
+                                  LocalDateTime now) {
+        jdbc.update("""
+                UPDATE im_callback_task
+                SET status='RETRYING',retry_count=:retryCount,next_retry_time=:nextRetryTime,
+                    response_code=:responseCode,response_body=:responseBody,last_error=:error,
+                    processing_started_time=NULL,updated_time=:now
+                WHERE id=:id
+                """, new MapSqlParameterSource()
+                .addValue("id", id)
+                .addValue("retryCount", retryCount)
+                .addValue("nextRetryTime", nextRetryTime)
+                .addValue("responseCode", responseCode)
+                .addValue("responseBody", truncate(responseBody, 2000))
+                .addValue("error", truncate(error, 1000))
+                .addValue("now", now));
+    }
+
+    public void markCallbackDead(String id,
+                                 int retryCount,
+                                 Integer responseCode,
+                                 String responseBody,
+                                 String error,
+                                 LocalDateTime now) {
+        jdbc.update("""
+                UPDATE im_callback_task
+                SET status='DEAD',retry_count=:retryCount,next_retry_time=NULL,
+                    response_code=:responseCode,response_body=:responseBody,last_error=:error,
+                    processing_started_time=NULL,updated_time=:now
+                WHERE id=:id
+                """, new MapSqlParameterSource()
+                .addValue("id", id)
+                .addValue("retryCount", retryCount)
+                .addValue("responseCode", responseCode)
+                .addValue("responseBody", truncate(responseBody, 2000))
+                .addValue("error", truncate(error, 1000))
+                .addValue("now", now));
+    }
+
+    public List<String> findStaleCallbackIds(LocalDateTime deadline, int limit) {
+        return jdbc.queryForList("""
+                SELECT id FROM im_callback_task
+                WHERE status='PROCESSING' AND processing_started_time<:deadline
+                ORDER BY processing_started_time,id
+                LIMIT :limit
+                """, Map.of("deadline", deadline, "limit", limit), String.class);
+    }
+
+    public int recoverStaleCallback(String id, LocalDateTime nextRetryTime, LocalDateTime now) {
+        return jdbc.update("""
+                UPDATE im_callback_task
+                SET status='RETRYING',retry_count=retry_count+1,next_retry_time=:nextRetryTime,
+                    last_error='CALLBACK_PROCESSING_TIMEOUT',processing_started_time=NULL,updated_time=:now
+                WHERE id=:id AND status='PROCESSING'
+                """, Map.of("id", id, "nextRetryTime", nextRetryTime, "now", now));
+    }
+
+    public void updateMessageCallbackStatus(String messageId, String callbackStatus, LocalDateTime now) {
+        jdbc.update("""
+                UPDATE im_message_task
+                SET callback_status=:callbackStatus,updated_time=:now
+                WHERE id=:messageId
+                """, Map.of("messageId", messageId, "callbackStatus", callbackStatus, "now", now));
+    }
+
+    private MapSqlParameterSource beanParams(CallbackTaskRecord task) {
+        return new MapSqlParameterSource()
+                .addValue("id", task.id())
+                .addValue("eventId", task.eventId())
+                .addValue("messageId", task.messageId())
+                .addValue("messageStatus", task.messageStatus())
+                .addValue("appCode", task.appCode())
+                .addValue("callbackUrl", task.callbackUrl())
+                .addValue("callbackSecretCiphertext", task.callbackSecretCiphertext())
+                .addValue("payloadJson", task.payloadJson())
+                .addValue("status", task.status())
+                .addValue("retryCount", task.retryCount())
+                .addValue("maxRetryCount", task.maxRetryCount())
+                .addValue("nextRetryTime", task.nextRetryTime())
+                .addValue("processingStartedTime", task.processingStartedTime())
+                .addValue("responseCode", task.responseCode())
+                .addValue("responseBody", task.responseBody())
+                .addValue("lastError", task.lastError())
+                .addValue("createdTime", task.createdTime())
+                .addValue("updatedTime", task.updatedTime());
+    }
+
+    private LocalDateTime timestamp(java.sql.Timestamp value) {
+        return value == null ? null : value.toLocalDateTime();
+    }
+
+    private String truncate(String value, int maxLength) {
+        if (value == null || value.length() <= maxLength) {
+            return value;
+        }
+        return value.substring(0, maxLength);
+    }
+
+    public record FinalMessageCandidate(
+            String messageId,
+            String messageNo,
+            String appCode,
+            String requestId,
+            String messageStatus,
+            String callbackUrl,
+            LocalDateTime occurredTime
+    ) {
+    }
+
+    public record CallbackTaskRecord(
+            String id,
+            String eventId,
+            String messageId,
+            String messageStatus,
+            String appCode,
+            String callbackUrl,
+            String callbackSecretCiphertext,
+            String payloadJson,
+            String status,
+            int retryCount,
+            int maxRetryCount,
+            LocalDateTime nextRetryTime,
+            LocalDateTime processingStartedTime,
+            Integer responseCode,
+            String responseBody,
+            String lastError,
+            LocalDateTime createdTime,
+            LocalDateTime updatedTime
+    ) {
+    }
+}

--- a/im-service/src/main/java/single/cjj/im/reliability/ImReliabilityWorker.java
+++ b/im-service/src/main/java/single/cjj/im/reliability/ImReliabilityWorker.java
@@ -1,0 +1,107 @@
+package single.cjj.im.reliability;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rabbitmq.client.Channel;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionTemplate;
+import single.cjj.im.config.ImRabbitConfiguration;
+import single.cjj.im.service.ChannelDispatchService;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+@Component
+public class ImReliabilityWorker {
+
+    private final ImOperationsRepository operationsRepository;
+    private final ChannelDispatchService dispatchService;
+    private final ObjectMapper objectMapper;
+    private final TransactionTemplate transactionTemplate;
+    private final int batchSize;
+    private final int outboxTimeoutMinutes;
+
+    public ImReliabilityWorker(ImOperationsRepository operationsRepository,
+                               ChannelDispatchService dispatchService,
+                               ObjectMapper objectMapper,
+                               TransactionTemplate transactionTemplate,
+                               @Value("${im.reliability.batch-size:100}") int batchSize,
+                               @Value("${im.outbox.processing-timeout-minutes:5}") int outboxTimeoutMinutes) {
+        this.operationsRepository = operationsRepository;
+        this.dispatchService = dispatchService;
+        this.objectMapper = objectMapper;
+        this.transactionTemplate = transactionTemplate;
+        this.batchSize = Math.max(1, Math.min(batchSize, 500));
+        this.outboxTimeoutMinutes = Math.max(1, outboxTimeoutMinutes);
+    }
+
+    @Scheduled(fixedDelayString = "${im.outbox.recovery-delay-ms:60000}")
+    public void recoverStaleOutbox() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime deadline = now.minusMinutes(outboxTimeoutMinutes);
+        for (String id : operationsRepository.findStaleOutboxIds(deadline, batchSize)) {
+            operationsRepository.recoverStaleOutbox(id, now.plusMinutes(1), now);
+        }
+    }
+
+    @Scheduled(fixedDelayString = "${im.reliability.reconcile-delay-ms:60000}")
+    public void reconcileMessageState() {
+        for (String messageId : operationsRepository.findAggregateMismatchMessageIds(batchSize)) {
+            dispatchService.refreshMessageStatus(messageId);
+        }
+        for (String channelTaskId : operationsRepository.findMissingLocalNotificationTaskIds(batchSize)) {
+            repairMissingLocalNotification(channelTaskId);
+        }
+    }
+
+    @RabbitListener(queues = ImRabbitConfiguration.CHANNEL_TASK_DLQ)
+    public void persistDeadLetter(String payload, Channel channel, Message message) throws Exception {
+        long deliveryTag = message.getMessageProperties().getDeliveryTag();
+        try {
+            String messageId = message.getMessageProperties().getMessageId();
+            if (messageId == null || messageId.isBlank()) {
+                messageId = UUID.nameUUIDFromBytes(payload.getBytes(StandardCharsets.UTF_8)).toString();
+            }
+            Object reasonHeader = message.getMessageProperties().getHeaders().get("x-first-death-reason");
+            String reason = reasonHeader == null ? "REJECTED_OR_NOT_REQUEUED" : String.valueOf(reasonHeader);
+            operationsRepository.insertDeadLetter(
+                    UUID.randomUUID().toString().replace("-", ""),
+                    ImRabbitConfiguration.CHANNEL_TASK_QUEUE,
+                    messageId,
+                    payload,
+                    reason,
+                    LocalDateTime.now()
+            );
+            channel.basicAck(deliveryTag, false);
+        } catch (Exception e) {
+            channel.basicNack(deliveryTag, false, true);
+        }
+    }
+
+    private void repairMissingLocalNotification(String channelTaskId) {
+        LocalDateTime now = LocalDateTime.now();
+        transactionTemplate.executeWithoutResult(status -> {
+            if (operationsRepository.requeueMissingLocalTask(channelTaskId, now) == 0) {
+                return;
+            }
+            try {
+                String payload = objectMapper.writeValueAsString(Map.of("channelTaskId", channelTaskId));
+                operationsRepository.insertRecoveryOutbox(
+                        UUID.randomUUID().toString().replace("-", ""),
+                        "local-notification-reconcile:" + channelTaskId,
+                        channelTaskId,
+                        payload,
+                        now
+                );
+            } catch (Exception e) {
+                status.setRollbackOnly();
+                throw new IllegalStateException("Failed to serialize reconciliation event", e);
+            }
+        });
+    }
+}

--- a/im-service/src/main/java/single/cjj/im/security/OpenApiSignatureFilter.java
+++ b/im-service/src/main/java/single/cjj/im/security/OpenApiSignatureFilter.java
@@ -2,18 +2,21 @@ package single.cjj.im.security;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.ServletException;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StreamUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
+import single.cjj.im.application.ImApplicationService;
+import single.cjj.im.application.ImApplicationService.ApplicationAuthenticationException;
+import single.cjj.im.application.ImApplicationService.AuthenticatedApplication;
+import single.cjj.im.application.ImOpenApiProperties;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -24,20 +27,23 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.time.Duration;
-import java.util.HashMap;
 import java.util.HexFormat;
-import java.util.Map;
 
 @Component
 public class OpenApiSignatureFilter extends OncePerRequestFilter {
 
     public static final String APP_CODE_ATTRIBUTE = "im.openApi.appCode";
+    public static final String APPLICATION_ATTRIBUTE = "im.openApi.application";
 
-    private final OpenApiProperties properties;
+    private final ImOpenApiProperties properties;
+    private final ImApplicationService applicationService;
     private final StringRedisTemplate redisTemplate;
 
-    public OpenApiSignatureFilter(OpenApiProperties properties, StringRedisTemplate redisTemplate) {
+    public OpenApiSignatureFilter(ImOpenApiProperties properties,
+                                  ImApplicationService applicationService,
+                                  StringRedisTemplate redisTemplate) {
         this.properties = properties;
+        this.applicationService = applicationService;
         this.redisTemplate = redisTemplate;
     }
 
@@ -52,17 +58,14 @@ public class OpenApiSignatureFilter extends OncePerRequestFilter {
                                     FilterChain filterChain) throws ServletException, IOException {
         CachedBodyRequest wrappedRequest = new CachedBodyRequest(request);
         String appCode;
+        AuthenticatedApplication application;
         try {
             appCode = requiredHeader(request, "X-App-Code");
             String timestampText = requiredHeader(request, "X-Timestamp");
             String nonce = requiredHeader(request, "X-Nonce");
             String signature = requiredHeader(request, "X-Signature");
 
-            String secret = properties.getCredentials().get(appCode);
-            if (!StringUtils.hasText(secret)) {
-                throw new SignatureException("未知或未启用的调用应用");
-            }
-
+            application = applicationService.authenticate(appCode, resolveSourceIp(request));
             long timestamp = Long.parseLong(timestampText);
             long now = System.currentTimeMillis();
             long allowedMillis = properties.getSignatureWindowSeconds() * 1000L;
@@ -86,17 +89,18 @@ public class OpenApiSignatureFilter extends OncePerRequestFilter {
                     + timestampText + "\n"
                     + nonce + "\n"
                     + bodyHash;
-            String expected = hmacSha256Hex(secret, canonical);
+            String expected = hmacSha256Hex(application.appSecret(), canonical);
             if (!MessageDigest.isEqual(
                     expected.getBytes(StandardCharsets.UTF_8),
                     signature.toLowerCase().getBytes(StandardCharsets.UTF_8))) {
                 redisTemplate.delete(nonceKey);
                 throw new SignatureException("签名校验失败");
             }
+            applicationService.enforceRateLimit(application);
         } catch (NumberFormatException e) {
             writeUnauthorized(response, "时间戳格式错误");
             return;
-        } catch (SignatureException e) {
+        } catch (ApplicationAuthenticationException | SignatureException e) {
             writeUnauthorized(response, e.getMessage());
             return;
         } catch (Exception e) {
@@ -105,7 +109,16 @@ public class OpenApiSignatureFilter extends OncePerRequestFilter {
         }
 
         wrappedRequest.setAttribute(APP_CODE_ATTRIBUTE, appCode);
+        wrappedRequest.setAttribute(APPLICATION_ATTRIBUTE, application);
         filterChain.doFilter(wrappedRequest, response);
+    }
+
+    private String resolveSourceIp(HttpServletRequest request) {
+        String forwarded = request.getHeader("X-Forwarded-For");
+        if (StringUtils.hasText(forwarded)) {
+            return forwarded.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
     }
 
     private String requiredHeader(HttpServletRequest request, String name) {
@@ -141,29 +154,6 @@ public class OpenApiSignatureFilter extends OncePerRequestFilter {
         SignatureException(String message) {
             super(message);
         }
-    }
-}
-
-@ConfigurationProperties(prefix = "im.open-api")
-class OpenApiProperties {
-
-    private int signatureWindowSeconds = 300;
-    private Map<String, String> credentials = new HashMap<>();
-
-    public int getSignatureWindowSeconds() {
-        return signatureWindowSeconds;
-    }
-
-    public void setSignatureWindowSeconds(int signatureWindowSeconds) {
-        this.signatureWindowSeconds = signatureWindowSeconds;
-    }
-
-    public Map<String, String> getCredentials() {
-        return credentials;
-    }
-
-    public void setCredentials(Map<String, String> credentials) {
-        this.credentials = credentials == null ? new HashMap<>() : credentials;
     }
 }
 

--- a/im-service/src/main/java/single/cjj/im/service/ReliableMessageFacade.java
+++ b/im-service/src/main/java/single/cjj/im/service/ReliableMessageFacade.java
@@ -1,0 +1,143 @@
+package single.cjj.im.service;
+
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import single.cjj.im.application.ImApplicationService;
+import single.cjj.im.application.ImApplicationService.AuthenticatedApplication;
+import single.cjj.im.domain.ImModels.AcceptedResponse;
+import single.cjj.im.domain.ImModels.MessageRecord;
+import single.cjj.im.domain.ImModels.SendMessageRequest;
+import single.cjj.im.domain.ImModels.TemplateRecord;
+import single.cjj.im.repository.ImMessageRepository;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class ReliableMessageFacade {
+
+    private final MessageCommandService commandService;
+    private final ImMessageRepository repository;
+    private final ImApplicationService applicationService;
+
+    public ReliableMessageFacade(MessageCommandService commandService,
+                                 ImMessageRepository repository,
+                                 ImApplicationService applicationService) {
+        this.commandService = commandService;
+        this.repository = repository;
+        this.applicationService = applicationService;
+    }
+
+    public AcceptedResponse acceptDirect(String appCode, SendMessageRequest request) {
+        SendMessageRequest prepared = prepare(appCode, request, false);
+        return executeIdempotently(appCode, prepared, false);
+    }
+
+    public AcceptedResponse acceptTemplate(String appCode, SendMessageRequest request) {
+        SendMessageRequest prepared = prepare(appCode, request, true);
+        return executeIdempotently(appCode, prepared, true);
+    }
+
+    private SendMessageRequest prepare(String appCode, SendMessageRequest request, boolean templateMode) {
+        AuthenticatedApplication application = applicationService.requireEnabled(appCode);
+        String tenantId = StringUtils.hasText(request.tenantId()) ? request.tenantId().trim() : application.tenantId();
+        if (!application.tenantId().equals(tenantId)) {
+            throw new ImBusinessException("请求 tenantId 与调用应用所属租户不一致");
+        }
+
+        Set<String> channels = resolveChannels(request, templateMode);
+        if (!application.allowedChannels().containsAll(channels)) {
+            Set<String> denied = new LinkedHashSet<>(channels);
+            denied.removeAll(application.allowedChannels());
+            throw new ImBusinessException("调用应用无权使用渠道: " + String.join(",", denied));
+        }
+
+        String callbackUrl = resolveCallbackUrl(application, request.callbackUrl());
+        return new SendMessageRequest(
+                request.requestId(),
+                request.messageType(),
+                request.templateCode(),
+                request.title(),
+                request.content(),
+                request.channels(),
+                request.templateParams(),
+                request.recipients(),
+                request.business(),
+                request.scheduledTime(),
+                request.expireTime(),
+                callbackUrl,
+                tenantId,
+                request.priority()
+        );
+    }
+
+    private Set<String> resolveChannels(SendMessageRequest request, boolean templateMode) {
+        if (request.channels() != null && !request.channels().isEmpty()) {
+            return normalize(request.channels());
+        }
+        if (!templateMode || !StringUtils.hasText(request.templateCode())) {
+            return Set.of();
+        }
+        TemplateRecord template = repository.findLatestEnabledTemplate(request.templateCode().trim())
+                .orElseThrow(() -> new ImBusinessException("消息模板不存在或未启用"));
+        return Arrays.stream(template.defaultChannels().split(","))
+                .map(String::trim)
+                .filter(StringUtils::hasText)
+                .map(value -> value.toUpperCase(Locale.ROOT))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    private String resolveCallbackUrl(AuthenticatedApplication application, String requestedCallbackUrl) {
+        if (StringUtils.hasText(requestedCallbackUrl)) {
+            if (!StringUtils.hasText(application.callbackUrl())
+                    || !application.callbackUrl().equals(requestedCallbackUrl.trim())) {
+                throw new ImBusinessException("callbackUrl 必须使用应用登记的回调地址");
+            }
+            return requestedCallbackUrl.trim();
+        }
+        return application.callbackUrl();
+    }
+
+    private AcceptedResponse executeIdempotently(String appCode,
+                                                 SendMessageRequest request,
+                                                 boolean templateMode) {
+        try {
+            return templateMode
+                    ? commandService.acceptTemplate(appCode, request)
+                    : commandService.acceptDirect(appCode, request);
+        } catch (DuplicateKeyException duplicate) {
+            MessageRecord existing = awaitExisting(appCode, request.requestId());
+            if (existing == null) {
+                throw duplicate;
+            }
+            return new AcceptedResponse(existing.messageNo(), existing.requestId(), existing.status(), true);
+        }
+    }
+
+    private MessageRecord awaitExisting(String appCode, String requestId) {
+        for (int attempt = 0; attempt < 8; attempt++) {
+            MessageRecord existing = repository.findMessageByAppRequest(appCode, requestId).orElse(null);
+            if (existing != null) {
+                return existing;
+            }
+            try {
+                Thread.sleep(25L * (attempt + 1));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private Set<String> normalize(Set<String> channels) {
+        return channels.stream()
+                .filter(StringUtils::hasText)
+                .map(value -> value.trim().toUpperCase(Locale.ROOT))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+}

--- a/im-service/src/main/java/single/cjj/im/worker/ImWorkerConfiguration.java
+++ b/im-service/src/main/java/single/cjj/im/worker/ImWorkerConfiguration.java
@@ -88,6 +88,10 @@ class OutboxDispatcher {
                         ImRabbitConfiguration.EXCHANGE,
                         ImRabbitConfiguration.CHANNEL_TASK_ROUTING_KEY,
                         event.payloadJson(),
+                        message -> {
+                            message.getMessageProperties().setMessageId(event.eventId());
+                            return message;
+                        },
                         correlationData
                 );
                 CorrelationData.Confirm confirm = correlationData.getFuture().get(5, TimeUnit.SECONDS);
@@ -141,7 +145,8 @@ class ChannelTaskConsumer {
         } catch (ImBusinessException e) {
             channel.basicReject(deliveryTag, false);
         } catch (Exception e) {
-            channel.basicNack(deliveryTag, false, true);
+            // 渠道层已经通过数据库状态机和 Outbox 负责重试，Broker 层不无限 requeue。
+            channel.basicNack(deliveryTag, false, false);
         }
     }
 }

--- a/im-service/src/main/resources/application.yml
+++ b/im-service/src/main/resources/application.yml
@@ -47,16 +47,33 @@ spring:
       mail.smtp.starttls.enable: ${MAIL_STARTTLS:false}
 
 im:
+  security:
+    # Production must provide an independently generated Base64 encoded 32-byte key.
+    master-key: ${IM_SECRET_MASTER_KEY:bWF0cml4LWltLWRldi1tYXN0ZXIta2V5LTMyYnl0ZSE=}
   open-api:
     signature-window-seconds: ${IM_SIGNATURE_WINDOW_SECONDS:300}
+    fallback-rate-limit-per-minute: ${IM_FALLBACK_RATE_LIMIT_PER_MINUTE:600}
     credentials:
       matrix: ${IM_MATRIX_APP_SECRET:change-me-before-use}
+      scheduler: ${SCHEDULER_IM_APP_SECRET:}
   outbox:
     batch-size: ${IM_OUTBOX_BATCH_SIZE:100}
     fixed-delay-ms: ${IM_OUTBOX_FIXED_DELAY_MS:3000}
+    processing-timeout-minutes: ${IM_OUTBOX_PROCESSING_TIMEOUT_MINUTES:5}
+    recovery-delay-ms: ${IM_OUTBOX_RECOVERY_DELAY_MS:60000}
   channel:
     max-retry-count: ${IM_CHANNEL_MAX_RETRY_COUNT:5}
     processing-timeout-minutes: ${IM_PROCESSING_TIMEOUT_MINUTES:10}
+  callback:
+    batch-size: ${IM_CALLBACK_BATCH_SIZE:100}
+    max-retry-count: ${IM_CALLBACK_MAX_RETRY_COUNT:6}
+    processing-timeout-minutes: ${IM_CALLBACK_PROCESSING_TIMEOUT_MINUTES:10}
+    prepare-delay-ms: ${IM_CALLBACK_PREPARE_DELAY_MS:3000}
+    dispatch-delay-ms: ${IM_CALLBACK_DISPATCH_DELAY_MS:3000}
+    recovery-delay-ms: ${IM_CALLBACK_RECOVERY_DELAY_MS:60000}
+  reliability:
+    batch-size: ${IM_RELIABILITY_BATCH_SIZE:100}
+    reconcile-delay-ms: ${IM_RECONCILE_DELAY_MS:60000}
   email:
     from: ${IM_EMAIL_FROM:${MAIL_USERNAME:}}
   websocket:

--- a/im-service/src/test/java/single/cjj/im/application/ImSecretCodecTest.java
+++ b/im-service/src/test/java/single/cjj/im/application/ImSecretCodecTest.java
@@ -1,0 +1,26 @@
+package single.cjj.im.application;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ImSecretCodecTest {
+
+    private static final String MASTER_KEY =
+            "bWF0cml4LWltLWRldi1tYXN0ZXIta2V5LTMyYnl0ZSE=";
+
+    @Test
+    void encryptsWithRandomIvAndDecrypts() {
+        ImSecretCodec codec = new ImSecretCodec(MASTER_KEY);
+
+        String first = codec.encrypt("scheduler-secret");
+        String second = codec.encrypt("scheduler-secret");
+
+        assertTrue(first.startsWith("v1:"));
+        assertNotEquals(first, second);
+        assertEquals("scheduler-secret", codec.decrypt(first));
+        assertEquals("scheduler-secret", codec.decrypt(second));
+    }
+}

--- a/im-service/src/test/java/single/cjj/im/callback/ImCallbackServiceTest.java
+++ b/im-service/src/test/java/single/cjj/im/callback/ImCallbackServiceTest.java
@@ -1,0 +1,24 @@
+package single.cjj.im.callback;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ImCallbackServiceTest {
+
+    @Test
+    void signsCallbackUsingCanonicalBodyHash() {
+        String signature = ImCallbackService.sign(
+                "callback-secret",
+                "https://example.com/api/scheduler/im/callbacks",
+                "1784720000000",
+                "nonce-001",
+                "{\"eventId\":\"evt-1\",\"status\":\"FAILED\"}"
+        );
+
+        assertEquals(
+                "4ddb13800966b1538eab1755e2ce4763a6510f871be1d394e0e18e54d98efb2a",
+                signature
+        );
+    }
+}

--- a/scheduler-service/src/main/java/single/cjj/scheduler/controller/SchedulerImCallbackController.java
+++ b/scheduler-service/src/main/java/single/cjj/scheduler/controller/SchedulerImCallbackController.java
@@ -1,0 +1,29 @@
+package single.cjj.scheduler.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import single.cjj.bizfi.entity.ApiResponse;
+import single.cjj.scheduler.service.SchedulerImNotificationService;
+
+@RestController
+public class SchedulerImCallbackController {
+
+    private final SchedulerImNotificationService notificationService;
+
+    public SchedulerImCallbackController(SchedulerImNotificationService notificationService) {
+        this.notificationService = notificationService;
+    }
+
+    @PostMapping("/scheduler/im/callbacks")
+    public ApiResponse<Boolean> callback(
+            @RequestHeader("X-IM-Timestamp") String timestamp,
+            @RequestHeader("X-IM-Nonce") String nonce,
+            @RequestHeader("X-IM-Signature") String signature,
+            @RequestHeader("X-IM-Event-Id") String eventId,
+            @RequestBody String rawBody) {
+        notificationService.acceptCallback(timestamp, nonce, signature, eventId, rawBody);
+        return ApiResponse.success(true);
+    }
+}

--- a/scheduler-service/src/main/java/single/cjj/scheduler/entity/MatrixSchedulerImOutbox.java
+++ b/scheduler-service/src/main/java/single/cjj/scheduler/entity/MatrixSchedulerImOutbox.java
@@ -1,0 +1,28 @@
+package single.cjj.scheduler.entity;
+
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@TableName("matrix_scheduler_im_outbox")
+public class MatrixSchedulerImOutbox {
+
+    @TableId
+    private Long fid;
+    private Long falertId;
+    private String frequestId;
+    private String fpayload;
+    private String fstatus;
+    private Integer fretryCount;
+    private LocalDateTime fnextRetryTime;
+    private LocalDateTime fprocessingStartedTime;
+    private String fmessageNo;
+    private String fcallbackStatus;
+    private String fcallbackEventId;
+    private String flastError;
+    private LocalDateTime fcreateTime;
+    private LocalDateTime fupdateTime;
+}

--- a/scheduler-service/src/main/java/single/cjj/scheduler/mapper/MatrixSchedulerAlertRecordMapper.java
+++ b/scheduler-service/src/main/java/single/cjj/scheduler/mapper/MatrixSchedulerAlertRecordMapper.java
@@ -1,7 +1,19 @@
 package single.cjj.scheduler.mapper;
 
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import org.apache.ibatis.annotations.Insert;
 import single.cjj.scheduler.entity.MatrixSchedulerAlertRecord;
 
 public interface MatrixSchedulerAlertRecordMapper extends BaseMapper<MatrixSchedulerAlertRecord> {
+
+    @Insert("""
+            INSERT IGNORE INTO matrix_scheduler_alert_record (
+                fid,fdedupe_key,fexecution_no,fjob_id,fexecutor_code,falert_type,flevel,
+                ftitle,fcontent,fstatus,fack_by,fack_time,fcreate_time,fupdate_time
+            ) VALUES (
+                #{fid},#{fdedupeKey},#{fexecutionNo},#{fjobId},#{fexecutorCode},#{falertType},#{flevel},
+                #{ftitle},#{fcontent},#{fstatus},#{fackBy},#{fackTime},#{fcreateTime},#{fupdateTime}
+            )
+            """)
+    int insertIgnore(MatrixSchedulerAlertRecord alert);
 }

--- a/scheduler-service/src/main/java/single/cjj/scheduler/mapper/MatrixSchedulerImOutboxMapper.java
+++ b/scheduler-service/src/main/java/single/cjj/scheduler/mapper/MatrixSchedulerImOutboxMapper.java
@@ -1,0 +1,9 @@
+package single.cjj.scheduler.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import org.apache.ibatis.annotations.Mapper;
+import single.cjj.scheduler.entity.MatrixSchedulerImOutbox;
+
+@Mapper
+public interface MatrixSchedulerImOutboxMapper extends BaseMapper<MatrixSchedulerImOutbox> {
+}

--- a/scheduler-service/src/main/java/single/cjj/scheduler/service/SchedulerAlertService.java
+++ b/scheduler-service/src/main/java/single/cjj/scheduler/service/SchedulerAlertService.java
@@ -4,7 +4,6 @@ import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.baomidou.mybatisplus.core.toolkit.IdWorker;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
-import org.springframework.dao.DuplicateKeyException;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,16 +24,20 @@ public class SchedulerAlertService {
     private final MatrixSchedulerAlertRecordMapper alertMapper;
     private final MatrixSchedulerExecutionMapper executionMapper;
     private final MatrixSchedulerExecutorMapper executorMapper;
+    private final SchedulerImNotificationService imNotificationService;
 
     public SchedulerAlertService(MatrixSchedulerAlertRecordMapper alertMapper,
                                  MatrixSchedulerExecutionMapper executionMapper,
-                                 MatrixSchedulerExecutorMapper executorMapper) {
+                                 MatrixSchedulerExecutorMapper executorMapper,
+                                 SchedulerImNotificationService imNotificationService) {
         this.alertMapper = alertMapper;
         this.executionMapper = executionMapper;
         this.executorMapper = executorMapper;
+        this.imNotificationService = imNotificationService;
     }
 
     @Scheduled(fixedDelayString = "${matrix.scheduler.alert.scan-ms:30000}")
+    @Transactional(rollbackFor = Exception.class)
     public void scan() {
         scanExecutionFailures();
         scanOfflineExecutors();
@@ -112,11 +115,6 @@ public class SchedulerAlertService {
                                 String level,
                                 String title,
                                 String content) {
-        Long count = alertMapper.selectCount(new LambdaQueryWrapper<MatrixSchedulerAlertRecord>()
-                .eq(MatrixSchedulerAlertRecord::getFdedupeKey, dedupeKey));
-        if (count != null && count > 0) {
-            return;
-        }
         LocalDateTime now = LocalDateTime.now();
         MatrixSchedulerAlertRecord alert = new MatrixSchedulerAlertRecord();
         alert.setFid(IdWorker.getId());
@@ -131,10 +129,8 @@ public class SchedulerAlertService {
         alert.setFstatus("PENDING");
         alert.setFcreateTime(now);
         alert.setFupdateTime(now);
-        try {
-            alertMapper.insert(alert);
-        } catch (DuplicateKeyException ignored) {
-            // 多实例扫描时由唯一键完成最终去重。
+        if (alertMapper.insertIgnore(alert) > 0) {
+            imNotificationService.enqueue(alert);
         }
     }
 

--- a/scheduler-service/src/main/java/single/cjj/scheduler/service/SchedulerImNotificationService.java
+++ b/scheduler-service/src/main/java/single/cjj/scheduler/service/SchedulerImNotificationService.java
@@ -1,0 +1,362 @@
+package single.cjj.scheduler.service;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
+import com.baomidou.mybatisplus.core.toolkit.IdWorker;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import single.cjj.scheduler.entity.MatrixSchedulerAlertRecord;
+import single.cjj.scheduler.entity.MatrixSchedulerImOutbox;
+import single.cjj.scheduler.mapper.MatrixSchedulerImOutboxMapper;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+public class SchedulerImNotificationService {
+
+    private static final String SEND_PATH = "/open-api/v1/messages/send";
+
+    private final MatrixSchedulerImOutboxMapper outboxMapper;
+    private final ObjectMapper objectMapper;
+    private final RestClient restClient;
+    private final boolean enabled;
+    private final String imBaseUrl;
+    private final String appCode;
+    private final String appSecret;
+    private final String tenantId;
+    private final String callbackUrl;
+    private final String callbackSecret;
+    private final List<String> recipientUserIds;
+    private final List<String> channels;
+    private final int batchSize;
+    private final int maxRetryCount;
+    private final int processingTimeoutMinutes;
+
+    public SchedulerImNotificationService(
+            MatrixSchedulerImOutboxMapper outboxMapper,
+            ObjectMapper objectMapper,
+            RestClient.Builder restClientBuilder,
+            @Value("${matrix.scheduler.im.enabled:false}") boolean enabled,
+            @Value("${matrix.scheduler.im.base-url:http://127.0.0.1:10000/api}") String imBaseUrl,
+            @Value("${matrix.scheduler.im.app-code:scheduler}") String appCode,
+            @Value("${matrix.scheduler.im.app-secret:}") String appSecret,
+            @Value("${matrix.scheduler.im.tenant-id:default}") String tenantId,
+            @Value("${matrix.scheduler.im.callback-url:}") String callbackUrl,
+            @Value("${matrix.scheduler.im.callback-secret:}") String callbackSecret,
+            @Value("${matrix.scheduler.im.recipient-user-ids:}") String recipientUserIds,
+            @Value("${matrix.scheduler.im.channels:LOCAL}") String channels,
+            @Value("${matrix.scheduler.im.batch-size:100}") int batchSize,
+            @Value("${matrix.scheduler.im.max-retry-count:8}") int maxRetryCount,
+            @Value("${matrix.scheduler.im.processing-timeout-minutes:5}") int processingTimeoutMinutes) {
+        this.outboxMapper = outboxMapper;
+        this.objectMapper = objectMapper;
+        this.restClient = restClientBuilder.build();
+        this.enabled = enabled;
+        this.imBaseUrl = trimTrailingSlash(imBaseUrl);
+        this.appCode = appCode;
+        this.appSecret = appSecret;
+        this.tenantId = tenantId;
+        this.callbackUrl = callbackUrl;
+        this.callbackSecret = callbackSecret;
+        this.recipientUserIds = split(recipientUserIds);
+        this.channels = split(channels);
+        this.batchSize = Math.max(1, Math.min(batchSize, 500));
+        this.maxRetryCount = Math.max(1, maxRetryCount);
+        this.processingTimeoutMinutes = Math.max(1, processingTimeoutMinutes);
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public void enqueue(MatrixSchedulerAlertRecord alert) {
+        if (!enabled) {
+            return;
+        }
+        String requestId = "scheduler-alert:" + alert.getFid();
+        Long existing = outboxMapper.selectCount(new LambdaQueryWrapper<MatrixSchedulerImOutbox>()
+                .eq(MatrixSchedulerImOutbox::getFrequestId, requestId));
+        if (existing != null && existing > 0) {
+            return;
+        }
+        LocalDateTime now = LocalDateTime.now();
+        MatrixSchedulerImOutbox outbox = new MatrixSchedulerImOutbox();
+        outbox.setFid(IdWorker.getId());
+        outbox.setFalertId(alert.getFid());
+        outbox.setFrequestId(requestId);
+        outbox.setFpayload(buildPayload(alert, requestId));
+        outbox.setFstatus("PENDING");
+        outbox.setFretryCount(0);
+        outbox.setFnextRetryTime(now);
+        outbox.setFcallbackStatus("PENDING");
+        outbox.setFcreateTime(now);
+        outbox.setFupdateTime(now);
+        outboxMapper.insert(outbox);
+    }
+
+    @Scheduled(fixedDelayString = "${matrix.scheduler.im.dispatch-delay-ms:5000}")
+    public void dispatchPending() {
+        if (!enabled) {
+            return;
+        }
+        LocalDateTime now = LocalDateTime.now();
+        List<MatrixSchedulerImOutbox> tasks = outboxMapper.selectList(
+                new LambdaQueryWrapper<MatrixSchedulerImOutbox>()
+                        .in(MatrixSchedulerImOutbox::getFstatus, "PENDING", "RETRYING")
+                        .and(wrapper -> wrapper.isNull(MatrixSchedulerImOutbox::getFnextRetryTime)
+                                .or()
+                                .le(MatrixSchedulerImOutbox::getFnextRetryTime, now))
+                        .orderByAsc(MatrixSchedulerImOutbox::getFcreateTime)
+                        .last("LIMIT " + batchSize));
+        for (MatrixSchedulerImOutbox task : tasks) {
+            if (!claim(task.getFid(), now)) {
+                continue;
+            }
+            deliver(task);
+        }
+    }
+
+    @Scheduled(fixedDelayString = "${matrix.scheduler.im.recovery-delay-ms:60000}")
+    public void recoverStale() {
+        if (!enabled) {
+            return;
+        }
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime deadline = now.minusMinutes(processingTimeoutMinutes);
+        List<MatrixSchedulerImOutbox> stale = outboxMapper.selectList(
+                new LambdaQueryWrapper<MatrixSchedulerImOutbox>()
+                        .eq(MatrixSchedulerImOutbox::getFstatus, "PROCESSING")
+                        .lt(MatrixSchedulerImOutbox::getFprocessingStartedTime, deadline)
+                        .orderByAsc(MatrixSchedulerImOutbox::getFprocessingStartedTime)
+                        .last("LIMIT " + batchSize));
+        for (MatrixSchedulerImOutbox task : stale) {
+            int retryCount = task.getFretryCount() == null ? 1 : task.getFretryCount() + 1;
+            task.setFretryCount(retryCount);
+            task.setFstatus(retryCount >= maxRetryCount ? "DEAD" : "RETRYING");
+            task.setFnextRetryTime(retryCount >= maxRetryCount ? null : now.plusMinutes(1));
+            task.setFprocessingStartedTime(null);
+            task.setFlastError("IM_DISPATCH_PROCESSING_TIMEOUT");
+            task.setFupdateTime(now);
+            outboxMapper.updateById(task);
+        }
+    }
+
+    public void acceptCallback(String timestamp,
+                               String nonce,
+                               String signature,
+                               String eventId,
+                               String rawBody) {
+        validateCallbackSignature(timestamp, nonce, signature, rawBody);
+        try {
+            JsonNode root = objectMapper.readTree(rawBody);
+            String requestId = root.path("requestId").asText();
+            String status = root.path("status").asText();
+            if (!StringUtils.hasText(requestId) || !StringUtils.hasText(status)) {
+                throw new IllegalArgumentException("IM callback missing requestId or status");
+            }
+            MatrixSchedulerImOutbox task = outboxMapper.selectOne(
+                    new LambdaQueryWrapper<MatrixSchedulerImOutbox>()
+                            .eq(MatrixSchedulerImOutbox::getFrequestId, requestId)
+                            .last("LIMIT 1"));
+            if (task == null) {
+                throw new IllegalArgumentException("Scheduler IM outbox not found");
+            }
+            if (eventId.equals(task.getFcallbackEventId())) {
+                return;
+            }
+            task.setFcallbackEventId(eventId);
+            task.setFcallbackStatus(status);
+            task.setFstatus("CALLBACK_SUCCESS");
+            task.setFupdateTime(LocalDateTime.now());
+            outboxMapper.updateById(task);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid IM callback payload", e);
+        }
+    }
+
+    private boolean claim(Long id, LocalDateTime now) {
+        return outboxMapper.update(null, new LambdaUpdateWrapper<MatrixSchedulerImOutbox>()
+                .set(MatrixSchedulerImOutbox::getFstatus, "PROCESSING")
+                .set(MatrixSchedulerImOutbox::getFprocessingStartedTime, now)
+                .set(MatrixSchedulerImOutbox::getFupdateTime, now)
+                .eq(MatrixSchedulerImOutbox::getFid, id)
+                .in(MatrixSchedulerImOutbox::getFstatus, "PENDING", "RETRYING")
+                .and(wrapper -> wrapper.isNull(MatrixSchedulerImOutbox::getFnextRetryTime)
+                        .or()
+                        .le(MatrixSchedulerImOutbox::getFnextRetryTime, now))) > 0;
+    }
+
+    private void deliver(MatrixSchedulerImOutbox task) {
+        try {
+            validateConfiguration();
+            String timestamp = String.valueOf(System.currentTimeMillis());
+            String nonce = UUID.randomUUID().toString().replace("-", "");
+            String endpoint = imBaseUrl + SEND_PATH;
+            String signature = sign(appSecret, endpoint, timestamp, nonce, task.getFpayload());
+            String responseBody = restClient.post()
+                    .uri(endpoint)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("X-App-Code", appCode)
+                    .header("X-Timestamp", timestamp)
+                    .header("X-Nonce", nonce)
+                    .header("X-Signature", signature)
+                    .body(task.getFpayload())
+                    .retrieve()
+                    .body(String.class);
+            JsonNode response = objectMapper.readTree(responseBody);
+            if (response.path("code").asInt() != 200 && response.path("code").asInt() != 0) {
+                throw new IllegalStateException("IM rejected notification: " + response.path("message").asText());
+            }
+            task.setFmessageNo(response.path("data").path("messageNo").asText(null));
+            task.setFstatus("ACCEPTED");
+            task.setFprocessingStartedTime(null);
+            task.setFnextRetryTime(null);
+            task.setFlastError(null);
+            task.setFupdateTime(LocalDateTime.now());
+            outboxMapper.updateById(task);
+        } catch (Exception e) {
+            int retryCount = task.getFretryCount() == null ? 1 : task.getFretryCount() + 1;
+            task.setFretryCount(retryCount);
+            task.setFstatus(retryCount >= maxRetryCount ? "DEAD" : "RETRYING");
+            task.setFnextRetryTime(retryCount >= maxRetryCount ? null : nextRetryTime(retryCount));
+            task.setFprocessingStartedTime(null);
+            task.setFlastError(trim(safeMessage(e), 2000));
+            task.setFupdateTime(LocalDateTime.now());
+            outboxMapper.updateById(task);
+        }
+    }
+
+    private String buildPayload(MatrixSchedulerAlertRecord alert, String requestId) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("requestId", requestId);
+        payload.put("messageType", "SCHEDULER_ALERT");
+        payload.put("title", alert.getFtitle());
+        payload.put("content", alert.getFcontent());
+        payload.put("channels", channels);
+        List<Map<String, Object>> recipients = new ArrayList<>();
+        for (String userId : recipientUserIds) {
+            recipients.add(Map.of("userId", userId));
+        }
+        payload.put("recipients", recipients);
+        payload.put("business", Map.of(
+                "type", "SCHEDULER_ALERT",
+                "id", String.valueOf(alert.getFid()),
+                "actionUrl", "/scheduler/operations?alertId=" + alert.getFid()
+        ));
+        payload.put("callbackUrl", callbackUrl);
+        payload.put("tenantId", tenantId);
+        payload.put("priority", "CRITICAL".equals(alert.getFlevel()) ? "URGENT" : "HIGH");
+        try {
+            return objectMapper.writeValueAsString(payload);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to serialize Scheduler IM payload", e);
+        }
+    }
+
+    private void validateConfiguration() {
+        if (!StringUtils.hasText(appSecret)) {
+            throw new IllegalStateException("SCHEDULER_IM_APP_SECRET is required when Scheduler IM integration is enabled");
+        }
+        if (recipientUserIds.isEmpty()) {
+            throw new IllegalStateException("SCHEDULER_IM_RECIPIENT_USER_IDS is required");
+        }
+        if (channels.isEmpty() || channels.stream().anyMatch(channel -> !"LOCAL".equalsIgnoreCase(channel))) {
+            throw new IllegalStateException("Scheduler IM integration currently supports LOCAL channel only");
+        }
+        if (!StringUtils.hasText(callbackUrl) || !StringUtils.hasText(callbackSecret)) {
+            throw new IllegalStateException("Scheduler IM callback URL and secret are required");
+        }
+    }
+
+    private void validateCallbackSignature(String timestamp,
+                                           String nonce,
+                                           String signature,
+                                           String rawBody) {
+        if (!StringUtils.hasText(timestamp)
+                || !StringUtils.hasText(nonce)
+                || !StringUtils.hasText(signature)
+                || !StringUtils.hasText(callbackSecret)) {
+            throw new IllegalArgumentException("Missing IM callback signature headers");
+        }
+        long requestTime = Long.parseLong(timestamp);
+        if (Math.abs(System.currentTimeMillis() - requestTime) > 300_000L) {
+            throw new IllegalArgumentException("IM callback timestamp expired");
+        }
+        String expected = sign(callbackSecret, callbackUrl, timestamp, nonce, rawBody);
+        if (!MessageDigest.isEqual(
+                expected.getBytes(StandardCharsets.UTF_8),
+                signature.toLowerCase().getBytes(StandardCharsets.UTF_8))) {
+            throw new IllegalArgumentException("Invalid IM callback signature");
+        }
+    }
+
+    public static String sign(String secret,
+                              String url,
+                              String timestamp,
+                              String nonce,
+                              String body) {
+        try {
+            String path = URI.create(url).getRawPath();
+            String bodyHash = HexFormat.of().formatHex(
+                    MessageDigest.getInstance("SHA-256").digest(body.getBytes(StandardCharsets.UTF_8)));
+            String canonical = "POST\n" + path + "\n" + timestamp + "\n" + nonce + "\n" + bodyHash;
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            return HexFormat.of().formatHex(mac.doFinal(canonical.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to sign Scheduler IM request", e);
+        }
+    }
+
+    private LocalDateTime nextRetryTime(int retryCount) {
+        long seconds = Math.min(3600L, 30L * (1L << Math.min(retryCount - 1, 6)));
+        return LocalDateTime.now().plusSeconds(seconds);
+    }
+
+    private List<String> split(String csv) {
+        if (!StringUtils.hasText(csv)) {
+            return List.of();
+        }
+        return Arrays.stream(csv.split(","))
+                .map(String::trim)
+                .filter(StringUtils::hasText)
+                .toList();
+    }
+
+    private String trimTrailingSlash(String value) {
+        String result = value == null ? "" : value.trim();
+        while (result.endsWith("/")) {
+            result = result.substring(0, result.length() - 1);
+        }
+        return result;
+    }
+
+    private String safeMessage(Exception e) {
+        return e.getMessage() == null || e.getMessage().isBlank()
+                ? e.getClass().getSimpleName()
+                : e.getMessage();
+    }
+
+    private String trim(String value, int maxLength) {
+        if (value == null || value.length() <= maxLength) {
+            return value;
+        }
+        return value.substring(0, maxLength);
+    }
+}

--- a/scheduler-service/src/main/resources/application.yml
+++ b/scheduler-service/src/main/resources/application.yml
@@ -77,3 +77,18 @@ matrix:
       publish-delay-ms: ${SCHEDULER_OUTBOX_DELAY_MS:3000}
       batch-size: ${SCHEDULER_OUTBOX_BATCH_SIZE:100}
       max-retry: ${SCHEDULER_OUTBOX_MAX_RETRY:10}
+    im:
+      enabled: ${SCHEDULER_IM_ENABLED:false}
+      base-url: ${SCHEDULER_IM_BASE_URL:http://127.0.0.1:10000/api}
+      app-code: ${SCHEDULER_IM_APP_CODE:scheduler}
+      app-secret: ${SCHEDULER_IM_APP_SECRET:}
+      tenant-id: ${SCHEDULER_IM_TENANT_ID:default}
+      callback-url: ${SCHEDULER_IM_CALLBACK_URL:}
+      callback-secret: ${SCHEDULER_IM_CALLBACK_SECRET:}
+      recipient-user-ids: ${SCHEDULER_IM_RECIPIENT_USER_IDS:}
+      channels: ${SCHEDULER_IM_CHANNELS:LOCAL}
+      batch-size: ${SCHEDULER_IM_BATCH_SIZE:100}
+      max-retry-count: ${SCHEDULER_IM_MAX_RETRY_COUNT:8}
+      processing-timeout-minutes: ${SCHEDULER_IM_PROCESSING_TIMEOUT_MINUTES:5}
+      dispatch-delay-ms: ${SCHEDULER_IM_DISPATCH_DELAY_MS:5000}
+      recovery-delay-ms: ${SCHEDULER_IM_RECOVERY_DELAY_MS:60000}

--- a/scheduler-service/src/main/resources/db/migration/V4__scheduler_im_notification_outbox.sql
+++ b/scheduler-service/src/main/resources/db/migration/V4__scheduler_im_notification_outbox.sql
@@ -1,0 +1,24 @@
+USE matrix_scheduler;
+
+CREATE TABLE IF NOT EXISTS matrix_scheduler_im_outbox (
+    fid                       BIGINT NOT NULL,
+    falert_id                 BIGINT NOT NULL,
+    frequest_id               VARCHAR(128) NOT NULL,
+    fpayload                  LONGTEXT NOT NULL,
+    fstatus                   VARCHAR(32) NOT NULL,
+    fretry_count              INT NOT NULL DEFAULT 0,
+    fnext_retry_time          DATETIME NULL,
+    fprocessing_started_time  DATETIME NULL,
+    fmessage_no               VARCHAR(64) NULL,
+    fcallback_status          VARCHAR(32) NULL,
+    fcallback_event_id        VARCHAR(160) NULL,
+    flast_error               VARCHAR(2000) NULL,
+    fcreate_time              DATETIME NOT NULL,
+    fupdate_time              DATETIME NOT NULL,
+    PRIMARY KEY (fid),
+    UNIQUE KEY uk_scheduler_im_request (frequest_id),
+    UNIQUE KEY uk_scheduler_im_callback_event (fcallback_event_id),
+    KEY idx_scheduler_im_due (fstatus, fnext_retry_time, fcreate_time),
+    KEY idx_scheduler_im_processing (fstatus, fprocessing_started_time),
+    KEY idx_scheduler_im_alert (falert_id)
+) ENGINE=InnoDB COMMENT='Scheduler 到 IM 平台的可靠通知 Outbox';

--- a/scheduler-service/src/test/java/single/cjj/scheduler/service/SchedulerImNotificationServiceTest.java
+++ b/scheduler-service/src/test/java/single/cjj/scheduler/service/SchedulerImNotificationServiceTest.java
@@ -1,0 +1,24 @@
+package single.cjj.scheduler.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SchedulerImNotificationServiceTest {
+
+    @Test
+    void usesSameCallbackCanonicalSignatureContract() {
+        String signature = SchedulerImNotificationService.sign(
+                "callback-secret",
+                "https://example.com/api/scheduler/im/callbacks",
+                "1784720000000",
+                "nonce-001",
+                "{\"eventId\":\"evt-1\",\"status\":\"FAILED\"}"
+        );
+
+        assertEquals(
+                "4ddb13800966b1538eab1755e2ce4763a6510f871be1d394e0e18e54d98efb2a",
+                signature
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- harden IM Outbox processing with stale recovery and reconciliation
- add RabbitMQ dead-letter exchange, DLQ persistence, and finite Broker retries
- add dynamic IM applications with tenant, channel permissions, IP allowlists, rate limits, status, callback registration, and AES-256-GCM encrypted secrets
- keep configuration credentials as a migration-only fallback
- resolve concurrent `(app_code, request_id)` duplicate requests as idempotent replays
- add signed final-result callbacks with durable retry tasks and stale callback recovery
- integrate Scheduler alerts through a business Outbox so IM availability does not block alert creation
- add signed IM callback handling in Scheduler

## Business flow

Scheduler alert creation and `matrix_scheduler_im_outbox` insertion share one database transaction. A scheduled dispatcher signs and submits the notification to IM. IM persists and delivers LOCAL notifications, aggregates final status, then calls Scheduler with an HMAC-signed result. Both directions are idempotent and retryable.

## Safety defaults

- Scheduler IM integration is disabled by default.
- Scheduler currently sends LOCAL alerts only because its recipient configuration is user-ID based.
- application and callback secrets are never stored as plaintext
- arbitrary per-request callback URLs are rejected; the URL must match the application registration
- Broker consumer failures are dead-lettered rather than requeued forever

## Database

Apply in order:

1. `docs/sql/im-platform-phase3.sql`
2. `scheduler-service/src/main/resources/db/migration/V4__scheduler_im_notification_outbox.sql`

Existing RabbitMQ installations must recreate `matrix.im.channel-task.queue` or apply the equivalent DLX policy before rollout because queue arguments cannot be changed in place.

## Configuration

Production must set an independently generated `IM_SECRET_MASTER_KEY` containing a Base64-encoded 32-byte key. Create the `scheduler` IM application before setting `SCHEDULER_IM_ENABLED=true`.

## Validation

CI will run IM, Scheduler, Gateway/OpenAPI, and any other path-triggered module checks. The feature remains a draft until all checks pass and the branch is synchronized with the latest `dev`.
